### PR TITLE
Warn if api_key in Config

### DIFF
--- a/garak/_config.py
+++ b/garak/_config.py
@@ -21,7 +21,6 @@ from xdg_base_dirs import (
     xdg_config_home,
     xdg_data_home,
 )
-from garak.exception import ConfigSecretWarning
 
 DICT_CONFIG_AFTER_LOAD = False
 

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -120,9 +120,11 @@ run.seed = None
 
 def _key_exists(d: dict, key: str) -> bool:
     # Check for the presence of a key in a nested dict.
-    if not isinstance(d, dict):
+    if not isinstance(d, dict) and not isinstance(d, list):
         return False
-    if key in d.keys():
+    if isinstance(d, list):
+        return any([_key_exists(item, key) for item in d])
+    if isinstance(d, dict) and key in d.keys():
         return True
     else:
         return any([_key_exists(val, key) for val in d.values()])

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -21,6 +21,7 @@ from xdg_base_dirs import (
     xdg_config_home,
     xdg_data_home,
 )
+from garak.command import hint
 
 DICT_CONFIG_AFTER_LOAD = False
 
@@ -116,6 +117,7 @@ run.seed = None
 # placeholder
 # generator, probe, detector, buff = {}, {}, {}, {}
 
+
 def _key_exists(d: dict, key: str) -> bool:
     # Check for the presence of a key in a nested dict.
     if not isinstance(d, dict):
@@ -155,7 +157,11 @@ def _load_yaml_config(settings_filenames) -> dict:
                     logging.info(f"API key found in {settings_filename}. Checking readability...")
                     res = os.stat(settings_filename)
                     if res.st_mode & stat.S_IROTH or res.st_mode & stat.S_IRGRP:
-                        logging.warn(f"A possibly secret value (`api_key`) was detected in {settings_filename}, which is readable by users other than yourself.")
+                        msg = (f"A possibly secret value (`api_key`) was detected in {settings_filename}, "
+                               f"which is readable by users other than yourself. "
+                               f"Consider changing permissions on this file to only be readable by you.")
+                        logging.warning(msg)
+                        hint(msg)
                 config = _combine_into(settings, config)
     return config
 

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -21,7 +21,6 @@ from xdg_base_dirs import (
     xdg_config_home,
     xdg_data_home,
 )
-from garak.command import hint
 
 DICT_CONFIG_AFTER_LOAD = False
 
@@ -163,7 +162,7 @@ def _load_yaml_config(settings_filenames) -> dict:
                                f"which is readable by users other than yourself. "
                                f"Consider changing permissions on this file to only be readable by you.")
                         logging.warning(msg)
-                        hint(msg)
+                        print(f"⚠️  {msg}")
                 config = _combine_into(settings, config)
     return config
 

--- a/garak/exception.py
+++ b/garak/exception.py
@@ -36,3 +36,7 @@ class ConfigFailure(GarakException):
 
 class PayloadFailure(GarakException):
     """Problem instantiating/using payloads"""
+
+
+class ConfigSecretWarning(Warning):
+    """Raised when a secret value is detected in a config"""

--- a/garak/exception.py
+++ b/garak/exception.py
@@ -36,7 +36,3 @@ class ConfigFailure(GarakException):
 
 class PayloadFailure(GarakException):
     """Problem instantiating/using payloads"""
-
-
-class ConfigSecretWarning(Warning):
-    """Raised when a secret value is detected in a config"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -826,3 +826,10 @@ def test_agent_is_used_aiohttp(httpserver: HTTPServer):
         "/", headers={"User-Agent": AGENT_TEST}
     ).respond_with_data("")
     asyncio.run(main())
+
+
+def test_api_key_in_config():
+    importlib.reload(_config)
+
+    _config.plugins.generators["a"]["b"]["c"]["api_key"] = "something"
+    assert _config._key_exists(_config.plugins.generators, "api_key")


### PR DESCRIPTION
Fixes #927 

Look for the presence of `api_key` as a key when loading config files, raise a warning to the user if the file is readable by group or others.

## Verification

List the steps needed to make sure this thing works

``` yaml
---
run:
    seed:
    eval_threshold: 0.5
    generations: 1
    probe_tags:

plugins:
    model_type: test
    model_name: Lipsum
    detector_spec: auto
    api_key: test
    probe_spec: test.Test

reporting:
    report_prefix: test
```

run `garak --config config.yaml`

NOTE: The warning does not get surfaced to the user directly, which shouldn't be the case when we warn, but it is written to the log. This is an artifact of our default verbosity and it may make sense to `print` the warning here. 