### PR TITLE
fix: correct argument in TAP

### DIFF
--- a/garak/resources/tap/tap_main.py
+++ b/garak/resources/tap/tap_main.py
@@ -498,7 +498,7 @@ def generate_tap(
         attack_max_attempts=attack_max_attempts,
         evaluator_model_type=evaluator_model_type,
         evaluator_model_name=evaluator_model_name,
-        evaluator_model_configs=evaluator_model_config,
+        evaluator_model_config=evaluator_model_config,
         branching_factor=branching_factor,
         width=width,
         depth=depth,


### PR DESCRIPTION
Fix incorrect configuration variable in `garak/resources/tap/tap_main.py`

### Fix

This PR addresses a bug in garak/resources/tap/tap_main.py where the incorrect variable name was used for the evaluator model configuration. Specifically, the line:

```python
evaluator_model_configs=evaluator_model_config
```
was corrected to:

```python
evaluator_model_config=evaluator_model_config
```

This fix ensures that the proper model configuration is being used when initializing the evaluator.