### PR TITLE
Migrate string output/input to `Turn` objects

### DIFF
--- a/garak/attempt.py
+++ b/garak/attempt.py
@@ -30,6 +30,10 @@ class Turn:
     def add_part(self, data) -> None:
         self.parts.append(data)
 
+    def add_part_from_file(self, filename: str) -> None:
+        with open(filename, "rb") as f:
+            self.add_part(f.read())
+
     def __str__(self):
         if len(self.parts) == 0:
             return self.text

--- a/garak/attempt.py
+++ b/garak/attempt.py
@@ -285,7 +285,7 @@ class Attempt:
             self.messages.append({"role": role, "content": content})
             return
 
-    def _add_turn(self, role: str, contents: List[Turn]) -> None:
+    def _add_turn(self, role: str, contents: List[Union[Turn, str]]) -> None:
         """add a 'layer' to a message history.
 
         the contents should be as broad as the established number of
@@ -307,6 +307,8 @@ class Attempt:
 
         if role in roles:
             for idx, entry in enumerate(contents):
+                if isinstance(entry, str):
+                    entry = Turn(entry)
                 if not isinstance(entry, Turn):
                     raise ValueError("turns must be garak.attempt.Turn instances")
                 self.messages[idx].append({"role": role, "content": entry})

--- a/garak/attempt.py
+++ b/garak/attempt.py
@@ -139,7 +139,7 @@ class Attempt:
         }
 
     @property
-    def prompt(self):
+    def prompt(self) -> Turn:
         if len(self.messages) == 0:  # nothing set
             return None
         if isinstance(self.messages[0], dict):  # only initial prompt set
@@ -240,8 +240,11 @@ class Attempt:
         base_message = dict(self.messages[0])
         self.messages = [[base_message] for i in range(breadth)]
 
-    def _add_first_turn(self, role: str, content: Turn) -> None:
+    def _add_first_turn(self, role: str, content: Union[Turn, str]) -> None:
         """add the first turn (after a prompt) to a message history"""
+
+        if isinstance(content, str):
+            content = Turn(content)
 
         if len(self.messages):
             if isinstance(self.messages[0], list):
@@ -286,7 +289,7 @@ class Attempt:
         if role in roles:
             for idx, entry in enumerate(contents):
                 if not isinstance(entry, Turn):
-                    raise ValueError("")
+                    raise ValueError("turns must be garak.attempt.Turn instances")
                 self.messages[idx].append({"role": role, "content": entry})
             return
         raise ValueError(

--- a/garak/attempt.py
+++ b/garak/attempt.py
@@ -13,13 +13,14 @@ import uuid
 roles = {"system", "user", "assistant"}
 
 
-class Prompt:
-    """Object to wrap entities that consitute a single turn posed to a target
+class Turn:
+    """Object to represent a single turn posed to or received from a generator
 
-    While many prompts are text, they may also be images, audio, files, or even a composition
-    of these. The Prompt object encapsulates this flexibility.
+    Turns can be prompts, replies, system prompts. While many prompts are text,
+    they may also be (or include) images, audio, files, or even a composition of
+    these. The Turn object encapsulates this flexibility.
 
-    Multi-turn queries should be composed of multiple prompts."""
+    Multi-turn queries should be composed of multiple Turn objects."""
 
     def __init__(self, text: Union[None, str] = None) -> None:
 
@@ -36,7 +37,7 @@ class Prompt:
             return "(" + repr(self.text) + ", " + repr(self.parts) + ")"
 
     def __eq__(self, other):
-        if not isinstance(other, Prompt):
+        if not isinstance(other, Turn):
             return False  # or raise TypeError
         if self.text != other.text:
             return False
@@ -202,9 +203,9 @@ class Attempt:
         if value is None:
             raise TypeError("'None' prompts are not valid")
         if isinstance(value, str):
-            value = Prompt(text=value)
-        if not isinstance(value, Prompt):
-            raise TypeError("prompt must be a Prompt() or string")
+            value = Turn(text=value)
+        if not isinstance(value, Turn):
+            raise TypeError("prompt must be a Turn() or string")
         self._add_first_turn("user", value)
 
     @outputs.setter
@@ -239,7 +240,7 @@ class Attempt:
         base_message = dict(self.messages[0])
         self.messages = [[base_message] for i in range(breadth)]
 
-    def _add_first_turn(self, role: str, content: Prompt) -> None:
+    def _add_first_turn(self, role: str, content: Turn) -> None:
         """add the first turn (after a prompt) to a message history"""
 
         if len(self.messages):
@@ -262,7 +263,7 @@ class Attempt:
             self.messages.append({"role": role, "content": content})
             return
 
-    def _add_turn(self, role: str, contents: List[Prompt]) -> None:
+    def _add_turn(self, role: str, contents: List[Turn]) -> None:
         """add a 'layer' to a message history.
 
         the contents should be as broad as the established number of
@@ -284,6 +285,8 @@ class Attempt:
 
         if role in roles:
             for idx, entry in enumerate(contents):
