### PR TITLE
Feature: use hf chat support

### DIFF
--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -79,6 +79,9 @@ class Pipeline(Generator, HFCompatible):
             set_seed(_config.run.seed)
 
         pipeline_kwargs = self._gather_hf_params(hf_constructor=pipeline)
+        pipeline_kwargs["truncation"] = (
+            True  # this is forced to maintain existing pipeline expectations
+        )
         self.generator = pipeline("text-generation", **pipeline_kwargs)
         if self.generator.tokenizer is None:
             # account for possible model without a stored tokenizer
@@ -113,27 +116,16 @@ class Pipeline(Generator, HFCompatible):
             warnings.simplefilter("ignore", category=UserWarning)
             try:
                 with torch.no_grad():
-                    # workaround for pipeline to truncate the input
-
                     # according to docs https://huggingface.co/docs/transformers/main/en/chat_templating
                     # chat template should be automatically utilized if the pipeline tokenizer has support
+                    # and a properly formatted list[dict] is supplied
                     if self.use_chat:
-                        formatted_prompt = self.generator.tokenizer.apply_chat_template(
-                            self._format_chat_prompt(prompt),
-                            tokenize=False,
-                            add_generation_prompt=True,
-                        )
+                        formatted_prompt = self._format_chat_prompt(prompt)
                     else:
                         formatted_prompt = prompt
 
-                    encoded_prompt = self.generator.tokenizer(
-                        formatted_prompt, truncation=True
-                    )
-                    truncated_prompt = self.generator.tokenizer.decode(
-                        encoded_prompt["input_ids"], skip_special_tokens=True
-                    )
                     raw_output = self.generator(
-                        truncated_prompt,
+                        formatted_prompt,
                         pad_token_id=self.generator.tokenizer.eos_token_id,
                         max_new_tokens=self.max_tokens,
                         num_return_sequences=generations_this_call,
@@ -148,11 +140,15 @@ class Pipeline(Generator, HFCompatible):
                 i["generated_text"] for i in raw_output
             ]  # generator returns 10 outputs by default in __init__
 
-        if not self.deprefix_prompt and not self.use_chat:
-            return outputs
+        if self.use_chat:
+            text_outputs = [_o[-1]["content"].strip() for _o in outputs]
         else:
-            # consider using formatted_prompt in removal as a `list` or `str`
-            return [re.sub("^" + re.escape(formatted_prompt), "", _o) for _o in outputs]
+            text_outputs = outputs
+
+        if not self.deprefix_prompt:
+            return text_outputs
+        else:
+            return [re.sub("^" + re.escape(prompt), "", _o) for _o in text_outputs]
 
 
 class OptimumPipeline(Pipeline, HFCompatible):
@@ -520,7 +516,7 @@ class Model(Pipeline, HFCompatible):
         if self.top_k is not None:
             self.generation_config.top_k = self.top_k
 
-        text_output = []
+        raw_text_output = []
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=UserWarning)
             with torch.no_grad():
@@ -537,6 +533,10 @@ class Model(Pipeline, HFCompatible):
                     formatted_prompt, truncation=True, return_tensors="pt"
                 ).to(self.device)
 
+                prefix_prompt = self.tokenizer.decode(
+                    inputs["input_ids"][0], skip_special_tokens=True
+                )
+
                 try:
                     outputs = self.model.generate(
                         **inputs, generation_config=self.generation_config
@@ -549,17 +549,22 @@ class Model(Pipeline, HFCompatible):
                         return returnval
                     else:
                         raise e
-                text_output = self.tokenizer.batch_decode(
+                raw_text_output = self.tokenizer.batch_decode(
                     outputs, skip_special_tokens=True, device=self.device
                 )
 
-        if not self.deprefix_prompt and not self.use_chat:
+        if self.use_chat:
+            text_output = [
+                re.sub("^" + re.escape(prefix_prompt), "", i).strip()
+                for i in raw_text_output
+            ]
+        else:
+            text_output = raw_text_output
+
+        if not self.deprefix_prompt:
             return text_output
         else:
-            # consider using formatted_prompt in removal as a `list` or `str`
-            return [
-                re.sub("^" + re.escape(formatted_prompt), "", i) for i in text_output
-            ]
+            return [re.sub("^" + re.escape(prefix_prompt), "", i) for i in text_output]
 
 
 class LLaVA(Generator, HFCompatible):

--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -148,10 +148,11 @@ class Pipeline(Generator, HFCompatible):
                 i["generated_text"] for i in raw_output
             ]  # generator returns 10 outputs by default in __init__
 
-        if not self.deprefix_prompt:
+        if not self.deprefix_prompt and not self.use_chat:
             return outputs
         else:
-            return [re.sub("^" + re.escape(prompt), "", _o) for _o in outputs]
+            # consider using formatted_prompt in removal as a `list` or `str`
+            return [re.sub("^" + re.escape(formatted_prompt), "", _o) for _o in outputs]
 
 
 class OptimumPipeline(Pipeline, HFCompatible):
@@ -552,10 +553,13 @@ class Model(Pipeline, HFCompatible):
                     outputs, skip_special_tokens=True, device=self.device
                 )
 
-        if not self.deprefix_prompt:
+        if not self.deprefix_prompt and not self.use_chat:
             return text_output
         else:
