### PR TITLE
pass device to transfomers pipeline

### DIFF
--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -120,7 +120,9 @@ class HFDetector(Detector, HFCompatible):
             self.detector_model_path
         )
         self.detector = TextClassificationPipeline(
-            model=self.detector_model, tokenizer=self.detector_tokenizer
+            model=self.detector_model,
+            tokenizer=self.detector_tokenizer,
+            device=self.device,
         )
 
         transformers_logging.set_verbosity(orig_loglevel)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
   "base2048>=0.1.3",
-  "transformers>=4.43.0,<4.47.0",
+  "transformers>=4.43.0",
   "datasets>=2.14.6,<2.17",
   "colorama>=0.4.3",
   "tqdm>=4.64.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 base2048>=0.1.3
-transformers>=4.43.0,<4.47.0
+transformers>=4.43.0
 datasets>=2.14.6,<2.17
 colorama>=0.4.3
 tqdm>=4.64.0


### PR DESCRIPTION
When a `pipeline` is created the base class attempts to auto-detect the optimal hardware, since the project accepts configuration for hardware device selection the device must be passed.

## Verification

- [x] actions macOS test automation
