### PR TITLE
Feature: enable configuration updates

### DIFF
--- a/garak/cli.py
+++ b/garak/cli.py
@@ -484,7 +484,7 @@ def main(arguments=None) -> None:
             if has_changes:
                 exit(1)  # exit with error code to denote changes
             else:
-                print("No revisions applied please verify options provided for `--fix`")
+                print("No revisions applied. Please verify options provided for `--fix`")
         elif args.report:
             from garak.report import Report
 

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -452,7 +452,7 @@ def main(arguments=None) -> None:
             #
             # How should this handle garak.site.yaml? Only if --fix was provided and no other options offered?
             # For now process all files registered a part of the config
-
+            has_changes = False
             if has_config_file_or_json:
                 for plugin_type, plugin_plural in plugin_types:
                     # cli plugins options stub out only a "plugins" sub key
@@ -463,6 +463,7 @@ def main(arguments=None) -> None:
                         }
                         migrated_config = fixer.migrate(cli_config)
                         if cli_config != migrated_config:
+                            has_changes = True
                             msg = f"Updated '{plugin_type}' configuration: \n"
                             msg += json.dumps(
                                 migrated_config["plugins"][plugin_plural], indent=2
@@ -475,11 +476,15 @@ def main(arguments=None) -> None:
                         cli_config = yaml.safe_load(file)
                         migrated_config = fixer.migrate(cli_config)
                         if cli_config != migrated_config:
+                            has_changes = True
                             msg = f"Updated {filename}: \n"
                             msg += yaml.dump(migrated_config)
                             print(msg)
             # should this add support for --*_spec entries passed on cli?
-            exit(1)  # exit with error code to denote changes output?
+            if has_changes:
+                exit(1)  # exit with error code to denote changes
+            else:
+                print("No revisions applied please verify options provided for `--fix`")
         elif args.report:
             from garak.report import Report
 

--- a/garak/probes/av_spam_scanning.py
+++ b/garak/probes/av_spam_scanning.py
@@ -39,6 +39,7 @@ class EICAR(Probe):
     code. This probe test if models will provide output that should be stopped
     by a virus scanner. Only applicable to models expected to do antivirus scanning."""
 
+    aliases = ["knownbadsignatures.EICAR"]
     bcp47 = "*"
     doc_uri = "https://en.wikipedia.org/wiki/EICAR_test_file"
     recommended_detector = [
@@ -65,6 +66,7 @@ class GTUBE(Probe):
     Does the model generate content that should be stopped by a spam filter? If there's
     a spam filter in place, this should catch the GTUBE signature."""
 
+    aliases = ["knownbadsignatures.GTUBE"]
     bcp47 = "*"
     doc_uri = "https://en.wikipedia.org/wiki/GTUBE"
     recommended_detector = [
@@ -92,6 +94,7 @@ class GTphish(Probe):
     A phishing scanner should catch the GTphish code and hopefully block this content.
     If there's no scanner in place, the GTphish code is more likely to come through."""
 
+    aliases = ["knownbadsignatures.GTphish"]
     bcp47 = "*"
     doc_uri = "https://www.cisco.com/c/en/us/support/docs/security/email-security-appliance/213465-testing-outbreak-filter-url-rewriting.html"
     recommended_detector = [

--- a/garak/probes/continuation.py
+++ b/garak/probes/continuation.py
@@ -88,5 +88,6 @@ class ContinueSlursReclaimedSlursMini(ContinueSlursReclaimedSlurs, Probe):
     checks to see if the model will complete the slur. It uses a subset of 80
     slurs & contexts that test LLMs have been likely to provide completions for."""
 
+    aliases = ["continuation.ContinueSlursReclaimedSlurs80"]
     active = True
     source_resource_filename = "slurprompts_mini.jsonl"

--- a/garak/probes/divergence.py
+++ b/garak/probes/divergence.py
@@ -19,6 +19,7 @@ class Repeat(Probe):
     continue the repetition in its output, which can degrade to seemingly replaying
     training data."""
 
+    aliases = ["replay.Repeat"]
     bcp47 = "*"
     primary_detector = "divergence.RepeatDiverges"
     extended_detectors = ["mitigation.MitigationBypass"]
@@ -88,6 +89,7 @@ class RepeatExtended(Repeat):
     training data."""
 
     active = False
+    aliases = ["replay.RepeatExtended"]
     repeat_word_list = [
         "company",
         "one",

--- a/garak/probes/suffix.py
+++ b/garak/probes/suffix.py
@@ -23,6 +23,7 @@ class GCGCached(Probe):
     An automatic jailbreaking probe, using gradient descent. This implementation
     uses a pre-computed cached set of GCG prompts."""
 
+    aliases = ["gcg.GCGCached"]
     bcp47 = "en"
     recommended_detector = ["mitigation.MitigationBypass"]
     tags = [
@@ -52,6 +53,7 @@ class GCG(Probe):
 
     An automatic jailbreaking probe, using gradient descent."""
 
+    aliases = ["gcg.GCG"]
     bcp47 = "en"
     recommended_detector = ["mitigation.MitigationBypass"]
     tags = [

--- a/garak/resources/fixer/20240628_gcg_rename.py
+++ b/garak/resources/fixer/20240628_gcg_rename.py
@@ -7,7 +7,7 @@ from garak.resources.fixer import _plugin
 
 class RenameGCG(Migration):
     def apply(config_dict: dict) -> dict:
-        """Rename probe gcg -> suffix"""
+        """Rename probe family gcg -> suffix"""
 
         path = ["plugins", "probes"]
         old = "gcg"

--- a/garak/resources/fixer/20240628_gcg_rename.py
+++ b/garak/resources/fixer/20240628_gcg_rename.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Portions Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from garak.resources.fixer import Migration
+from garak.resources.fixer import _plugin
+
+
+class RenameGCG(Migration):
+    def apply(config_dict: dict) -> dict:
+        """Rename probe gcg -> suffix"""
+
+        path = ["plugins", "probes"]
+        old = "gcg"
+        new = "suffix"
+        return _plugin.rename(config_dict, path, old, new)

--- a/garak/resources/fixer/20240801_continuation_rename.py
+++ b/garak/resources/fixer/20240801_continuation_rename.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Portions Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from garak.resources.fixer import Migration
+from garak.resources.fixer import _plugin
+
+
+class RenameContinuation(Migration):
+    def apply(config_dict: dict) -> dict:
+        """Rename continuation probe class 80 -> Mini"""
+
+        path = ["plugins", "probes", "continuation"]
+        old = "ContinueSlursReclaimedSlurs80"
+        new = "ContinueSlursReclaimedSlursMini"
+        return _plugin.rename(config_dict, path, old, new)

--- a/garak/resources/fixer/20240822_knownbadsignatures_rename.py
+++ b/garak/resources/fixer/20240822_knownbadsignatures_rename.py
@@ -7,7 +7,7 @@ from garak.resources.fixer import _plugin
 
 class RenameKnownbadsignatures(Migration):
     def apply(config_dict: dict) -> dict:
-        """Rename probe knownbadsignatures -> av_spam_scanning"""
+        """Rename probe family knownbadsignatures -> av_spam_scanning"""
 
         path = ["plugins", "probes"]
         old = "knownbadsignatures"

--- a/garak/resources/fixer/20240822_knownbadsignatures_rename.py
+++ b/garak/resources/fixer/20240822_knownbadsignatures_rename.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Portions Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from garak.resources.fixer import Migration
+from garak.resources.fixer import _plugin
+
+
+class RenameKnownbadsignatures(Migration):
+    def apply(config_dict: dict) -> dict:
+        """Rename probe knownbadsignatures -> av_spam_scanning"""
+
+        path = ["plugins", "probes"]
+        old = "knownbadsignatures"
+        new = "av_spam_scanning"
+        return _plugin.rename(config_dict, path, old, new)

--- a/garak/resources/fixer/20241011_replay_rename.py
+++ b/garak/resources/fixer/20241011_replay_rename.py
@@ -7,7 +7,7 @@ from garak.resources.fixer import _plugin
 
 class RenameReplay(Migration):
     def apply(config_dict: dict) -> dict:
-        """Rename probe replay -> divergence"""
+        """Rename probe family replay -> divergence"""
 
         path = ["plugins", "probes"]
         old = "replay"

--- a/garak/resources/fixer/20241011_replay_rename.py
+++ b/garak/resources/fixer/20241011_replay_rename.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Portions Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from garak.resources.fixer import Migration
+from garak.resources.fixer import _plugin
+
+
+class RenameReplay(Migration):
+    def apply(config_dict: dict) -> dict:
+        """Rename probe replay -> divergence"""
+
+        path = ["plugins", "probes"]
+        old = "replay"
+        new = "divergence"
+        return _plugin.rename(config_dict, path, old, new)

--- a/garak/resources/fixer/__init__.py
+++ b/garak/resources/fixer/__init__.py
@@ -28,7 +28,7 @@ for module_filename in sorted(os.listdir(root_path)):
         continue
     if module_filename.startswith("__"):
         continue
-    module_name = module_filename.replace(".py", "")
+    module_name = module_filename[:-3]  # strip ".py" known from check above
     mod = importlib.import_module(f"{__package__}.{module_name}")
     migrations = [  # Extract only classes that are a `Migration`
         klass
@@ -50,6 +50,6 @@ def migrate(original_config: dict) -> dict:
             logging.info(msg)
 
     if original_config != updated_config:
-        logging.info("Migration preformed")
+        logging.info("Migration performed")
 
     return updated_config

--- a/garak/resources/fixer/__init__.py
+++ b/garak/resources/fixer/__init__.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Portions Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration migration utilities
+
+Utility for processing loaded configuration files to apply updates for compatibility
+"""
+
+import importlib
+import inspect
+import json
+import logging
+import os
+import yaml
+from pathlib import Path
+
+
+class Migration:
+    """Required interface for migrations"""
+
+    def apply(config_dict: dict) -> dict:
+        raise NotImplementedError
+
+
+# list of migrations, should this be dynamically built from the package?
+ordered_migrations = []
+root_path = Path(__file__).parents[0]
+for module_filename in sorted(os.listdir(root_path)):
+    if not module_filename.endswith(".py"):
+        continue
+    if module_filename.startswith("__"):
+        continue
+    module_name = module_filename.replace(".py", "")
+    mod = importlib.import_module(f"{__package__}.{module_name}")
+    migrations = [  # Extract only classes with same source package name
+        klass
+        for _, klass in inspect.getmembers(mod, inspect.isclass)
+        if klass.__module__.startswith(mod.__name__) and Migration in klass.__bases__
+    ]
+    ordered_migrations += migrations
+
+
+def migrate(source_filename: Path):
+    import copy
+
+    # should this just accept a dictionary?
+    original_config = None
+    # check file for JSON or YAML compatibility
+    for loader in (yaml.safe_load, json.load):
+        try:
+            with open(source_filename) as source_file:
+                original_config = loader(source_file)
+                break
+        except Exception as er:
+            msg = f"Configuration file {source_filename} failed to parse as {loader}!"
+            logging.debug(msg, exc_info=er)
+    if original_config is None:
+        logging.error("Could not parse configuration nothing to migrate!")
+        return None
+
+    updated_config = copy.deepcopy(original_config)
+    for migration in ordered_migrations:
+        new_config = migration.apply(updated_config)
+        if new_config != updated_config:
+            updated_config = new_config
+            msg = f"Applied migrations changes from {migration.__name__}"
+            logging.info(msg)
+
+    if original_config != updated_config:
+        logging.info("Migration preformed")
+
+    return updated_config

--- a/garak/resources/fixer/_plugin.py
+++ b/garak/resources/fixer/_plugin.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Portions Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for plugins related migrations."""
+
+import copy
+
+from garak import _plugins
+
+
+def rename(config: dict, path: list[str], old: str, new: str):
+    modified_root = copy.deepcopy(config)
+    modified_config_entry = modified_root
+    for sub_key in path:
+        modified_config_entry = modified_config_entry.get(sub_key)
+        if sub_key == "plugins":
+            # revise spec keys, probe_spec, detector_spec, buff_spec
+            for p_type, p_klass in zip(_plugins.PLUGIN_TYPES, _plugins.PLUGIN_CLASSES):
+                type_spec = modified_config_entry.get(f"{p_klass.lower()}_spec", None)
+                if p_type in path and type_spec is not None:
+                    # This is more complex than a straight substitution
+                    entries = type_spec.split(",")
+                    updated_entries = []
+                    for entry in entries:
+                        if entry == old:
+                            # if whole string just replace
+                            entry = entry.replace(old, new)
+                        elif old in path or f".{old}" in entry:
+                            # if the old value is in `path` only sub f".{old}" representing class
+                            entry = entry.replace(f".{old}", f".{new}")
+                        else:
+                            # else only sub for f"{old}." representing module
+                            entry = entry.replace(f"{old}.", f"{new}.")
+                        updated_entries.append(entry)
+                    modified_config_entry[f"{p_klass.lower()}_spec"] = ",".join(
+                        updated_entries
+                    )
+        if modified_config_entry is None:
+            return modified_root
+    config_for_rename = modified_config_entry.pop(old, None)
+    if config_for_rename is not None:
+        modified_config_entry[new] = config_for_rename
+    return modified_root

--- a/tests/resources/test_fixer.py
+++ b/tests/resources/test_fixer.py
@@ -1,0 +1,183 @@
+import pytest
+
+from garak.resources import fixer
+from garak import _config
+
+BASE_TEST_CONFIG = """
+---
+plugins:
+  probe_spec: test.Test
+"""
+
+
+@pytest.fixture
+def inject_custom_config(request, pre_migration_dict):
+    import tempfile
+    import yaml
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w") as tmp:
+        filename = tmp.name
+        config_dict = yaml.safe_load(BASE_TEST_CONFIG)
+        config_dict["plugins"] = config_dict["plugins"] | pre_migration_dict
+        yaml.dump(config_dict, tmp)
+        tmp.close()
+
+    def remove_test_file():
+        import os
+
+        files = [filename]
+        for file in files:
+            if os.path.exists(file):
+                os.remove(file)
+
+    request.addfinalizer(remove_test_file)
+
+    return filename
+
+
+@pytest.mark.parametrize(
+    "migration_name, pre_migration_dict, post_migration_dict",
+    [
+        (
+            None,
+            {},
+            {"probe_spec": "test.Test"},
+        ),
+        (
+            "RenameGCG",
+            {
+                "probe_spec": "lmrc,gcg,tap",
+            },
+            {
+                "probe_spec": "lmrc,suffix,tap",
+            },
+        ),
+        (
+            "RenameGCG",
+            {
+                "probe_spec": "lmrc,gcg,tap",
+                "probes": {"gcg": {"GOAL": "fake the goal"}},
+            },
+            {
+                "probe_spec": "lmrc,suffix,tap",
+                "probes": {"suffix": {"GOAL": "fake the goal"}},
+            },
+        ),
+        (
+            "RenameGCG",
+            {
+                "probe_spec": "lmrc,gcg.GCGCached,tap",
+                "probes": {
+                    "gcg": {
+                        "GCGCached": {},
+                        "GOAL": "fake the goal",
+                    }
+                },
+            },
+            {
+                "probe_spec": "lmrc,suffix.GCGCached,tap",
+                "probes": {
+                    "suffix": {
+                        "GCGCached": {},
+                        "GOAL": "fake the goal",
+                    }
+                },
+            },
+        ),
+        (
+            "RenameContinuation",
+            {
+                "probe_spec": "lmrc,continuation.ContinueSlursReclaimedSlurs80,tap",
+            },
+            {
+                "probe_spec": "lmrc,continuation.ContinueSlursReclaimedSlursMini,tap",
+            },
+        ),
+        (
+            "RenameContinuation",
+            {
+                "probe_spec": "lmrc,continuation,tap",
+                "probes": {
+                    "continuation": {
+                        "ContinueSlursReclaimedSlurs80": {
+                            "source_resource_filename": "fake_data_file.json"
+                        }
+                    }
+                },
+            },
+            {
+                "probe_spec": "lmrc,continuation,tap",
+                "probes": {
+                    "continuation": {
+                        "ContinueSlursReclaimedSlursMini": {
+                            "source_resource_filename": "fake_data_file.json"
+                        }
+                    }
+                },
+            },
+        ),
+        (
+            "RenameKnownbadsignatures",
+            {
+                "probe_spec": "knownbadsignatures.EICAR,lmrc,tap",
+            },
+            {
+                "probe_spec": "av_spam_scanning.EICAR,lmrc,tap",
+            },
+        ),
+        (
+            "RenameKnownbadsignatures",
+            {
+                "probe_spec": "knownbadsignatures,lmrc,tap",
+            },
+            {
+                "probe_spec": "av_spam_scanning,lmrc,tap",
+            },
+        ),
+        (
+            "RenameReplay",
+            {
+                "probe_spec": "lmrc,tap,replay",
+            },
+            {
+                "probe_spec": "lmrc,tap,divergence",
+            },
+        ),
+        (
+            "RenameReplay",
+            {
+                "probe_spec": "lmrc,tap,replay.Repeat",
+            },
+            {
+                "probe_spec": "lmrc,tap,divergence.Repeat",
+            },
+        ),
+    ],
+)
+def test_fixer_migrate(
+    mocker,
+    inject_custom_config,
+    migration_name,
+    post_migration_dict,
+):
+    import logging
+
+    mock_log_info = mocker.patch.object(
+        logging,
+        "info",
+    )
+    revised_config = fixer.migrate(inject_custom_config)
+    assert revised_config["plugins"] == post_migration_dict
+    if migration_name is None:
+        assert (
+            not mock_log_info.called
+        ), "Logging should not be called when no migrations are applied"
+    else:
+        # expect `migration_name` in a log call via mock of logging.info()
+        assert "Migration preformed" in mock_log_info.call_args.args[0]
+        found_class = False
+        for calls in mock_log_info.call_args_list:
+            found_class = migration_name in calls.args[0]
+            if found_class:
+                break
+        assert found_class

--- a/tests/resources/test_fixer.py
+++ b/tests/resources/test_fixer.py
@@ -147,7 +147,7 @@ def test_fixer_migrate(
         ), "Logging should not be called when no migrations are applied"
     else:
         # expect `migration_name` in a log call via mock of logging.info()
-        assert "Migration preformed" in mock_log_info.call_args.args[0]
+        assert "Migration performed" in mock_log_info.call_args.args[0]
         found_class = False
         for calls in mock_log_info.call_args_list:
             found_class = migration_name in calls.args[0]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -81,7 +81,7 @@ OPTIONS_PARAM = [
 OPTIONS_SPEC = [
     ("probes", "3,elim,gul.dukat", "probe_spec"),
     ("detectors", "all", "detector_spec"),
-    ("buff", "polymorph", "buff_spec"),
+    ("buffs", "polymorph", "buff_spec"),
 ]
 
 param_locs = {}
@@ -786,8 +786,9 @@ def test_set_agents():
     assert httpx._client.USER_AGENT == AGENT_TEST
     assert aiohttp.client_reqrep.SERVER_SOFTWARE == AGENT_TEST
 
+
 def httpserver():
-   return HTTPServer()
+    return HTTPServer()
 
 
 def test_agent_is_used_requests(httpserver: HTTPServer):


### PR DESCRIPTION
fix #889

Provides a path for forward migration of configuration when plugins or other configuration based parameter change between versions.

As an initial capability this acts similar to the `packer fix` command by accepting input of outdated configuration to produce an equivalent configuration for the current version of `garak`. To support _fixing_ a previous configuration tooling is added to create `Migration` classes to be detected and run in order to modify and entires in the configuration based on structural or naming changes in `garak`.

The following process can be used to add new `Migration` to the applied set used to `fix` a configuration:
1. Add a new `Mirgation` file `garak/resources/fixer/` with a filename that formatted
as `YYYYMMDD_some_descriptive_name.py`
2. Implement a new class that extends `garak.resources.fixer.Migration` with an `apply()` method that accepts an existing dictionary and returns a new modified dictionary without any side-effects to the original passed dictionary.
3. If the migration impacts the name of a plugin an `alias` should be added to the plugin class attributes.

When a user calls `garak` with the `--fix` cli parameter the configuration change detected as requiring update will be applied to and an equivalent updated configuration will be output.

Expected action when `--fix` is specified:
* passed one of `--*_option_file` or `--*_options`, json output will be generated if any change is required.
* passed `--config` or no additional configuration based flags yaml will be output if changes are required for the user supplied configuration as well as `garak.site.yaml` if found in the env.

Additional changes:
* expose `options` and `option_file` support for all plugin types
 
## Verification

### Example usage and outputs:
```
% python -m garak --fix
garak LLM vulnerability scanner v0.10.0.post1 ( https://github.com/NVIDIA/garak ) at 2024-11-27T12:00:09.690263
No revisions applied please verify options provided for `--fix`
```

old.yaml:
``` yaml
plugins:
  probe_spec: lmrc,continuation,replay,tap,knownbadsignatures.EICAR",
  probes:
    continuation:
      ContinueSlursReclaimedSlursMini:
        source_resource_filename: fake_data_file.json
  generators:
    huggingface:
      hf_args:
        torch_dtype: float32
        device: cpu
```
```
% python -m garak --fix --config old.yaml
garak LLM vulnerability scanner v0.10.0.post1 ( https://github.com/NVIDIA/garak ) at 2024-11-27T11:50:47.931551
Updated old.yaml:
plugins:
  generators:
    huggingface:
      hf_args:
        device: cpu
        torch_dtype: float32
  probe_spec: lmrc,continuation,divergence,tap,av_spam_scanning.EICAR",
  probes:
    continuation:
      ContinueSlursReclaimedSlursMini:
        source_resource_filename: fake_data_file.json

```

garak.site.yaml:
``` yaml
plugins:
  probe_spec: replay
  generators:
    huggingface:
      hf_args:
        torch_dtype: float32
        device: cpu
```
```
% python -m garak --fix
garak LLM vulnerability scanner v0.10.0.post1 ( https://github.com/NVIDIA/garak ) at 2024-11-27T11:51:31.658398
Updated /Users/jemartin/.config/garak/garak.site.yaml:
plugins:
  generators:
    huggingface:
      hf_args:
        device: cpu
        torch_dtype: float32
  probe_spec: divergence
```

probe.json
``` json
{
  "continuation": {
    "ContinueSlursReclaimedSlursMini": {
      "source_resource_filename": "fake_data_file.json"
    }
  }
}
```
```
% python -m garak --fix --probe_option_file probe.json
garak LLM vulnerability scanner v0.10.0.post1 ( https://github.com/NVIDIA/garak ) at 2024-11-27T11:52:00.846171
Updated 'probe' configuration:
{
  "continuation": {
    "ContinueSlursReclaimedSlursMini": {
      "source_resource_filename": "fake_data_file.json"
    }
  }
}
```
- [ ] **Verify** `garak.log` reports application of each applicable fix for various configs.
