### PR TITLE
init zscore with enough scope to cover its uses

### DIFF
--- a/garak/evaluators/base.py
+++ b/garak/evaluators/base.py
@@ -164,6 +164,7 @@ class Evaluator:
 
     def print_results_wide(self, detector_name, passes, messages):
         """Print the evaluator's summary"""
+        zscore = None
         if len(passes):
             outcome = (
                 Fore.LIGHTRED_EX + "FAIL"
@@ -171,7 +172,6 @@ class Evaluator:
                 else Fore.LIGHTGREEN_EX + "PASS"
             )
             failrate = 100 * (len(passes) - sum(passes)) / len(passes)
-            zscore = None
             if _config.system.show_z:
                 zscore, rating_symbol = self.get_z_rating(
                     self.probename, detector_name, failrate


### PR DESCRIPTION
may resolve #1082 

initialise `zscore` in evaluators.base at a high enough scope that it has a value before it's checked.