### PR TITLE
Update for latest ollama support

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,13 +8,17 @@ on:
 jobs:
   linux:
     name: Nightly Linux
+    if: github.repository_owner == 'NVIDIA'
     uses: ./.github/workflows/test_linux.yml
   windows:
     name: Nightly Windows
+    if: github.repository_owner == 'NVIDIA'
     uses: ./.github/workflows/test_windows.yml
   macos:
     name: Nightly MacOS
+    if: github.repository_owner == 'NVIDIA'
     uses: ./.github/workflows/test_macos.yml
   package_test:
     name: Nightly Packaging
+    if: github.repository_owner == 'NVIDIA'
     uses: ./.github/workflows/remote_package_install.yml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,20 @@
+name: Nightly Testing
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  linux:
+    name: Nightly Linux
+    uses: ./.github/workflows/test_linux.yml
+  windows:
+    name: Nightly Windows
+    uses: ./.github/workflows/test_windows.yml
+  macos:
+    name: Nightly MacOS
+    uses: ./.github/workflows/test_macos.yml
+  package_test:
+    name: Nightly Packaging
+    uses: ./.github/workflows/remote_package_install.yml

--- a/.github/workflows/remote_package_install.yml
+++ b/.github/workflows/remote_package_install.yml
@@ -6,6 +6,7 @@ on:
       - 'main'
   pull_request:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -6,6 +6,7 @@ on:
       - 'main'
   pull_request:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -6,6 +6,7 @@ on:
       - 'main'
   pull_request:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build_macos:

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -6,6 +6,7 @@ on:
       - 'main'
   pull_request:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build_windows:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ dependencies = [
   "lorem==0.1.1",
   "xdg-base-dirs>=6.0.1",
   "wn==0.9.5",
-  "ollama>=0.1.7",
+  "ollama>=0.4.7",
   "tiktoken>=0.7.0"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ python-magic>=0.4.21; sys_platform != "win32"
 lorem==0.1.1
 xdg-base-dirs>=6.0.1
 wn==0.9.5
-ollama>=0.1.7
+ollama>=0.4.7
 tiktoken>=0.7.0
 # tests
 pytest>=8.0

--- a/tests/generators/test_ollama.py
+++ b/tests/generators/test_ollama.py
@@ -2,7 +2,6 @@ import pytest
 import ollama
 import respx
 import httpx
-from httpx import ConnectError
 from garak.generators.ollama import OllamaGeneratorChat, OllamaGenerator
 
 PINGED_OLLAMA_SERVER = False  # Avoid calling the server multiple times if it is not running
@@ -17,7 +16,7 @@ def ollama_is_running():
         try:
             ollama.list()  # Gets a list of all pulled models. Used as a ping
             OLLAMA_SERVER_UP = True
-        except ConnectError:
+        except ConnectionError:
             OLLAMA_SERVER_UP = False
         finally:
             PINGED_OLLAMA_SERVER = True


### PR DESCRIPTION
The latest `ollama` package changed the error raised from `httpx` to `OSError`.

To provide early detection of similar issues a workflow triggering pytest and package testing is also added.

* set new minimum version for ollama > 0.4.7
* update error handler in test
* add nightly pytest & package test workflow

Adding `workflow_call` to existing workflows allows the new workflow to reuse them.

For now the action results will need to be reviewed periodically, notifications for failures can be added in the future.