### PR TITLE
detect if tokenizer is not loaded and adjust

### DIFF
--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -80,6 +80,13 @@ class Pipeline(Generator, HFCompatible):
 
         pipeline_kwargs = self._gather_hf_params(hf_constructor=pipeline)
         self.generator = pipeline("text-generation", **pipeline_kwargs)
+        if self.generator.tokenizer is None:
+            # account for possible model without a stored tokenizer
+            from transformers import AutoTokenizer
+
+            self.generator.tokenizer = AutoTokenizer.from_pretrained(
+                pipeline_kwargs["model"]
+            )
         if not hasattr(self, "deprefix_prompt"):
             self.deprefix_prompt = self.name in models_to_deprefix
         if _config.loaded:


### PR DESCRIPTION
In some cases a pretrained model pipeline may not specify the tokenizer in the stored config. If missing attempt to get tokenizer by model name. An example of this as time of revision is [`nvidia/Minitron-4B-Base`](https://huggingface.co/nvidia/Minitron-4B-Base).

## Verification

List the steps needed to make sure this thing works

- [ ] Tests against a model where pipeline is known to not have a saved tokenizer:
``` bash
python -m garak -m huggingface -n nvidia/Minitron-4B-Base --probes dan.Dan_11_0
```
- [ ] Run the tests and ensure they pass `python -m pytest tests/`
- [ ] **Verify** the generator returned inference responses
