### PR TITLE
Feature: configuration based rest ssl suppression

### DIFF
--- a/docs/source/garak.generators.rest.rst
+++ b/docs/source/garak.generators.rest.rst
@@ -18,6 +18,7 @@ Uses the following options from ``_config.plugins.generators["rest.RestGenerator
 * ``request_timeout`` - How many seconds should we wait before timing out? Default 20
 * ``ratelimit_codes`` - Which endpoint HTTP response codes should be caught as indicative of rate limiting and retried? ``List[int]``, default ``[429]``
 * ``skip_codes`` - Which endpoint HTTP response code should lead to the generation being treated as not possible and skipped for this query. Takes precedence over ``ratelimit_codes``.
+* ``verify_ssl`` - (optional) Enforce ssl certificate validation? Default is True (bool)
 
 Templates can be either a string or a JSON-serialisable Python object.
 Instance of ``$INPUT`` here are replaced with the prompt; instances of ``$KEY``

--- a/docs/source/garak.generators.rest.rst
+++ b/docs/source/garak.generators.rest.rst
@@ -18,7 +18,7 @@ Uses the following options from ``_config.plugins.generators["rest.RestGenerator
 * ``request_timeout`` - How many seconds should we wait before timing out? Default 20
 * ``ratelimit_codes`` - Which endpoint HTTP response codes should be caught as indicative of rate limiting and retried? ``List[int]``, default ``[429]``
 * ``skip_codes`` - Which endpoint HTTP response code should lead to the generation being treated as not possible and skipped for this query. Takes precedence over ``ratelimit_codes``.
-* ``verify_ssl`` - (optional) Enforce ssl certificate validation? Default is True (bool)
+* ``verify_ssl`` - (optional) Enforce ssl certificate validation? Default is ``True``, a file path to a CA bundle can be provided. (bool|str)
 
 Templates can be either a string or a JSON-serialisable Python object.
 Instance of ``$INPUT`` here are replaced with the prompt; instances of ``$KEY``

--- a/garak/generators/rest.py
+++ b/garak/generators/rest.py
@@ -130,6 +130,10 @@ class RestGenerator(Generator):
                     "`proxies` value provided is not in the required format. See documentation from the `requests` package for details on expected format. https://requests.readthedocs.io/en/latest/user/advanced/#proxies"
                 )
 
+        # suppress warnings about intentional SSL validation suppression
+        if isinstance(self.verify_ssl, bool) and not self.verify_ssl:
+            requests.packages.urllib3.disable_warnings()
+
         # validate jsonpath
         if self.response_json and self.response_json_field:
             try:

--- a/garak/generators/rest.py
+++ b/garak/generators/rest.py
@@ -36,6 +36,7 @@ class RestGenerator(Generator):
         "req_template": "$INPUT",
         "request_timeout": 20,
         "proxies": None,
+        "verify_ssl": True,
     }
 
     ENV_VAR = "REST_API_KEY"
@@ -61,6 +62,7 @@ class RestGenerator(Generator):
         "temperature",
         "top_k",
         "proxies",
+        "verify_ssl",
     )
 
     def __init__(self, uri=None, config_root=_config):
@@ -204,6 +206,7 @@ class RestGenerator(Generator):
             "headers": request_headers,
             "timeout": self.request_timeout,
             "proxies": self.proxies,
+            "verify": self.verify_ssl,
         }
         resp = self.http_function(self.uri, **req_kArgs)
 


### PR DESCRIPTION
Adds configuration based support to suppress ssl verification to the rest.RestGenerator.

This extracts the capability from @au70ma70n's PR https://github.com/NVIDIA/garak/pull/878

## Verification

example rest_config.json, add any required configuration for your rest endpoint [found here](https://reference.garak.ai/en/latest/garak.generators.rest.html):
``` json
{
    "rest": {
        "RestGenerator": {
           "uri": "http://my_internal_llm_endpoint",
           "verify_ssl": false
        }
    }
}
```
- [ ] `garak -m rest -G rest_config.json -p lmrc`
- [ ] **Verify** test with a self signed certificate not in the local certificate store
- [x] **Verify** test with an http only endpoint