-            return [re.sub("^" + re.escape(prompt), "", i) for i in text_output]
+            # consider using formatted_prompt in removal as a `list` or `str`
+            return [
+                re.sub("^" + re.escape(formatted_prompt), "", i) for i in text_output
+            ]
 
 
 class LLaVA(Generator, HFCompatible):

--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -90,10 +90,11 @@ class Pipeline(Generator, HFCompatible):
             self.generator.tokenizer = AutoTokenizer.from_pretrained(
                 pipeline_kwargs["model"]
             )
-        self.use_chat = (
-            hasattr(self.generator.tokenizer, "chat_template")
-            and self.generator.tokenizer.chat_template is not None
-        )
+        if not hasattr(self, "use_chat"):
+            self.use_chat = (
+                hasattr(self.generator.tokenizer, "chat_template")
+                and self.generator.tokenizer.chat_template is not None
+            )
         if not hasattr(self, "deprefix_prompt"):
             self.deprefix_prompt = self.name in models_to_deprefix
         if _config.loaded:
@@ -486,11 +487,12 @@ class Model(Pipeline, HFCompatible):
                 self.name, padding_side="left"
             )
 
-        # test tokenizer for `apply_chat_template` support
-        self.use_chat = (
-            hasattr(self.tokenizer, "chat_template")
-            and self.tokenizer.chat_template is not None
-        )
+        if not hasattr(self, "use_chat"):
+            # test tokenizer for `apply_chat_template` support
+            self.use_chat = (
+                hasattr(self.tokenizer, "chat_template")
+                and self.tokenizer.chat_template is not None
+            )
 
         self.generation_config = transformers.GenerationConfig.from_pretrained(
             self.name

--- a/tests/generators/test_huggingface.py
+++ b/tests/generators/test_huggingface.py
@@ -58,8 +58,11 @@ def test_pipeline_chat(mocker, hf_generator_config):
     mock_format = mocker.patch.object(
         g, "_format_chat_prompt", wraps=g._format_chat_prompt
     )
-    g.generate("Hello world!")
+    output = g.generate("Hello world!")
     mock_format.assert_called_once()
+    assert len(output) == 1
+    for item in output:
+        assert isinstance(item, str)
 
 
 def test_inference(mocker, hf_mock_response, hf_generator_config):
@@ -141,8 +144,11 @@ def test_model_chat(mocker, hf_generator_config):
     mock_format = mocker.patch.object(
         g, "_format_chat_prompt", wraps=g._format_chat_prompt
     )
-    g.generate("Hello world!")
+    output = g.generate("Hello world!")
     mock_format.assert_called_once()
+    assert len(output) == 1
+    for item in output:
+        assert isinstance(item, str)
 
 
 def test_select_hf_device():

--- a/tests/generators/test_huggingface.py
+++ b/tests/generators/test_huggingface.py
@@ -50,6 +50,18 @@ def test_pipeline(hf_generator_config):
         assert isinstance(item, str)
 
 
+def test_pipeline_chat(mocker, hf_generator_config):
+    # uses a ~350M model with chat support
+    g = garak.generators.huggingface.Pipeline(
+        "microsoft/DialoGPT-small", config_root=hf_generator_config
+    )
+    mock_format = mocker.patch.object(
+        g, "_format_chat_prompt", wraps=g._format_chat_prompt
+    )
+    g.generate("Hello world!")
+    mock_format.assert_called_once()
+
+
 def test_inference(mocker, hf_mock_response, hf_generator_config):
     model_name = "gpt2"
     mock_request = mocker.patch.object(
@@ -119,6 +131,18 @@ def test_model(hf_generator_config):
     assert len(output) == 1  # expect 1 generation by default
     for item in output:
         assert item is None  # gpt2 is known raise exception returning `None`
+
+
+def test_model_chat(mocker, hf_generator_config):
+    # uses a ~350M model with chat support
+    g = garak.generators.huggingface.Model(
+        "microsoft/DialoGPT-small", config_root=hf_generator_config
+    )
+    mock_format = mocker.patch.object(
+        g, "_format_chat_prompt", wraps=g._format_chat_prompt
+    )
+    g.generate("Hello world!")
+    mock_format.assert_called_once()
 
 
 def test_select_hf_device():


### PR DESCRIPTION
Fix #1029 

When a huggingface model supports a chat_template wrap the prompt in a chat list to enable request formatting. Using the trained template formatting can have significant impact on the inference efficiency as well the context of the response. This aligns local model execution with deployed scenarios.

* shift `truncation` requirement into pipeline creation call
* apply chat templates when available
* remove template as prefix if found in output for `huggingface.Model` inference

As a future task I could see possibly wanting to suppress `chat_template` formatting to test poorly configured inference against a instruct model.  This idea is left as an exercise for future consideration.

## Verification

List the steps needed to make sure this thing works

- [ ] `python -m garak -m huggingface -n mistralai/Mistral-7B-Instruct-v0.1 -p atkgen`
- [ ] `python -m garak -m huggingface -n mistralai/Mistral-7B-Instruct-v0.1 -p lmrc`
- [ ] `python -m garak -m huggingface -n gpt2 -p lmrc`
- [ ] `python -m garak -m huggingface.Model -n mistralai/Mistral-7B-Instruct-v0.1 -p atkgen`
- [ ] `python -m garak -m huggingface.Model -n mistralai/Mistral-7B-Instruct-v0.1 -p lmrc`
- [ ] `python -m garak -m huggingface.Model -n gpt2 -p lmrc`
