### PR TITLE
Use HF safetensors by default

### DIFF
--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -78,7 +78,7 @@ class Pipeline(Generator, HFCompatible):
         if _config.run.seed is not None:
             set_seed(_config.run.seed)
 
-        pipeline_kwargs = self._gather_hf_params(hf_constructor=pipeline)
+        pipeline_kwargs = self._gather_hf_params(hf_constructor=pipeline, use_safetensors=_config.system.security["use_safetensors"])
         self.generator = pipeline("text-generation", **pipeline_kwargs)
         if self.generator.tokenizer is None:
             # account for possible model without a stored tokenizer

--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -78,9 +78,7 @@ class Pipeline(Generator, HFCompatible):
         if _config.run.seed is not None:
             set_seed(_config.run.seed)
 
-        pipeline_kwargs = self._gather_hf_params(
-            hf_constructor=pipeline,
-        )
+        pipeline_kwargs = self._gather_hf_params(hf_constructor=pipeline)
         self.generator = pipeline("text-generation", **pipeline_kwargs)
         if self.generator.tokenizer is None:
             # account for possible model without a stored tokenizer
@@ -170,9 +168,7 @@ class OptimumPipeline(Pipeline, HFCompatible):
             if "use_fp8" in _config.plugins.generators.OptimumPipeline:
                 self.use_fp8 = True
 
-        pipeline_kwargs = self._gather_hf_params(
-            hf_constructor=pipeline,
-        )
+        pipeline_kwargs = self._gather_hf_params(hf_constructor=pipeline)
         self.generator = pipeline("text-generation", **pipeline_kwargs)
         if not hasattr(self, "deprefix_prompt"):
             self.deprefix_prompt = self.name in models_to_deprefix
@@ -200,9 +196,7 @@ class ConversationalPipeline(Pipeline, HFCompatible):
 
         # Note that with pipeline, in order to access the tokenizer, model, or device, you must get the attribute
         # directly from self.generator instead of from the ConversationalPipeline object itself.
-        pipeline_kwargs = self._gather_hf_params(
-            hf_constructor=pipeline,
-        )
+        pipeline_kwargs = self._gather_hf_params(hf_constructor=pipeline)
         self.generator = pipeline("conversational", **pipeline_kwargs)
         self.conversation = Conversation()
         if not hasattr(self, "deprefix_prompt"):
@@ -452,7 +446,7 @@ class Model(Pipeline, HFCompatible):
         print(dir(_config.system))
 
         model_kwargs = self._gather_hf_params(
-            hf_constructor=transformers.AutoConfig.from_pretrained,
+            hf_constructor=transformers.AutoConfig.from_pretrained
         )  # will defer to device_map if device map was `auto` may not match self.device
 
         self.config = transformers.AutoConfig.from_pretrained(self.name, **model_kwargs)
@@ -571,7 +565,7 @@ class LLaVA(Generator, HFCompatible):
 
         self.device = self._select_hf_device()
         model_kwargs = self._gather_hf_params(
-            hf_constructor=LlavaNextForConditionalGeneration.from_pretrained,
+            hf_constructor=LlavaNextForConditionalGeneration.from_pretrained
         )  # will defer to device_map if device map was `auto` may not match self.device
 
         self.processor = LlavaNextProcessor.from_pretrained(self.name)

--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -171,8 +171,11 @@ class OptimumPipeline(Pipeline, HFCompatible):
             if "use_fp8" in _config.plugins.generators.OptimumPipeline:
                 self.use_fp8 = True
 
-        pipline_kwargs = self._gather_hf_params(hf_constructor=pipeline)
-        self.generator = pipeline("text-generation", **pipline_kwargs)
+        pipeline_kwargs = self._gather_hf_params(
+            hf_constructor=pipeline,
+            use_safetensors=_config.system.security["use_safetensors"],
+        )
+        self.generator = pipeline("text-generation", **pipeline_kwargs)
         if not hasattr(self, "deprefix_prompt"):
             self.deprefix_prompt = self.name in models_to_deprefix
         if _config.loaded:
@@ -199,8 +202,11 @@ class ConversationalPipeline(Pipeline, HFCompatible):
 
         # Note that with pipeline, in order to access the tokenizer, model, or device, you must get the attribute
         # directly from self.generator instead of from the ConversationalPipeline object itself.
-        pipline_kwargs = self._gather_hf_params(hf_constructor=pipeline)
-        self.generator = pipeline("conversational", **pipline_kwargs)
+        pipeline_kwargs = self._gather_hf_params(
+            hf_constructor=pipeline,
+            use_safetensors=_config.system.security["use_safetensors"],
+        )
+        self.generator = pipeline("conversational", **pipeline_kwargs)
         self.conversation = Conversation()
         if not hasattr(self, "deprefix_prompt"):
             self.deprefix_prompt = self.name in models_to_deprefix
@@ -447,7 +453,8 @@ class Model(Pipeline, HFCompatible):
             transformers.set_seed(_config.run.seed)
 
         model_kwargs = self._gather_hf_params(
-            hf_constructor=transformers.AutoConfig.from_pretrained
+            hf_constructor=transformers.AutoConfig.from_pretrained,
+            use_safetensors=_config.system.security["use_safetensors"],
         )  # will defer to device_map if device map was `auto` may not match self.device
 
         self.config = transformers.AutoConfig.from_pretrained(self.name, **model_kwargs)
@@ -566,7 +573,8 @@ class LLaVA(Generator, HFCompatible):
 
         self.device = self._select_hf_device()
         model_kwargs = self._gather_hf_params(
-            hf_constructor=LlavaNextForConditionalGeneration.from_pretrained
+            hf_constructor=LlavaNextForConditionalGeneration.from_pretrained,
+            use_safetensors=_config.system.security["use_safetensors"],
         )  # will defer to device_map if device map was `auto` may not match self.device
 
         self.processor = LlavaNextProcessor.from_pretrained(self.name)

--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -80,7 +80,6 @@ class Pipeline(Generator, HFCompatible):
 
         pipeline_kwargs = self._gather_hf_params(
             hf_constructor=pipeline,
-            use_safetensors=_config.system.security["use_safetensors"],
         )
         self.generator = pipeline("text-generation", **pipeline_kwargs)
         if self.generator.tokenizer is None:
@@ -173,7 +172,6 @@ class OptimumPipeline(Pipeline, HFCompatible):
 
         pipeline_kwargs = self._gather_hf_params(
             hf_constructor=pipeline,
-            use_safetensors=_config.system.security["use_safetensors"],
         )
         self.generator = pipeline("text-generation", **pipeline_kwargs)
         if not hasattr(self, "deprefix_prompt"):
@@ -204,7 +202,6 @@ class ConversationalPipeline(Pipeline, HFCompatible):
         # directly from self.generator instead of from the ConversationalPipeline object itself.
         pipeline_kwargs = self._gather_hf_params(
             hf_constructor=pipeline,
-            use_safetensors=_config.system.security["use_safetensors"],
         )
         self.generator = pipeline("conversational", **pipeline_kwargs)
         self.conversation = Conversation()
@@ -452,9 +449,10 @@ class Model(Pipeline, HFCompatible):
         if _config.run.seed is not None:
             transformers.set_seed(_config.run.seed)
 
+        print(dir(_config.system))
+
         model_kwargs = self._gather_hf_params(
             hf_constructor=transformers.AutoConfig.from_pretrained,
-            use_safetensors=_config.system.security["use_safetensors"],
         )  # will defer to device_map if device map was `auto` may not match self.device
 
         self.config = transformers.AutoConfig.from_pretrained(self.name, **model_kwargs)