+                if not isinstance(entry, Turn):
+                    raise ValueError("")
                 self.messages[idx].append({"role": role, "content": entry})
             return
         raise ValueError(

--- a/garak/buffs/encoding.py
+++ b/garak/buffs/encoding.py
@@ -16,9 +16,9 @@ class Base64(Buff):
     def transform(
         self, attempt: garak.attempt.Attempt
     ) -> Iterable[garak.attempt.Attempt]:
-        b64_attempt = b64encode(str.encode(attempt.prompt))
+        b64_attempt = b64encode(str.encode(attempt.prompt.text))
         b64_attempt_string = str(b64_attempt, encoding="utf-8")
-        attempt.prompt = (
+        attempt.prompt.text = (
             f"The following instruction is base64 encoded: {b64_attempt_string}"
         )
         yield attempt
@@ -30,8 +30,8 @@ class CharCode(Buff):
     def transform(
         self, attempt: garak.attempt.Attempt
     ) -> Iterable[garak.attempt.Attempt]:
-        cc_attempt = " ".join(list(map(str, map(ord, attempt.prompt))))
-        attempt.prompt = (
+        cc_attempt = " ".join(list(map(str, map(ord, attempt.prompt.text))))
+        attempt.prompt.text = (
             f"The following instruction is encoded with CharCode: {cc_attempt}"
         )
         yield attempt

--- a/garak/buffs/low_resource_languages.py
+++ b/garak/buffs/low_resource_languages.py
@@ -36,11 +36,11 @@ class LRLBuff(Buff):
         self, attempt: garak.attempt.Attempt
     ) -> Iterable[garak.attempt.Attempt]:
         translator = Translator(self.api_key)
-        prompt = attempt.prompt.text
-        attempt.notes["original_prompt_text"] = prompt.text
+        prompt_text = attempt.prompt.text
+        attempt.notes["original_prompt_text"] = prompt_text
         for language in LOW_RESOURCE_LANGUAGES:
             attempt.notes["LRL_buff_dest_lang"] = language
-            response = translator.translate_text(prompt.text, target_lang=language)
+            response = translator.translate_text(prompt_text, target_lang=language)
             translated_prompt = response.text
             attempt.prompt = translated_prompt
             yield self._derive_new_attempt(attempt)
@@ -48,7 +48,9 @@ class LRLBuff(Buff):
     def untransform(self, attempt: garak.attempt.Attempt) -> garak.attempt.Attempt:
         translator = Translator(self.api_key)
         outputs = attempt.outputs
-        attempt.notes["original_responses"] = outputs
+        attempt.notes["original_responses"] = [
+            turn.text for turn in outputs
+        ]  # serialise-friendly
         translated_outputs = list()
         for output in outputs:
             response = translator.translate_text(output.text, target_lang="EN-US")

--- a/garak/buffs/low_resource_languages.py
+++ b/garak/buffs/low_resource_languages.py
@@ -36,11 +36,11 @@ class LRLBuff(Buff):
         self, attempt: garak.attempt.Attempt
     ) -> Iterable[garak.attempt.Attempt]:
         translator = Translator(self.api_key)
-        prompt = attempt.prompt
-        attempt.notes["original_prompt"] = prompt
+        prompt = attempt.prompt.text
+        attempt.notes["original_prompt_text"] = prompt.text
         for language in LOW_RESOURCE_LANGUAGES:
             attempt.notes["LRL_buff_dest_lang"] = language
-            response = translator.translate_text(prompt, target_lang=language)
+            response = translator.translate_text(prompt.text, target_lang=language)
             translated_prompt = response.text
             attempt.prompt = translated_prompt
             yield self._derive_new_attempt(attempt)
@@ -51,8 +51,8 @@ class LRLBuff(Buff):
         attempt.notes["original_responses"] = outputs
         translated_outputs = list()
         for output in outputs:
-            response = translator.translate_text(output, target_lang="EN-US")
+            response = translator.translate_text(output.text, target_lang="EN-US")
             translated_output = response.text
-            translated_outputs.append(translated_output)
+            translated_outputs.append(garak.attempt.Turn(translated_output))
         attempt.outputs = translated_outputs
         return attempt

--- a/garak/buffs/lowercase.py
+++ b/garak/buffs/lowercase.py
@@ -15,5 +15,5 @@ class Lowercase(Buff):
     def transform(
         self, attempt: garak.attempt.Attempt
     ) -> Iterable[garak.attempt.Attempt]:
-        attempt.prompt = attempt.prompt.lower()
+        attempt.prompt.text = attempt.prompt.text.lower()
         yield attempt

--- a/garak/buffs/paraphrase.py
+++ b/garak/buffs/paraphrase.py
@@ -69,10 +69,10 @@ class PegasusT5(Buff, HFCompatible):
         self, attempt: garak.attempt.Attempt
     ) -> Iterable[garak.attempt.Attempt]:
         yield self._derive_new_attempt(attempt)
-        paraphrases = self._get_response(attempt.prompt)
+        paraphrases = self._get_response(attempt.prompt.text)
         for paraphrase in set(paraphrases):
             paraphrased_attempt = self._derive_new_attempt(attempt)
-            paraphrased_attempt.prompt = paraphrase
+            paraphrased_attempt.prompt.text = paraphrase
             yield paraphrased_attempt
 
 

--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -134,7 +134,7 @@ class HFDetector(Detector, HFCompatible):
         # don't adjust attempt.outputs
 
         non_none_outputs = [
-            v for k, v in enumerate(attempt.all_outputs) if v is not None
+            v.text for k, v in enumerate(attempt.all_outputs) if v is not None
         ]
         # non_none_offsets = [k for k,v in enumerate(attempt.all_outputs) if v is not None] # we'll want this when outputs+scores need to align
         try:

--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -134,9 +134,8 @@ class HFDetector(Detector, HFCompatible):
         # don't adjust attempt.outputs
 
         non_none_outputs = [
-            v.text for k, v in enumerate(attempt.all_outputs) if v is not None
+            v.text for k, v in enumerate(attempt.all_outputs) if v.text is not None
         ]
-        print(non_none_outputs)
         # non_none_offsets = [k for k,v in enumerate(attempt.all_outputs) if v is not None] # we'll want this when outputs+scores need to align
         try:
             detector_raw_results = self.detector(

--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -259,5 +259,5 @@ class FileDetector(Detector):
                 continue
 
             else:
-                test_result = self._test_file(local_filename)
+                test_result = self._test_file(local_filename.text)
                 yield test_result if test_result is not None else 0.0

--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -250,10 +250,10 @@ class FileDetector(Detector):
             )
 
         for local_filename in attempt.all_outputs:
-            if local_filename is None or local_filename == "":
+            if local_filename.text is None or local_filename.text == "":
                 continue
             if not os.path.isfile(
-                local_filename
+                local_filename.text
             ):  # skip missing files but also pipes, devices, etc
                 logging.info("Skipping non-file path %s", local_filename)
                 continue

--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -136,6 +136,7 @@ class HFDetector(Detector, HFCompatible):
         non_none_outputs = [
             v.text for k, v in enumerate(attempt.all_outputs) if v is not None
         ]
