### PR TITLE
Fix huggingface inference endpoint name

### DIFF
--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -376,7 +376,7 @@ class InferenceEndpoint(InferenceAPI):
 
     def __init__(self, name="", config_root=_config):
         super().__init__(name, config_root=config_root)
-        self.uri = name
+        self.uri = self.name
 
     @backoff.on_exception(
         backoff.fibo,

--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -256,7 +256,7 @@ class InferenceAPI(Generator):
         self.name = name
         super().__init__(self.name, config_root=config_root)
 
-        self.uri = self.URI + name
+        self.uri = self.URI + self.name
 
         # special case for api token requirement this also reserves `headers` as not configurable
         if self.api_key:

--- a/tests/generators/conftest.py
+++ b/tests/generators/conftest.py
@@ -11,3 +11,10 @@ def openai_compat_mocks():
     """Mock responses for OpenAI compatible endpoints"""
     with open(pathlib.Path(__file__).parents[0] / "openai.json") as mock_openai:
         return json.load(mock_openai)
+
+
+@pytest.fixture
+def hf_endpoint_mocks():
+    """Mock responses for Huggingface InferenceAPI based endpoints"""
+    with open(pathlib.Path(__file__).parents[0] / "hf_inference.json") as mock_openai:
+        return json.load(mock_openai)

--- a/tests/generators/hf_inference.json
+++ b/tests/generators/hf_inference.json
@@ -1,0 +1,10 @@
+{
+    "hf_inference": {
+        "code": 200,
+        "json": [
+            {
+                "generated_text":"restricted by their policy,"
+           }
+         ]
+    }
+}


### PR DESCRIPTION
fix #998 

the name provided during construction is populated by the call to `super().__init__()`, access to `self` attributes is required for any value populated by `Configurable`.


## Verification

List the steps needed to make sure this thing works

- [ ] Execute against public InferenceAPI:
``` bash
python -m garak --model_type huggingface.InferenceAPI --model_name microsoft/Phi-3-mini-4k-instruct --probes malwaregen.Evasion
```
- [ ] **Verify** valid responses are received from endpoint.
- [ ] **Verify** added automation tests pass
