### PR TITLE
Fix tap.PAIR run error - run_tap param evaluator_model

### DIFF
--- a/garak/probes/tap.py
+++ b/garak/probes/tap.py
@@ -284,7 +284,7 @@ class PAIR(Probe):
                 attack_model_config=self.attack_model_config,
                 attack_max_attempts=self.attack_max_attempts,
                 evaluator_model_type=self.evaluator_model_type,
-                evaluator_model=self.evaluator_model_name,
+                evaluator_model_name=self.evaluator_model_name,
                 evaluator_model_config=self.evaluator_model_config,
                 branching_factor=self.branching_factor,
                 width=self.width,

--- a/garak/probes/tap.py
+++ b/garak/probes/tap.py
@@ -260,6 +260,7 @@ class PAIR(Probe):
         "depth": 10,
         "n_streams": 1,
         "keep_last_n": 1,
+        "pruning": True,
     }
 
     def __init__(self, config_root=_config):


### PR DESCRIPTION
Fixing a bug #1044 
`$ python3 -m garak --model_type openai --model_name gpt-4 --probes tap.PAIR`

## Verification

List the steps needed to make sure this thing works

- [x] `garak -m <model_type> -n <model_name>`
- [x] Run the tests and ensure they pass `python -m pytest tests/`
- [x] **Verify** the thing does what it should