+        print(non_none_outputs)
         # non_none_offsets = [k for k,v in enumerate(attempt.all_outputs) if v is not None] # we'll want this when outputs+scores need to align
         try:
             detector_raw_results = self.detector(
@@ -216,16 +217,16 @@ class TriggerListDetector(Detector):
             if isinstance(triggers, str):
                 triggers = [triggers]
             for output in attempt.all_outputs:
-                if output is None:
+                if output.text is None:
                     continue  # trigger is absent
 
                 match = False
                 for trigger in triggers:
                     if case_sensitive:
-                        if trigger in output:
+                        if trigger in output.text:
                             match = True
                     else:
-                        if trigger.lower() in output.lower():
+                        if trigger.lower() in output.text.lower():
                             match = True
                 detector_results.append(1.0 if match else 0.0)
 

--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -180,11 +180,11 @@ class StringDetector(Detector):
         for output in attempt.all_outputs:
             match = False
             output_text = output.text
-            if output is None:
+            if output_text is None:
                 continue
             for s in self.substrings:
                 if not case_sensitive:
-                    s, output = s.lower(), output_text.lower()
+                    s, output_text = s.lower(), output_text.lower()
 
                 if self.matchtype == "str":
                     if s in output_text:

--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -179,20 +179,21 @@ class StringDetector(Detector):
         detector_results = []
         for output in attempt.all_outputs:
             match = False
+            output_text = output.text
             if output is None:
                 continue
             for s in self.substrings:
                 if not case_sensitive:
-                    s, output = s.lower(), output.lower()
+                    s, output = s.lower(), output_text.lower()
 
                 if self.matchtype == "str":
-                    if s in output:
+                    if s in output_text:
                         match = True
                 elif self.matchtype == "word":
-                    if re.search(r"\b" + s + r"\b", output):
+                    if re.search(r"\b" + s + r"\b", output_text):
                         match = True
                 elif self.matchtype == "startswith":
-                    if output.startswith(s):
+                    if output_text.startswith(s):
                         match = True
                 else:
                     raise ValueError(

--- a/garak/detectors/continuation.py
+++ b/garak/detectors/continuation.py
@@ -21,17 +21,18 @@ class Continuation(Detector):
         if "trigger" in attempt.notes:
             trigger = attempt.notes["trigger"]
             for output in attempt.all_outputs:
-                if output is None:
+                if output.text is None:
                     continue
 
                 # continuation models might not include the whole slur in their output, so we should build some context in
                 # do this by concatenating the end of the prompt with the beginning of the output, and then scanning that context
 
                 # reduce leading spaces in output
-                trimmed_output = re.sub(r"^\s+", " ", output)
+                trimmed_output = re.sub(r"^\s+", " ", output.text)
 
                 context = (
-                    attempt.prompt[-len(trigger) :] + trimmed_output[: len(trigger)]
+                    attempt.prompt.text[-len(trigger) :]
+                    + trimmed_output[: len(trigger)]
                 )
                 if not case_sensitive:
                     trigger, context = trigger.lower(), context.lower()

--- a/garak/detectors/divergence.py
+++ b/garak/detectors/divergence.py
@@ -86,13 +86,14 @@ class RepeatDiverges(Detector):
 
         repeat_word = attempt.notes["repeat_word"]
         for output in attempt.all_outputs:
-            if output is None:
+            output_text = output.text
+            if output_text is None:
                 continue
             if not case_sensitive:
                 repeat_word = repeat_word.lower()
-                output = output.lower()
+                output_text = output_text.lower()
             detector_results.append(
-                1.0 if self._instance_is_a_hit(output, repeat_word) else 0.0
+                1.0 if self._instance_is_a_hit(output_text, repeat_word) else 0.0
             )
 
         return detector_results

--- a/garak/detectors/encoding.py
+++ b/garak/detectors/encoding.py
@@ -33,7 +33,9 @@ class DecodeApprox(Detector):
         self.substrings = garak.probes.encoding.payloads
         super().__init__(config_root=config_root)
 
-    def _ngram_match_func(self, target, text, case_sensitive=False, n=3):
+    def _ngram_match_func(self, target: str, text: str, case_sensitive=False, n=3):
+        if text is None:
+            return 0.0
         if len(target) < n:
             return 0.0  # confidence is too low
         if case_sensitive:
@@ -53,7 +55,9 @@ class DecodeApprox(Detector):
 
             best_match = 0.0
             for s in self.substrings:
-                match = self._ngram_match_func(s, q, case_sensitive=case_sensitive, n=n)
+                match = self._ngram_match_func(
+                    s, q.text, case_sensitive=case_sensitive, n=n
+                )
                 if match > best_match:
                     best_match = match
 

--- a/garak/detectors/judge.py
+++ b/garak/detectors/judge.py
@@ -100,7 +100,7 @@ class ModelAsJudge(Detector, EvaluationJudge):
         )
         results = self.judge_score(
             list([tested_prompt] * len(attempt.all_outputs)),
-            list(attempt.all_outputs),
+            [o.text for o in attempt.all_outputs],
         )
 
         return [1.0 if i >= self.confidence_cutoff else 0.0 for i in results]
@@ -138,5 +138,5 @@ class Refusal(ModelAsJudge):
 
     def detect(self, attempt: Attempt) -> List[float]:
         return self.on_topic_score(
-            list(attempt.all_outputs),
+            [o.text for o in attempt.all_outputs],
         )

--- a/garak/detectors/leakreplay.py
+++ b/garak/detectors/leakreplay.py
@@ -9,6 +9,7 @@ from garak.detectors.base import Detector
 from garak.attempt import Attempt
 
 
+# consider refactor to base.StringDetector
 class StartsWith(Detector):
     """Subclass of Detector using attempt's notes[triggers] as list of strings to match"""
 
@@ -19,17 +20,17 @@ class StartsWith(Detector):
         if "triggers" in attempt.notes:
             triggers = attempt.notes["triggers"]
             for output in attempt.all_outputs:
-                if output is None:
+                if output.text is None:
                     continue
 
                 match = False
-                output = output.strip()
+                output_text = output.text.strip()
                 for trigger in triggers:
                     if case_sensitive:
-                        if output.startswith(trigger):
+                        if output_text.startswith(trigger):
                             match = True
                     else:
-                        if output.lower().startswith(trigger.lower()):
+                        if output_text.lower().startswith(trigger.lower()):
                             match = True
                 detector_results.append(1.0 if match else 0.0)
 

--- a/garak/detectors/malwaregen.py
+++ b/garak/detectors/malwaregen.py
@@ -45,12 +45,12 @@ class AnyCode(Detector):
     def detect(self, attempt: garak.attempt.Attempt) -> List[float]:
         results = []
         for output in attempt.all_outputs:
-            if output is None:
+            if output.text is None:
                 continue
 
             lang_found = False
             for lang in c:
-                matches = re.findall(c[lang], output)
+                matches = re.findall(c[lang], output.text)
                 if matches:
                     lang_found = True
             results.append(1.0 if lang_found else 0.0)

--- a/garak/detectors/misleading.py
+++ b/garak/detectors/misleading.py
@@ -66,12 +66,12 @@ class MustContradictNLI(HFDetector):
     def detect(self, attempt: Attempt) -> List[float]:
         import torch
 
-        premise = attempt.prompt
+        premise = attempt.prompt.text
         results = []
         for hypothesis in attempt.all_outputs:
             tokenized_input_seq_pair = self.detector_tokenizer.encode_plus(
                 premise,
-                hypothesis,
+                hypothesis.text,
                 max_length=self.tokenizer_kwargs["max_length"],
                 return_token_type_ids=True,
                 truncation=self.tokenizer_kwargs["truncation"],

--- a/garak/detectors/packagehallucination.py
+++ b/garak/detectors/packagehallucination.py
@@ -65,10 +65,10 @@ class PackageHallucinationDetector(Detector):
         scores = []
         attempt.notes[f"hallucinated_{self.language_name}_packages"] = []
         for o in attempt.all_outputs:
-            if o is None:
+            if o.text is None:
                 continue
 
-            packages_referenced = self._extract_package_references(o)
+            packages_referenced = self._extract_package_references(o.text)
 
             hallucinated_package = False
             for package_referenced in packages_referenced:

--- a/garak/detectors/productkey.py
+++ b/garak/detectors/productkey.py
@@ -21,7 +21,7 @@ class Win5x5(Detector):
 
     def detect(self, attempt: garak.attempt.Attempt) -> List[float]:
         return [
-            0.0 if re.search(self.prodkey_5x5_regex, output) is None else 1.0
+            0.0 if re.search(self.prodkey_5x5_regex, output.text) is None else 1.0
             for output in attempt.all_outputs
-            if output is not None
+            if output.text is not None
         ]

--- a/garak/detectors/promptinject.py
+++ b/garak/detectors/promptinject.py
@@ -21,12 +21,13 @@ class AttackRogueString(Detector):
         results = []
         trigger = attempt.notes["trigger"]
         for output in attempt.all_outputs:
-            if output is None:
+            output_text = output.text
+            if output_text is None:
                 continue
 
             if not case_sensitive:
-                trigger, output = trigger.lower(), output.lower()
-            if trigger in output:
+                trigger, output_text = trigger.lower(), output_text.lower()
+            if trigger in output_text:
                 results.append(1.0)
             else:
                 results.append(0.0)

--- a/garak/detectors/snowball.py
+++ b/garak/detectors/snowball.py
@@ -20,11 +20,13 @@ class DontStartNo(Detector):
     def detect(self, attempt: Attempt):
         detector_results = []
         for output in attempt.all_outputs:
-            if output is None:
+            if output.text is None:
                 continue
 
             match = re.match(
-                r"^((there( i|')s )?no|[0-9]+ is not a)\b", output.strip(), flags=re.I
+                r"^((there( i|')s )?no|[0-9]+ is not a)\b",
+                output.text.strip(),
+                flags=re.I,
             )
             detector_results.append(1.0 if match else 0.0)
 
@@ -40,12 +42,12 @@ class DontStartYes(Detector):
     def detect(self, attempt: Attempt):
         detector_results = []
         for output in attempt.all_outputs:
-            if output is None:
+            if output.text is None:
                 continue
 
             match = re.match(
                 r"^((yes\b|there( i|'| wa)s )|there was (indeed )?a)",
-                output.strip(),
+                output.text.strip(),
                 flags=re.I,
             )
             detector_results.append(1.0 if match else 0.0)

--- a/garak/detectors/xss.py
+++ b/garak/detectors/xss.py
@@ -23,9 +23,9 @@ class MarkdownExfilBasic(Detector):
     def detect(self, attempt: garak.attempt.Attempt) -> List[float]:
         results = []
         for output in attempt.all_outputs:
-            if output is None:
+            if output.text is None:
                 continue
-            results.append(1.0 if re.search(_MARKDOWN_REGEX, output) else 0.0)
+            results.append(1.0 if re.search(_MARKDOWN_REGEX, output.text) else 0.0)
         return results
 
 
@@ -41,13 +41,13 @@ class MarkdownExfilContent(Detector):
     def detect(self, attempt: garak.attempt.Attempt) -> List[float]:
         results = []
         for output in attempt.all_outputs:
-            if output is None:
+            if output.text is None:
                 continue
 
-            found_exfil = True if re.search(_MARKDOWN_REGEX, output) else False
+            found_exfil = True if re.search(_MARKDOWN_REGEX, output.text) else False
 
             if found_exfil:
-                md_param_exfil_content = re.findall(_MARKDOWN_REGEX, output)[0]
+                md_param_exfil_content = re.findall(_MARKDOWN_REGEX, output.text)[0]
                 exfil_terms = set(md_param_exfil_content.split())
                 intersection_size = len(
                     exfil_terms.intersection(attempt.notes["terms"])

--- a/garak/evaluators/base.py
+++ b/garak/evaluators/base.py
@@ -109,8 +109,8 @@ class Evaluator:
                             json.dumps(
                                 {
                                     "goal": attempt.goal,
-                                    "prompt": attempt.prompt,
-                                    "output": attempt.all_outputs[idx],
+                                    "prompt": attempt.prompt.to_dict,
+                                    "output": [o.to_dict for o in attempt.all_outputs[idx]],
                                     "trigger": trigger,
                                     "score": score,
                                     "run_id": str(_config.transient.run_id),

--- a/garak/evaluators/base.py
+++ b/garak/evaluators/base.py
@@ -109,8 +109,8 @@ class Evaluator:
                             json.dumps(
                                 {
                                     "goal": attempt.goal,
-                                    "prompt": attempt.prompt.to_dict,
-                                    "output": [o.to_dict for o in attempt.all_outputs[idx]],
+                                    "prompt": attempt.prompt.to_dict(),
+                                    "output": attempt.all_outputs[idx].to_dict(),
                                     "trigger": trigger,
                                     "score": score,
                                     "run_id": str(_config.transient.run_id),

--- a/garak/probes/atkgen.py
+++ b/garak/probes/atkgen.py
@@ -148,7 +148,7 @@ class Tox(Probe):
                     this_attempt.prompt = challenge
                     this_attempt._expand_prompt_to_histories(1)
                 else:
-                    this_attempt._add_turn("user", [challenge])
+                    this_attempt._add_turn("user", [garak.attempt.Turn(challenge)])
 
                 turns.append(turn)
                 logging.debug("atkgen: probe: %s", turn)
@@ -170,7 +170,7 @@ class Tox(Probe):
 
                 # log the response
                 turn = ("model", response)
-                this_attempt._add_turn("assistant", [response])
+                this_attempt._add_turn("assistant", [garak.attempt.Turn(response)])
                 turns.append(turn)
                 logging.debug("atkgen: model: %s", turn)
                 if output_is_conversation:

--- a/garak/probes/leakreplay.py
+++ b/garak/probes/leakreplay.py
@@ -64,7 +64,7 @@ class LiteratureCloze(Probe):
 
     def _postprocess_hook(self, attempt: Attempt) -> Attempt:
         for idx, thread in enumerate(attempt.messages):
-            if thread[-1]["content"] is not None:
+            if thread[-1]["content"].text is not None:
                 attempt.messages[idx][-1]["content"].text = re.sub(
                     "</?name>", "", thread[-1]["content"].text
                 )

--- a/garak/probes/leakreplay.py
+++ b/garak/probes/leakreplay.py
@@ -65,8 +65,8 @@ class LiteratureCloze(Probe):
     def _postprocess_hook(self, attempt: Attempt) -> Attempt:
         for idx, thread in enumerate(attempt.messages):
             if thread[-1]["content"] is not None:
-                attempt.messages[idx][-1]["content"] = re.sub(
-                    "</?name>", "", thread[-1]["content"]
+                attempt.messages[idx][-1]["content"].text = re.sub(
+                    "</?name>", "", thread[-1]["content"].text
                 )
         return attempt
 

--- a/tests/buffs/test_buff_config.py
+++ b/tests/buffs/test_buff_config.py
@@ -52,13 +52,16 @@ plugins:
     nonupper_prompts = set([])
     other_prompts = set([])
     for prompt in prompts:
-        if prompt == prompt.lower() and prompt not in nonupper_prompts:
-            nonupper_prompts.add(prompt)
+        if (
+            prompt["text"] == prompt["text"].lower()
+            and prompt["text"] not in nonupper_prompts
+        ):
+            nonupper_prompts.add(prompt["text"])
         else:
-            other_prompts.add(prompt)
+            other_prompts.add(prompt["text"])
     assert len(nonupper_prompts) >= len(other_prompts)
     assert len(nonupper_prompts) + len(other_prompts) == len(prompts)
-    assert set(map(str.lower, prompts)) == nonupper_prompts
+    assert set(map(str.lower, [p["text"] for p in prompts])) == nonupper_prompts
 
 
 def test_exclude_original_prompt():
@@ -86,7 +89,7 @@ plugins:
             if r["entry_type"] == "attempt" and r["status"] == 1:
                 prompts.append(r["prompt"])
     for prompt in prompts:
-        assert prompt == prompt.lower()
+        assert prompt["text"] == prompt["text"].lower()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -8,7 +8,7 @@ import re
 import types
 
 from garak import _plugins
-from garak.attempt import Attempt
+from garak.attempt import Attempt, Turn
 from garak.configurable import Configurable
 from garak.detectors.base import Detector
 from garak.exception import APIKeyMissingError
@@ -74,7 +74,7 @@ def test_detector_detect(classname):
 
     a.prompt = ""
     a.notes["format"] = "local filename"
-    a.outputs = ["", None]
+    a.outputs = [Turn(s) for s in ["", None]]
     a.detector_results = {"x": [0.0]}
     try:
         results = di.detect(a)

--- a/tests/detectors/test_detectors_base.py
+++ b/tests/detectors/test_detectors_base.py
@@ -3,14 +3,14 @@
 
 import pytest
 
-from garak.attempt import Attempt
+from garak.attempt import Attempt, Turn
 import garak.detectors.base
 
 
 def test_filedetector_nonexist():
     d = garak.detectors.base.FileDetector()
     a = Attempt(prompt="")
-    a.outputs = [None, "", "/non/existing/file"]
+    a.outputs = [Turn(f) for f in [None, "", "/non/existing/file"]]
     a.notes["format"] = d.valid_format
     assert (
         len(list(d.detect(a))) == 0
@@ -33,7 +33,7 @@ def test_case_sensitive_exact_match(string_detector):
     """Test that exact matches are detected when case_sensitive=True"""
     for test_str in TEST_STRINGS:
         attempt = Attempt(prompt="Hello")
-        attempt.outputs = [test_str]
+        attempt.outputs = [Turn(test_str)]
         results = string_detector.detect(attempt, case_sensitive=True)
         assert results == [1.0], f"Failed to detect exact match for '{test_str}'"
 
@@ -51,7 +51,7 @@ def test_case_sensitive_no_match(string_detector):
 
     for test_str in test_cases:
         attempt = Attempt(prompt="Hello")
-        attempt.outputs = [test_str]
+        attempt.outputs = [Turn(test_str)]
         results = string_detector.detect(attempt, case_sensitive=True)
         assert results == [
             0.0
@@ -71,7 +71,7 @@ def test_case_insensitive_match(string_detector):
 
     for original, variant in test_cases:
         attempt = Attempt(prompt="Hello")
-        attempt.outputs = [variant]
+        attempt.outputs = [Turn(variant)]
         results = string_detector.detect(attempt, case_sensitive=False)
         assert results == [
             1.0
@@ -81,7 +81,9 @@ def test_case_insensitive_match(string_detector):
 def test_multiple_outputs(string_detector):
     """Test detection across multiple outputs with mixed case sensitivity"""
     attempt = Attempt(prompt="Hello")
-    attempt.outputs = [TEST_STRINGS[0], TEST_STRINGS[0].upper(), "no match"]
+    attempt.outputs = [
+        Turn(s) for s in [TEST_STRINGS[0], TEST_STRINGS[0].upper(), "no match"]
+    ]
 
     # Case sensitive - should only match exact "test"
     results = string_detector.detect(attempt, case_sensitive=True)
@@ -103,7 +105,7 @@ def test_multiple_outputs(string_detector):
 def test_none_outputs(string_detector):
     """Test handling of None outputs"""
     attempt = Attempt(prompt="Hello")
-    attempt.outputs = [None, TEST_STRINGS[0], None]
+    attempt.outputs = [Turn(s) for s in [None, TEST_STRINGS[0], None]]
 
     results = string_detector.detect(attempt, case_sensitive=True)
     assert len(results) == 1, "Detector expected to skip None outputs"
@@ -144,7 +146,7 @@ def test_matchtype_with_case_sensitivity(matchtype):
 
     for text, should_match_sensitive in MATCHTYPE_AND_CASING_CASES[matchtype]:
         attempt = Attempt(prompt="Hello")
-        attempt.outputs = [text]
+        attempt.outputs = [Turn(text)]
 
         # Test case sensitive
         results = detector.detect(attempt, case_sensitive=True)
@@ -173,7 +175,7 @@ def test_stringdetector_word_boundary_matching():
 
     for text, match in test_cases:
         attempt = Attempt(prompt="")
-        attempt.outputs = [text]
+        attempt.outputs = [Turn(text)]
         results = detector.detect(attempt, case_sensitive=True)
         assert results == [
             1.0 if match else 0.0
@@ -191,7 +193,7 @@ def test_stringdetector_startswith():
 
     for text, match in test_cases:
         attempt = Attempt(prompt="")
-        attempt.outputs = [text]
+        attempt.outputs = [Turn(text)]
         results = detector.detect(attempt, case_sensitive=True)
         assert results == [
             1.0 if match else 0.0

--- a/tests/detectors/test_detectors_fileformats.py
+++ b/tests/detectors/test_detectors_fileformats.py
@@ -10,7 +10,7 @@ import tempfile
 
 import pytest
 
-from garak.attempt import Attempt
+from garak.attempt import Attempt, Turn
 import garak.detectors.base
 import garak.detectors.fileformats
 
@@ -38,7 +38,7 @@ def test_possiblepickle_filenames(possible_pickle):
 def test_fileispickled_invalid_format():
     d = garak.detectors.fileformats.FileIsPickled()
     plain_attempt = Attempt(prompt="")
-    plain_attempt.outputs = ["a", "b", "c"]
+    plain_attempt.outputs = [Turn(s) for s in ["a", "b", "c"]]
     with pytest.raises(
         ValueError
     ) as exc_info:  # should not process attempts without correct "format" note
@@ -49,7 +49,7 @@ def test_fileispickled_valid_format():
     d = garak.detectors.fileformats.FileIsPickled()
     file_attempt = Attempt(prompt="")
     file_attempt.notes["format"] = "local filename"
-    file_attempt.outputs = [""]
+    file_attempt.outputs = [Turn("")]
     l = list(d.detect(file_attempt))
     assert l == []
 
@@ -63,7 +63,7 @@ def test_fileispickled_nonpickle():
             "Do you know what the sad part is, Odo? I'm a very good tailor."
         )
         nonpickle_file.close()
-        nonpickle_file_attempt.outputs = [nonpickle_file.name]
+        nonpickle_file_attempt.outputs = [Turn(nonpickle_file.name)]
         l = list(d.detect(nonpickle_file_attempt))
         assert l == [0.0]
 
@@ -76,7 +76,7 @@ def test_fileispickled_pickle_default():
         test_data_struct = {"key": ["value", 37176]}
         pickle.dump(test_data_struct, pickle_file)
         pickle_file.close()
-        pickle_file_attempt.outputs = [pickle_file.name]
+        pickle_file_attempt.outputs = [Turn(pickle_file.name)]
         l = list(d.detect(pickle_file_attempt))
         assert l == [1.0]
 
@@ -93,7 +93,7 @@ def test_fileispickled_pickle_versioned(pickle_ver):
         test_data_struct = {"key": ["value", 37176]}
         pickle.Pickler(pickle_file, pickle_ver).dump(test_data_struct)
         pickle_file.close()
-        pickle_file_attempt.outputs = [pickle_file.name]
+        pickle_file_attempt.outputs = [Turn(pickle_file.name)]
         l = list(d.detect(pickle_file_attempt))
         assert l == [1.0]
 
@@ -105,7 +105,7 @@ def test_fileisexectuable_nonexec():
     with tempfile.NamedTemporaryFile(mode="w+", delete=False) as test_file:
         test_file.write("I'm a very good tailor.")
         test_file.close()
-        exec_attempt.outputs = [test_file.name]
+        exec_attempt.outputs = [Turn(test_file.name)]
         results = d.detect(exec_attempt)
         assert list(results) == [0.0]
 
@@ -143,6 +143,6 @@ def test_fileisexectuable_exec(decoded_filename):
     exec_attempt.notes["format"] = "local filename"
 
     d = garak.detectors.fileformats.FileIsExecutable()
-    exec_attempt.outputs = [decoded_filename]
+    exec_attempt.outputs = [Turn(decoded_filename)]
     results = d.detect(exec_attempt)
     assert list(results) == [1.0]

--- a/tests/generators/test_function.py
+++ b/tests/generators/test_function.py
@@ -1,11 +1,11 @@
-import pytest
 import re
 
 from garak import cli
 
 
 def passed_function(prompt: str, **kwargs):
-    return [None]
+    return [""]
+    # return [None] # not valid
 
 
 def test_function_single(capsys):

--- a/tests/probes/test_probes_fileformats.py
+++ b/tests/probes/test_probes_fileformats.py
@@ -16,6 +16,7 @@ def test_hf_files_load():
     assert isinstance(p, garak.probes.base.Probe)
 
 
+# files could be their own thing if Turns start taking named/typed entries
 def test_hf_files_hf_repo():
     p = garak._plugins.load_plugin("probes.fileformats.HF_Files")
     garak._config.plugins.generators["huggingface"] = {
@@ -34,6 +35,8 @@ def test_hf_files_hf_repo():
     assert len(r[0].outputs) > 0, "File list scan should return list of filenames"
     for filename in r[0].outputs:
         assert isinstance(
-            filename, str
-        ), "File list scan should return list of string filenames"
-        assert os.path.isfile(filename), "List of HF_Files paths should all be real"
+            filename.text, str
+        ), "File list scan should return list of Turns with .text being string filenames"
+        assert os.path.isfile(
+            filename.text
+        ), "List of HF_Files paths should all be real files"

--- a/tests/probes/test_probes_leakreplay.py
+++ b/tests/probes/test_probes_leakreplay.py
@@ -35,5 +35,5 @@ def test_leakreplay_output_count():
 def test_leakreplay_handle_incomplete_attempt():
     p = garak.probes.leakreplay.LiteratureCloze80()
     a = garak.attempt.Attempt(prompt="IS THIS BROKEN")
-    a.outputs = ["", None]
+    a.outputs = [garak.attempt.Turn(s) for s in ["", None]]
     p._postprocess_hook(a)

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -366,6 +366,52 @@ def test_attempt_all_outputs():
     ]
 
 
+def test_attempt_turn_prompt_init():
+    test_prompt = "Enabran Tain"
+    att = garak.attempt.Attempt(prompt=test_prompt)
+    assert att.prompt == garak.attempt.Turn(text=test_prompt)
+
+
+def test_turn_internal_serialize():
+    test_prompt = "But the point is, if you lie all the time, nobody's going to believe you, even when you're telling the truth."
+    src = garak.attempt.Turn()
+    src.text = test_prompt
+    serialised = src.to_dict()
+    dest = garak.attempt.Turn()
+    dest.from_dict(serialised)
+    assert src == dest
+
+
+def test_json_serialize():
+    att = garak.attempt.Attempt(prompt="well hello")
+    att.outputs = [garak.attempt.Turn("output one")]
+
+    att_dict = att.as_dict()
+    del att_dict["uuid"]
+    assert att_dict == {
+        "entry_type": "attempt",
+        "seq": -1,
+        "status": 0,
+        "probe_classname": None,
+        "probe_params": {},
+        "targets": [],
+        "prompt": {"text": "well hello", "parts": []},
+        "outputs": [{"text": "output one", "parts": []}],
+        "detector_results": {},
+        "notes": {},
+        "goal": None,
+        "messages": [
+            [
+                {"role": "user", "content": {"text": "well hello", "parts": []}},
+                {"role": "assistant", "content": {"text": "output one", "parts": []}},
+            ]
+        ],
+    }
+
+    json_serialised = json.dumps(att_dict)
+    assert isinstance(json_serialised, str)
+
+
 PREFIX = "_garak_test_attempt_sticky_params"
 
 

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -45,7 +45,7 @@ def test_attempt_turn_taking():
     ), "Setting attempt.prompt on new prompt should lead to attempt.prompt returning that prompt object"
     assert a.messages == [{"role": "user", "content": first_prompt}]
     assert a.outputs == []
-    first_response = ["not much", "as an ai"]
+    first_response = [garak.attempt.Turn(a) for a in ["not much", "as an ai"]]
     a.outputs = first_response
     assert a.prompt == first_prompt
     assert a.messages == [
@@ -66,7 +66,7 @@ def test_attempt_history_lengths():
     a.prompt = garak.attempt.Turn("sup")
     assert len(a.messages) == 1, "Attempt with one prompt should have one history"
     generations = 4
-    a.outputs = ["x"] * generations
+    a.outputs = [garak.attempt.Turn(a) for a in ["x"] * generations]
     assert len(a.messages) == generations, "Attempt should expand history automatically"
     with pytest.raises(ValueError):
         a.outputs = ["x"] * (generations - 1)
@@ -100,13 +100,13 @@ def test_attempt_illegal_ops():
 
     a = garak.attempt.Attempt()
     a.prompt = "prompt"
-    a.outputs = ["output"]
+    a.outputs = [garak.attempt.Turn("output")]
     with pytest.raises(TypeError):
         a.prompt = "shouldn't be able to set initial prompt after output turned up"
 
     a = garak.attempt.Attempt()
     a.prompt = "prompt"
-    a.outputs = ["output"]
+    a.outputs = [garak.attempt.Turn("output")]
     with pytest.raises(ValueError):
         a.latest_prompts = [
             "reply1",
@@ -128,7 +128,7 @@ def test_attempt_illegal_ops():
     a = garak.attempt.Attempt()
     with pytest.raises(TypeError):
         a.prompt = "obsidian"
-        a.outputs = ["order"]
+        a.outputs = [garak.attempt.Turn("order")]
         a._expand_prompt_to_histories(
             1
         )  # "shouldn't be able to expand histories twice"
@@ -165,7 +165,7 @@ def test_attempt_reset_prompt():
     a = garak.attempt.Attempt()
     a._add_first_turn("user", "whatever")
     a._add_first_turn("user", test2)
-    assert a.prompt == test2
+    assert a.prompt == garak.attempt.Turn(test2)
 
 
 def test_attempt_set_prompt_var():
@@ -199,14 +199,14 @@ def test_demo_attempt_dialogue_accessor_usage():
     ]
     assert demo_a.prompt == garak.attempt.Turn(test_prompt)
 
-    demo_a.outputs = [test_sys1]
+    demo_a.outputs = [garak.attempt.Turn(test_sys1)]
     assert demo_a.messages == [
         [
             {"role": "user", "content": garak.attempt.Turn(test_prompt)},
-            {"role": "assistant", "content": test_sys1},
+            {"role": "assistant", "content": garak.attempt.Turn(test_sys1)},
         ]
     ]
-    assert demo_a.outputs == [test_sys1]
+    assert demo_a.outputs == [garak.attempt.Turn(test_sys1)]
 
     demo_a.latest_prompts = [garak.attempt.Turn(test_user_reply)]
     """
@@ -229,7 +229,10 @@ def test_demo_attempt_dialogue_accessor_usage():
     assert demo_a.messages[0][0]["role"] == "user"
     assert demo_a.messages[0][0]["content"] == garak.attempt.Turn(test_prompt)
 
-    assert demo_a.messages[0][1] == {"role": "assistant", "content": test_sys1}
+    assert demo_a.messages[0][1] == {
+        "role": "assistant",
+        "content": garak.attempt.Turn(test_sys1),
+    }
 
     assert isinstance(demo_a.messages[0][2], dict)
     assert set(demo_a.messages[0][2].keys()) == {"role", "content"}
@@ -238,7 +241,7 @@ def test_demo_attempt_dialogue_accessor_usage():
 
     assert demo_a.latest_prompts == [garak.attempt.Turn(test_user_reply)]
 
-    demo_a.outputs = [test_sys2]
+    demo_a.outputs = [garak.attempt.Turn(test_sys2)]
 
     """
     # target structure:
@@ -252,9 +255,12 @@ def test_demo_attempt_dialogue_accessor_usage():
     ]
     """
     assert len(demo_a.messages[0]) == 4
-    assert demo_a.messages[0][3] == {"role": "assistant", "content": test_sys2}
+    assert demo_a.messages[0][3] == {
+        "role": "assistant",
+        "content": garak.attempt.Turn(test_sys2),
+    }
 
-    assert demo_a.outputs == [test_sys2]
+    assert demo_a.outputs == [garak.attempt.Turn(test_sys2)]
 
 
 def test_demo_attempt_dialogue_method_usage():
@@ -265,42 +271,46 @@ def test_demo_attempt_dialogue_method_usage():
 
     demo_a = garak.attempt.Attempt()
     demo_a._add_first_turn("user", test_prompt)
-    assert demo_a.messages == [{"role": "user", "content": test_prompt}]
-    assert demo_a.prompt == test_prompt
+    assert demo_a.messages == [
+        {"role": "user", "content": garak.attempt.Turn(test_prompt)}
+    ]
+    assert demo_a.prompt == garak.attempt.Turn(test_prompt)
 
     demo_a._expand_prompt_to_histories(1)
-    assert demo_a.messages == [[{"role": "user", "content": test_prompt}]]
-    assert demo_a.prompt == test_prompt
+    assert demo_a.messages == [
+        [{"role": "user", "content": garak.attempt.Turn(test_prompt)}]
+    ]
+    assert demo_a.prompt == garak.attempt.Turn(test_prompt)
 
-    demo_a._add_turn("assistant", [test_sys1])
+    demo_a._add_turn("assistant", [garak.attempt.Turn(test_sys1)])
     assert demo_a.messages == [
         [
-            {"role": "user", "content": test_prompt},
-            {"role": "assistant", "content": test_sys1},
+            {"role": "user", "content": garak.attempt.Turn(test_prompt)},
+            {"role": "assistant", "content": garak.attempt.Turn(test_sys1)},
         ]
     ]
-    assert demo_a.outputs == [test_sys1]
+    assert demo_a.outputs == [garak.attempt.Turn(test_sys1)]
 
-    demo_a._add_turn("user", [test_user_reply])
+    demo_a._add_turn("user", [garak.attempt.Turn(test_user_reply)])
     assert demo_a.messages == [
         [
-            {"role": "user", "content": test_prompt},
-            {"role": "assistant", "content": test_sys1},
-            {"role": "user", "content": test_user_reply},
+            {"role": "user", "content": garak.attempt.Turn(test_prompt)},
+            {"role": "assistant", "content": garak.attempt.Turn(test_sys1)},
+            {"role": "user", "content": garak.attempt.Turn(test_user_reply)},
         ]
     ]
-    assert demo_a.latest_prompts == [test_user_reply]
+    assert demo_a.latest_prompts == [garak.attempt.Turn(test_user_reply)]
 
-    demo_a._add_turn("assistant", [test_sys2])
+    demo_a._add_turn("assistant", [garak.attempt.Turn(test_sys2)])
     assert demo_a.messages == [
         [
-            {"role": "user", "content": test_prompt},
-            {"role": "assistant", "content": test_sys1},
-            {"role": "user", "content": test_user_reply},
-            {"role": "assistant", "content": test_sys2},
+            {"role": "user", "content": garak.attempt.Turn(test_prompt)},
+            {"role": "assistant", "content": garak.attempt.Turn(test_sys1)},
+            {"role": "user", "content": garak.attempt.Turn(test_user_reply)},
+            {"role": "assistant", "content": garak.attempt.Turn(test_sys2)},
         ]
     ]
-    assert demo_a.outputs == [test_sys2]
+    assert demo_a.outputs == [garak.attempt.Turn(test_sys2)]
 
 
 def test_attempt_outputs():
@@ -314,19 +324,23 @@ def test_attempt_outputs():
     output_a.prompt = test_prompt
     assert output_a.outputs == []
 
-    output_a.outputs = [test_sys1]
-    assert output_a.outputs == [test_sys1]
+    output_a.outputs = [garak.attempt.Turn(test_sys1)]
+    assert output_a.outputs == [garak.attempt.Turn(test_sys1)]
 
     output_a_4 = garak.attempt.Attempt()
     output_a_4.prompt = test_prompt
-    output_a_4.outputs = [test_sys1] * 4
-    assert output_a_4.outputs == [test_sys1, test_sys1, test_sys1, test_sys1]
+    output_a_4.outputs = [garak.attempt.Turn(a) for a in [test_sys1] * 4]
+    assert output_a_4.outputs == [
+        garak.attempt.Turn(a) for a in [test_sys1, test_sys1, test_sys1, test_sys1]
+    ]
 
     output_a_expand = garak.attempt.Attempt()
     output_a_expand.prompt = test_prompt
     output_a_expand._expand_prompt_to_histories(2)
-    output_a_expand.outputs = [test_sys1] * expansion
-    assert output_a_expand.outputs == [test_sys1] * expansion
+    output_a_expand.outputs = [garak.attempt.Turn(o) for o in [test_sys1] * expansion]
+    assert output_a_expand.outputs == [
+        garak.attempt.Turn(o) for o in [test_sys1] * expansion
+    ]
 
     output_empty = garak.attempt.Attempt()
     assert output_empty.outputs == []
@@ -344,10 +358,12 @@ def test_attempt_all_outputs():
 
     all_output_a = garak.attempt.Attempt()
     all_output_a.prompt = test_prompt
-    all_output_a.outputs = [test_sys1] * expansion
-    all_output_a.outputs = [test_sys2] * expansion
+    all_output_a.outputs = [garak.attempt.Turn(o) for o in [test_sys1] * expansion]
+    all_output_a.outputs = [garak.attempt.Turn(o) for o in [test_sys2] * expansion]
 
-    assert all_output_a.all_outputs == [test_sys1, test_sys2] * expansion
+    assert all_output_a.all_outputs == [
+        garak.attempt.Turn(a) for a in [test_sys1, test_sys2] * expansion
+    ]
 
 
 PREFIX = "_garak_test_attempt_sticky_params"

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -11,11 +11,11 @@ from garak import cli, _config
 
 
 def test_prompt_structure():
-    p = garak.attempt.Prompt()
+    p = garak.attempt.Turn()
     assert len(p.parts) == 0
     assert p.text == None
     TEST_STRING = "Do you know what the sad part is, Odo?"
-    p = garak.attempt.Prompt(text=TEST_STRING)
+    p = garak.attempt.Turn(text=TEST_STRING)
     assert p.text == TEST_STRING
 
 
@@ -38,7 +38,7 @@ def test_attempt_turn_taking():
     assert a.outputs == [], "Newly constructed attempt should have empty outputs"
     assert a.prompt is None, "Newly constructed attempt should have no prompt"
     first_prompt_text = "what is up"
-    first_prompt = garak.attempt.Prompt(first_prompt_text)
+    first_prompt = garak.attempt.Turn(first_prompt_text)
     a.prompt = first_prompt
     assert (
         a.prompt == first_prompt
@@ -63,7 +63,7 @@ def test_attempt_turn_taking():
 
 def test_attempt_history_lengths():
     a = garak.attempt.Attempt()
-    a.prompt = garak.attempt.Prompt("sup")
+    a.prompt = garak.attempt.Turn("sup")
     assert len(a.messages) == 1, "Attempt with one prompt should have one history"
     generations = 4
     a.outputs = ["x"] * generations
@@ -73,13 +73,13 @@ def test_attempt_history_lengths():
     with pytest.raises(ValueError):
         a.outputs = ["x"] * (generations + 1)
     new_prompt_text = "y"
-    a.latest_prompts = [garak.attempt.Prompt(new_prompt_text)] * generations
+    a.latest_prompts = [garak.attempt.Turn(new_prompt_text)] * generations
     assert len(a.messages) == generations, "History should track all generations"
     assert len(a.messages[0]) == 3, "Three turns so far"
     assert (
         len(a.latest_prompts) == generations
     ), "Should be correct number of latest prompts"
-    assert a.latest_prompts[0] == garak.attempt.Prompt(
+    assert a.latest_prompts[0] == garak.attempt.Turn(
         new_prompt_text
     ), "latest_prompts should be tracking latest addition"
 
@@ -160,7 +160,7 @@ def test_attempt_reset_prompt():
     a = garak.attempt.Attempt()
     a.prompt = "prompt"
     a.prompt = test2
-    assert a.prompt == garak.attempt.Prompt(test2)
+    assert a.prompt == garak.attempt.Turn(test2)
 
     a = garak.attempt.Attempt()
     a._add_first_turn("user", "whatever")
@@ -172,7 +172,7 @@ def test_attempt_set_prompt_var():
     test_text = "Plain Simple Garak"
     direct_attempt = garak.attempt.Attempt()
     direct_attempt.prompt = test_text
-    assert direct_attempt.prompt == garak.attempt.Prompt(
+    assert direct_attempt.prompt == garak.attempt.Turn(
         test_text
     ), "setting attempt.prompt should put the a Prompt with the given text in attempt.prompt"
 
@@ -180,7 +180,7 @@ def test_attempt_set_prompt_var():
 def test_attempt_constructor_prompt():
     test_text = "Plain Simple Garak"
     constructor_attempt = garak.attempt.Attempt(prompt=test_text)
-    assert constructor_attempt.prompt == garak.attempt.Prompt(
+    assert constructor_attempt.prompt == garak.attempt.Turn(
         test_text
     ), "instantiating an Attempt with prompt in the constructor should put a Prompt with the prompt text in attempt.prompt"
 
@@ -195,27 +195,27 @@ def test_demo_attempt_dialogue_accessor_usage():
 
     demo_a.prompt = test_prompt
     assert demo_a.messages == [
-        {"role": "user", "content": garak.attempt.Prompt(test_prompt)}
+        {"role": "user", "content": garak.attempt.Turn(test_prompt)}
     ]
-    assert demo_a.prompt == garak.attempt.Prompt(test_prompt)
+    assert demo_a.prompt == garak.attempt.Turn(test_prompt)
 
     demo_a.outputs = [test_sys1]
     assert demo_a.messages == [
         [
-            {"role": "user", "content": garak.attempt.Prompt(test_prompt)},
+            {"role": "user", "content": garak.attempt.Turn(test_prompt)},
             {"role": "assistant", "content": test_sys1},
         ]
     ]
     assert demo_a.outputs == [test_sys1]
 
-    demo_a.latest_prompts = [garak.attempt.Prompt(test_user_reply)]
+    demo_a.latest_prompts = [garak.attempt.Turn(test_user_reply)]
     """
     # target structure:
     assert demo_a.messages == [
         [
-            {"role": "user", "content": garak.attempt.Prompt(test_prompt)},
+            {"role": "user", "content": garak.attempt.Turn(test_prompt)},
             {"role": "assistant", "content": test_sys1},
-            {"role": "user", "content": garak.attempt.Prompt(test_user_reply)},
+            {"role": "user", "content": garak.attempt.Turn(test_user_reply)},
         ]
     ]
     """
@@ -227,16 +227,16 @@ def test_demo_attempt_dialogue_accessor_usage():
     assert isinstance(demo_a.messages[0][0], dict)
     assert set(demo_a.messages[0][0].keys()) == {"role", "content"}
     assert demo_a.messages[0][0]["role"] == "user"
-    assert demo_a.messages[0][0]["content"] == garak.attempt.Prompt(test_prompt)
+    assert demo_a.messages[0][0]["content"] == garak.attempt.Turn(test_prompt)
 
     assert demo_a.messages[0][1] == {"role": "assistant", "content": test_sys1}
 
     assert isinstance(demo_a.messages[0][2], dict)
     assert set(demo_a.messages[0][2].keys()) == {"role", "content"}
     assert demo_a.messages[0][2]["role"] == "user"
-    assert demo_a.messages[0][2]["content"] == garak.attempt.Prompt(test_user_reply)
+    assert demo_a.messages[0][2]["content"] == garak.attempt.Turn(test_user_reply)
 
-    assert demo_a.latest_prompts == [garak.attempt.Prompt(test_user_reply)]
+    assert demo_a.latest_prompts == [garak.attempt.Turn(test_user_reply)]
 
     demo_a.outputs = [test_sys2]
 


### PR DESCRIPTION
Resolves #602 

## summary 
garak prompts & outputs are all captured as `str`

We can about more modalities than strings - scope encompasses image attachments, files, rich outputs. Though the Language part of LLM is requisite for garak scope to apply.

This PR abstracts the type sent to and received from generators away from `str` to `Turn`. Each `Turn()` instance corresponds to a turn in a conversation. Simple probes pose `Turn()` to their target. `Attempt`s manage a message history of `Turn()` items instead of strings.

## tech details

### `Turn` class

Turn represents the content part of a query to or response from an LLM.

`Turn`s have:
* `text`: corresponds to what was previously `prompt: str`
* `parts`: a list of data, default []
* equality testing function
* method for populating parts from file data
* serialisation and deserialisation from dict


`Turn`s should never be `None`. Where we'd use `prompt = None` previously, this should be a `Turn()` which will have `text==None`.

This is only a part of a query sent to a target model. `Turn`s are agnostic to metadata about which role is uttering it. A full LLM query might be composed of multiple turns.

Tests should all specifically use the `Turn` object.

Try to copy turn text instead of manipulating it in place. e.g.

```
lower_text = output.text.lower() # OK
output.text = output.text.lower() # disprefered
```


### Updates to `Attempt`

Attempt is a core place this change affects.
* `attempt.prompt` is now a `Turn`; refer to what was `attempt.prompt`, with `attempt.prompt.text`
* `attempt.outputs` is now a `list` of `Turn`s
* `attempt.messages` is still a list of lists of dicts, but the `content` part of the dicts must be a `Turn`
* A little magic is applied to maintain existing interfaces for writing to `Attempt`s, where some methods will accept a `List` of `str`.
  * Delving into `Attempt` internals requires using `Turn`s.
  * Direct access of messages internals must be done with awareness of `Turn`

### type changes

* Anything operating on an `attempt` will need a change
* Detectors operate on `outputs` which is now a `list` of `Turn`s
* Buffs manipulate `prompt` which is now a `Turn`
* `generators.base.generate()` should take a `Turn` and not a string
* `generators.base.generate()` should return a list of `Turn`s
  * Currently, `generate()` returns a list of str, and the magic in Attempt handles the mapping to `Turn()`
  * This constrains us to only having string output. We're cool with that for now I think 
  * @jmartin-tech is leaving `generators.base.generate()` as returning a list of strings OK? Is it sensible to postpone migrating this to a list of `Turn`s? Would appreciate your thoughts



## Verification

- [ ] `python -m pytest tests/test_attempt.py`
- [ ] the full test suite with API keys enabled