### PR TITLE
use allowed action name

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: "CA & DCO Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the Contributor Agreement including DCO and I hereby sign the Contributor Agreement and DCO') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.3.2
+        uses: cla-assistant/github-action@v2.3.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret


### PR DESCRIPTION
cla-assistant/github-action moved to contributor-assistant/github-action

This utilizes the repository redirect to match existing allowlist actions, migration to DCO app or org update should be discussed for future needs.