@@ -574,7 +572,6 @@ class LLaVA(Generator, HFCompatible):
         self.device = self._select_hf_device()
         model_kwargs = self._gather_hf_params(
             hf_constructor=LlavaNextForConditionalGeneration.from_pretrained,
-            use_safetensors=_config.system.security["use_safetensors"],
         )  # will defer to device_map if device map was `auto` may not match self.device
 
         self.processor = LlavaNextProcessor.from_pretrained(self.name)

--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -78,7 +78,10 @@ class Pipeline(Generator, HFCompatible):
         if _config.run.seed is not None:
             set_seed(_config.run.seed)
 
-        pipeline_kwargs = self._gather_hf_params(hf_constructor=pipeline, use_safetensors=_config.system.security["use_safetensors"])
+        pipeline_kwargs = self._gather_hf_params(
+            hf_constructor=pipeline,
+            use_safetensors=_config.system.security["use_safetensors"],
+        )
         self.generator = pipeline("text-generation", **pipeline_kwargs)
         if self.generator.tokenizer is None:
             # account for possible model without a stored tokenizer

--- a/garak/resources/api/huggingface.py
+++ b/garak/resources/api/huggingface.py
@@ -85,7 +85,7 @@ class HFCompatible:
         ):
             args["trust_remote_code"] = False
 
-        if "use_safetensors" in params_to_process and "use_safetensors" not in params:
+        if "use_safetensors" not in params:
             args["use_safetensors"] = True
 
         return args

--- a/garak/resources/api/huggingface.py
+++ b/garak/resources/api/huggingface.py
@@ -17,7 +17,7 @@ class HFCompatible:
             if isinstance(config.n_ctx, int):
                 self.context_len = config.n_ctx
 
-    def _gather_hf_params(self, hf_constructor: Callable, use_safetensors=True):
+    def _gather_hf_params(self, hf_constructor: Callable):
         """ "Identify arguments that impact huggingface transformers resources and behavior"""
         import torch
 

--- a/garak/resources/api/huggingface.py
+++ b/garak/resources/api/huggingface.py
@@ -86,7 +86,7 @@ class HFCompatible:
             args["trust_remote_code"] = False
 
         if "use_safetensors" in params_to_process and "use_safetensors" not in params:
-            args["use_safetensors"] = use_safetensors
+            args["use_safetensors"] = True
 
         return args
 

--- a/garak/resources/api/huggingface.py
+++ b/garak/resources/api/huggingface.py
@@ -17,7 +17,7 @@ class HFCompatible:
             if isinstance(config.n_ctx, int):
                 self.context_len = config.n_ctx
 
-    def _gather_hf_params(self, hf_constructor: Callable):
+    def _gather_hf_params(self, hf_constructor: Callable, use_safetensors=True):
         """ "Identify arguments that impact huggingface transformers resources and behavior"""
         import torch
 
@@ -84,6 +84,9 @@ class HFCompatible:
             and "trust_remote_code" not in params
         ):
             args["trust_remote_code"] = False
+
+        if "use_safetensors" in params_to_process and "use_safetensors" not in params:
+            args["use_safetensors"] = use_safetensors
 
         return args
 

--- a/garak/resources/garak.core.yaml
+++ b/garak/resources/garak.core.yaml
@@ -7,6 +7,8 @@ system:
   lite: true
   show_z: false
   enable_experimental: false
+  security:
+    use_safetensors: true
 
 run:
   seed:

--- a/garak/resources/garak.core.yaml
+++ b/garak/resources/garak.core.yaml
@@ -7,8 +7,6 @@ system:
   lite: true
   show_z: false
   enable_experimental: false
-  security:
-    use_safetensors: true
 
 run:
   seed:


### PR DESCRIPTION
Support `use_safetensors` in hugging face models & enable by default

## Verification

Little tricky since HF doesn't always go for pickles even if they're present and `use_safetensors` is disabled:

```
>>> g_s = pipeline("text-generation", model="gpt2", use_safetensors=False)
config.json: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 665/665 [00:00<00:00, 3.54MB/s]
model.safetensors:  67%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████▊                                                      | 367M/548M [00:31<00:16, 11.2MB/s]