### PR TITLE
guard against `None` in `leakreplay` attempt history management

### DIFF
--- a/garak/probes/leakreplay.py
+++ b/garak/probes/leakreplay.py
@@ -64,9 +64,10 @@ class LiteratureCloze(Probe):
 
     def _postprocess_hook(self, attempt: Attempt) -> Attempt:
         for idx, thread in enumerate(attempt.messages):
-            attempt.messages[idx][-1]["content"] = re.sub(
-                "</?name>", "", thread[-1]["content"]
-            )
+            if thread[-1]["content"] is not None:
+                attempt.messages[idx][-1]["content"] = re.sub(
+                    "</?name>", "", thread[-1]["content"]
+                )
         return attempt
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ authors = [
   { name = "Shine-afk" },
   { name = "Rafael Sandroni" },  
   { name = "Eric Hacker" },
+  { name = "Blessed Uyo" },
 ]
 license = { file = "LICENSE" }
 description = "LLM vulnerability scanner"

--- a/tests/probes/test_probes_leakreplay.py
+++ b/tests/probes/test_probes_leakreplay.py
@@ -8,6 +8,7 @@ import garak._config
 import garak._plugins
 import garak.attempt
 import garak.cli
+import garak.probes.leakreplay
 
 
 def test_leakreplay_hitlog():
@@ -29,3 +30,10 @@ def test_leakreplay_output_count():
     p.generator = g
     results = p._execute_all([a])
     assert len(a.all_outputs) == generations
+
+
+def test_leakreplay_handle_incomplete_attempt():
+    p = garak.probes.leakreplay.LiteratureCloze80()
+    a = garak.attempt.Attempt(prompt="IS THIS BROKEN")
+    a.outputs = ["", None]
+    p._postprocess_hook(a)


### PR DESCRIPTION
resolves #879 

`NoneType` in attempt message history would cause a crash when `leakreplay` rewrites that message history. Guard against `None` here. It's unclear how a None would get in there in the first place, but the original report hasn't had updates, so this may have been a transient behaviour.

Thanks @bleszily


## Verification

- `python -m pytest tests/probes/test_probes_leakreplay.py::test_leakreplay_handle_incomplete_attempt`
