### PR TITLE
update: Give clearer message when heading encoding fails

### DIFF
--- a/garak/generators/rest.py
+++ b/garak/generators/rest.py
@@ -218,7 +218,7 @@ class RestGenerator(Generator):
             # only RFC2616 (latin-1) is guaranteed
             # don't print a repr, this might leak api keys
             logging.error(
-                "Only latin-1 encoding supported by HTTP RFC 2616, check headers",
+                "Only latin-1 encoding supported by HTTP RFC 2616, check headers and values for unusual chars",
                 exc_info=uee,
             )
             raise BadGeneratorException from uee

--- a/garak/generators/rest.py
+++ b/garak/generators/rest.py
@@ -212,7 +212,16 @@ class RestGenerator(Generator):
             "proxies": self.proxies,
             "verify": self.verify_ssl,
         }
-        resp = self.http_function(self.uri, **req_kArgs)
+        try:
+            resp = self.http_function(self.uri, **req_kArgs)
+        except UnicodeEncodeError as uee:
+            # only RFC2616 (latin-1) is guaranteed
+            # don't print a repr, this might leak api keys
+            logging.error(
+                "Only latin-1 encoding supported by HTTP RFC 2616, check headers",
+                exc_info=uee,
+            )
+            raise BadGeneratorException from uee
 
         if resp.status_code in self.skip_codes:
             logging.debug(

--- a/tests/generators/test_rest.py
+++ b/tests/generators/test_rest.py
@@ -3,6 +3,8 @@ import pytest
 
 from garak import _config, _plugins
 
+from garak.exception import BadGeneratorException
+
 from garak.generators.rest import RestGenerator
 
 DEFAULT_NAME = "REST Test"
@@ -202,3 +204,16 @@ def test_rest_ssl_suppression(mocker, requests_mock, verify_ssl):
     generator._call_model("Who is Enabran Tain's son?")
     mock_http_function.assert_called_once()
     assert mock_http_function.call_args_list[0].kwargs["verify"] is verify_ssl
+
+
+@pytest.mark.usefixtures("set_rest_config")
+def test_rest_non_latin1():
+    _config.plugins.generators["rest"]["RestGenerator"]["uri"] = "http://127.0.0.9" # don't mock
+    _config.plugins.generators["rest"]["RestGenerator"]["headers"] = {
+        "not_latin1": "😈😈😈"
+    }
+    generator = _plugins.load_plugin(
+        "generators.rest.RestGenerator", config_root=_config
+    )
+    with pytest.raises(BadGeneratorException):
+        generator._call_model("summon a demon and bind it")


### PR DESCRIPTION
resolves #1035 (best effort)

HTTP under base RFC2616 only supports ASCII and latin-1 (iso-8859-1) encodings. This is echoed in Python's `http` lib implementation. When characters from outside these sets turn up in certain parts of an HTTP requests, an encoding exception is raised.

This PR catches that exception, wraps it in an error message, logs with a suggestion, and then tries to stop generation using a BadGeneratorException.

Design decisions:

* Because the encoding is likely in the HTTP headers or other meta-information, and this information will be static across all requests, it's likely none of the requests will succeed. In this case we may as well give up the run as soon as possible, rather than skipping.
* Because headers may contain API keys, we don't try to log or print the request that led to the failure


## Verification

* [ ] `python -m pytest tests/generators/test_rest::test_rest_non_latin1`