### PR TITLE
generators: add option to skip output btw given delimiters; add hook for postprocessing

### DIFF
--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -11,7 +11,6 @@ from colorama import Fore, Style
 import tqdm
 
 from garak import _config
-from garak.attempt import Attempt
 from garak.configurable import Configurable
 import garak.resources.theme
 

--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -92,18 +92,30 @@ class Generator(Configurable):
         return outputs
 
     def _prune_skip_sequences(self, outputs: List[str | None]) -> List[str | None]:
-        rx = re.escape(self.skip_seq_start) + ".*?" + re.escape(self.skip_seq_end)
-
-        return list(
-            [
-                (
-                    re.sub(rx, "", o, flags=re.DOTALL | re.MULTILINE)
-                    if o is not None
-                    else None
-                )
-                for o in outputs
-            ]
+        rx_complete = (
+            re.escape(self.skip_seq_start) + ".*?" + re.escape(self.skip_seq_end)
         )
+        rx_missing_final = re.escape(self.skip_seq_start) + ".*?$"
+
+        complete_seqs_removed = [
+            (
+                re.sub(rx_complete, "", o, flags=re.DOTALL | re.MULTILINE)
+                if o is not None
+                else None
+            )
+            for o in outputs
+        ]
+
+        partial_seqs_removed = [
+            (
+                re.sub(rx_missing_final, "", o, flags=re.DOTALL | re.MULTILINE)
+                if o is not None
+                else None
+            )
+            for o in complete_seqs_removed
+        ]
+
+        return partial_seqs_removed
 
     def generate(
         self, prompt: str, generations_this_call: int = 1

--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -94,7 +94,16 @@ class Generator(Configurable):
     def _prune_skip_sequences(self, outputs: List[str | None]) -> List[str | None]:
         rx = re.escape(self.skip_seq_start) + ".*?" + re.escape(self.skip_seq_end)
 
-        return list([re.sub(rx, "", o) if o is not None else None for o in outputs])
+        return list(
+            [
+                (
+                    re.sub(rx, "", o, flags=re.DOTALL | re.MULTILINE)
+                    if o is not None
+                    else None
+                )
+                for o in outputs
+            ]
+        )
 
     def generate(
         self, prompt: str, generations_this_call: int = 1

--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -162,7 +162,7 @@ class Generator(Configurable):
                     self._verify_model_result(output_one)
                     outputs.append(output_one[0])
 
-        outputs = self._post_generate_hook
+        outputs = self._post_generate_hook(outputs)
 
         if self.skip_seq_start is not None and self.skip_seq_end is not None:
             outputs = self._prune_skip_sequences(outputs)

--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -174,7 +174,8 @@ class Generator(Configurable):
 
         outputs = self._post_generate_hook(outputs)
 
-        if self.skip_seq_start is not None and self.skip_seq_end is not None:
-            outputs = self._prune_skip_sequences(outputs)
+        if hasattr(self, "skip_seq_start") and hasattr(self, "skip_seq_end"):
+            if self.skip_seq_start is not None and self.skip_seq_end is not None:
+                outputs = self._prune_skip_sequences(outputs)
 
         return outputs

--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -11,6 +11,7 @@ from colorama import Fore, Style
 import tqdm
 
 from garak import _config
+from garak.attempt import Attempt
 from garak.configurable import Configurable
 import garak.resources.theme
 
@@ -88,12 +89,13 @@ class Generator(Configurable):
     def clear_history(self):
         pass
 
-    def _post_generate_hook(self, outputs: List[str]) -> List[str]:
+    def _post_generate_hook(self, outputs: List[str | None]) -> List[str | None]:
         return outputs
 
-    def _prune_skip_sequences(self, outputs: List[str]) -> List[str]:
+    def _prune_skip_sequences(self, outputs: List[str | None]) -> List[str | None]:
         rx = re.escape(self.skip_seq_start) + ".*?" + re.escape(self.skip_seq_end)
-        return list([re.sub(rx, "", o) for o in outputs])
+
+        return list([re.sub(rx, "", o) if o is not None else None for o in outputs])
 
     def generate(
         self, prompt: str, generations_this_call: int = 1

--- a/garak/generators/litellm.py
+++ b/garak/generators/litellm.py
@@ -102,6 +102,8 @@ class LiteLLMGenerator(Generator):
         "top_k",
         "frequency_penalty",
         "presence_penalty",
+        "skip_seq_start",
+        "skip_seq_end",
         "stop",
     )
 

--- a/garak/generators/nim.py
+++ b/garak/generators/nim.py
@@ -44,7 +44,7 @@ class NVOpenAIChat(OpenAICompatible):
         "uri": "https://integrate.api.nvidia.com/v1/",
         "vary_seed_each_call": True,  # encourage variation when generations>1. not respected by all NIMs
         "vary_temp_each_call": True,  # encourage variation when generations>1. not respected by all NIMs
-        "suppressed_params": {"n", "frequency_penalty", "presence_penalty"},
+        "suppressed_params": {"n", "frequency_penalty", "presence_penalty", "timeout"},
     }
     active = True
     supports_multiple_generations = False
@@ -91,8 +91,8 @@ class NVOpenAIChat(OpenAICompatible):
             logging.critical(msg, exc_info=uee)
             raise GarakException(f"🛑 {msg}") from uee
         #        except openai.NotFoundError as oe:
-        except Exception as oe:
-            msg = "NIM endpoint not found. Is the model name spelled correctly?"
+        except Exception as oe:  # too broad
+            msg = "NIM generation failed. Is the model name spelled correctly?"
             logging.critical(msg, exc_info=oe)
             raise GarakException(f"🛑 {msg}") from oe
 

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -257,6 +257,17 @@ class OpenAICompatible(Generator):
             else:
                 raise e
 
+        if not hasattr(response, "choices"):
+            logging.debug(
+                "Did not get a well-formed response, retrying. Expected object with .choices member, got: '%s'"
+                % repr(response)
+            )
+            msg = "no .choices member in generator response"
+            if self.retry_json:
+                raise garak.exception.GarakBackoffTrigger(msg)
+            else:
+                return [None]
+
         if self.generator == self.client.completions:
             return [c.text for c in response.choices]
         elif self.generator == self.client.chat.completions:

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -127,7 +127,7 @@ class OpenAICompatible(Generator):
         "presence_penalty": 0.0,
         "seed": None,
         "stop": ["#", ";"],
-        "suppressed_params": {"timeout"},
+        "suppressed_params": set(),
         "retry_json": True,
         "extra_params": {},
     }

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -129,7 +129,7 @@ class OpenAICompatible(Generator):
         "stop": ["#", ";"],
         "suppressed_params": {"timeout"},
         "retry_json": True,
-        "extra_params": set(),
+        "extra_params": {},
     }
 
     # avoid attempt to pickle the client attribute
@@ -214,8 +214,9 @@ class OpenAICompatible(Generator):
                 if getattr(self, arg) is not None:
                     create_args[arg] = getattr(self, arg)
 
-        for k, v in self.extra_params.items():
-            create_args[k] = v
+        if hasattr(self, "extra_params"):
+            for k, v in self.extra_params.items():
+                create_args[k] = v
 
         if self.generator == self.client.completions:
             if not isinstance(prompt, str):

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -127,8 +127,9 @@ class OpenAICompatible(Generator):
         "presence_penalty": 0.0,
         "seed": None,
         "stop": ["#", ";"],
-        "suppressed_params": set(),
+        "suppressed_params": {"timeout"},
         "retry_json": True,
+        "extra_params": set(),
     }
 
     # avoid attempt to pickle the client attribute
@@ -207,8 +208,14 @@ class OpenAICompatible(Generator):
             if arg == "model":
                 create_args[arg] = self.name
                 continue
+            if arg == "extra_params":
+                continue
             if hasattr(self, arg) and arg not in self.suppressed_params:
-                create_args[arg] = getattr(self, arg)
+                if getattr(self, arg) is not None:
+                    create_args[arg] = getattr(self, arg)
+
+        for k, v in self.extra_params.items():
+            create_args[k] = v
 
         if self.generator == self.client.completions:
             if not isinstance(prompt, str):

--- a/garak/generators/rest.py
+++ b/garak/generators/rest.py
@@ -59,6 +59,8 @@ class RestGenerator(Generator):
         "request_timeout",
         "ratelimit_codes",
         "skip_codes",
+        "skip_seq_start",
+        "skip_seq_end",
         "temperature",
         "top_k",
         "proxies",

--- a/tests/generators/test_function.py
+++ b/tests/generators/test_function.py
@@ -1,4 +1,3 @@
-import pytest
 import re
 
 from garak import cli

--- a/tests/generators/test_generators.py
+++ b/tests/generators/test_generators.py
@@ -4,11 +4,9 @@
 import importlib
 import inspect
 import pytest
-import random
 
 from garak import _plugins
 from garak import _config
-from garak.generators.test import Blank, Repeat, Single
 from garak.generators.base import Generator
 
 DEFAULT_GENERATOR_NAME = "garak test"
@@ -18,112 +16,6 @@ DEFAULT_PROMPT_TEXT = "especially the lies"
 GENERATORS = [
     classname for (classname, active) in _plugins.enumerate_plugins("generators")
 ]
-
-
-def test_generators_test_blank():
-    g = Blank(DEFAULT_GENERATOR_NAME)
-    output = g.generate(prompt="test", generations_this_call=5)
-    assert output == [
-        "",
-        "",
-        "",
-        "",
-        "",
-    ], "generators.test.Blank with generations_this_call=5 should return five empty strings"
-
-
-def test_generators_test_repeat():
-    g = Repeat(DEFAULT_GENERATOR_NAME)
-    output = g.generate(prompt=DEFAULT_PROMPT_TEXT)
-    assert output == [
-        DEFAULT_PROMPT_TEXT
-    ], "generators.test.Repeat should send back a list of the posed prompt string"
-
-
-def test_generators_test_single_one():
-    g = Single(DEFAULT_GENERATOR_NAME)
-    output = g.generate(prompt="test")
-    assert isinstance(
-        output, list
-    ), "Single generator .generate() should send back a list"
-    assert (
-        len(output) == 1
-    ), "Single.generate() without generations_this_call should send a list of one string"
-    assert isinstance(
-        output[0], str
-    ), "Single generator output list should contain strings"
-
-    output = g._call_model(prompt="test")
-    assert isinstance(output, list), "Single generator _call_model should return a list"
-    assert (
-        len(output) == 1
-    ), "_call_model w/ generations_this_call 1 should return a list of length 1"
-    assert isinstance(
-        output[0], str
-    ), "Single generator output list should contain strings"
-
-
-def test_generators_test_single_many():
-    random_generations = random.randint(2, 12)
-    g = Single(DEFAULT_GENERATOR_NAME)
-    output = g.generate(prompt="test", generations_this_call=random_generations)
-    assert isinstance(
-        output, list
-    ), "Single generator .generate() should send back a list"
-    assert (
-        len(output) == random_generations
-    ), "Single.generate() with generations_this_call should return equal generations"
-    for i in range(0, random_generations):
-        assert isinstance(
-            output[i], str
-        ), "Single generator output list should contain strings (all positions)"
-
-
-def test_generators_test_single_too_many():
-    g = Single(DEFAULT_GENERATOR_NAME)
-    with pytest.raises(ValueError):
-        output = g._call_model(prompt="test", generations_this_call=2)
-    assert "Single._call_model should refuse to process generations_this_call > 1"
-
-
-def test_generators_test_blank_one():
-    g = Blank(DEFAULT_GENERATOR_NAME)
-    output = g.generate(prompt="test")
-    assert isinstance(
-        output, list
-    ), "Blank generator .generate() should send back a list"
-    assert (
-        len(output) == 1
-    ), "Blank generator .generate() without generations_this_call should return a list of length 1"
-    assert isinstance(
-        output[0], str
-    ), "Blank generator output list should contain strings"
-    assert (
-        output[0] == ""
-    ), "Blank generator .generate() output list should contain strings"
-
-
-def test_generators_test_blank_many():
-    g = Blank(DEFAULT_GENERATOR_NAME)
-    output = g.generate(prompt="test", generations_this_call=2)
-    assert isinstance(
-        output, list
-    ), "Blank generator .generate() should send back a list"
-    assert (
-        len(output) == 2
-    ), "Blank generator .generate() w/ generations_this_call=2 should return a list of length 2"
-    assert isinstance(
-        output[0], str
-    ), "Blank generator output list should contain strings (first position)"
-    assert isinstance(
-        output[1], str
-    ), "Blank generator output list should contain strings (second position)"
-    assert (
-        output[0] == ""
-    ), "Blank generator .generate() output list should contain strings (first position)"
-    assert (
-        output[1] == ""
-    ), "Blank generator .generate() output list should contain strings (second position)"
 
 
 def test_parallel_requests():

--- a/tests/generators/test_generators.py
+++ b/tests/generators/test_generators.py
@@ -116,9 +116,10 @@ def test_instantiate_generators(classname):
 
 
 def test_skip_seq():
+    target_string = "TEST TEST 1234"
     test_string_with_thinking = "TEST TEST <think>not thius tho</think>1234"
     test_string_with_thinking_complex = '<think></think>TEST TEST <think>not thius tho</think>1234<think>!"(^-&$(!$%*))</think>'
-    target_string = "TEST TEST 1234"
+    test_string_with_newlines = "<think>\n\n</think>" + target_string
     g = _plugins.load_plugin("generators.test.Repeat")
     r = g.generate(test_string_with_thinking)
     g.skip_seq_start = None
@@ -136,3 +137,7 @@ def test_skip_seq():
     assert (
         r[0] == target_string
     ), "content between multiple skip sequences should be removed"
+    r = g.generate(test_string_with_newlines)
+    assert (
+        r[0] == target_string
+    ), "skip seqs full of newlines should be removed"

--- a/tests/generators/test_generators.py
+++ b/tests/generators/test_generators.py
@@ -138,6 +138,16 @@ def test_skip_seq():
         r[0] == target_string
     ), "content between multiple skip sequences should be removed"
     r = g.generate(test_string_with_newlines)
-    assert (
-        r[0] == target_string
-    ), "skip seqs full of newlines should be removed"
+    assert r[0] == target_string, "skip seqs full of newlines should be removed"
+
+    test_no_answer = "<think>not sure the output to provide</think>"
+    r = g.generate(test_no_answer)
+    assert r[0] == "", "Output of all skip strings should be empty"
+
+    test_truncated_think = f"<think>thinking a bit</think>{target_string}<think>this process required a lot of details that is processed by"
+    r = g.generate(test_truncated_think)
+    assert r[0] == target_string, "truncated skip strings should be omitted"
+
+    test_truncated_think_no_answer = "<think>thinking a bit</think><think>this process required a lot of details that is processed by"
+    r = g.generate(test_truncated_think_no_answer)
+    assert r[0] == "", "truncated skip strings should be omitted"

--- a/tests/generators/test_generators_base.py
+++ b/tests/generators/test_generators_base.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import random
+
+from garak.generators.test import Blank, Repeat, Single
+
+DEFAULT_GENERATOR_NAME = "garak test"
+DEFAULT_PROMPT_TEXT = "especially the lies"
+
+
+def test_generators_test_blank():
+    g = Blank(DEFAULT_GENERATOR_NAME)
+    output = g.generate(prompt="test", generations_this_call=5)
+    assert output == [
+        "",
+        "",
+        "",
+        "",
+        "",
+    ], "generators.test.Blank with generations_this_call=5 should return five empty strings"
+
+
+def test_generators_test_repeat():
+    g = Repeat(DEFAULT_GENERATOR_NAME)
+    output = g.generate(prompt=DEFAULT_PROMPT_TEXT)
+    assert output == [
+        DEFAULT_PROMPT_TEXT
+    ], "generators.test.Repeat should send back a list of the posed prompt string"
+
+
+def test_generators_test_single_one():
+    g = Single(DEFAULT_GENERATOR_NAME)
+    output = g.generate(prompt="test")
+    assert isinstance(
+        output, list
+    ), "Single generator .generate() should send back a list"
+    assert (
+        len(output) == 1
+    ), "Single.generate() without generations_this_call should send a list of one string"
+    assert isinstance(
+        output[0], str
+    ), "Single generator output list should contain strings"
+
+    output = g._call_model(prompt="test")
+    assert isinstance(output, list), "Single generator _call_model should return a list"
+    assert (
+        len(output) == 1
+    ), "_call_model w/ generations_this_call 1 should return a list of length 1"
+    assert isinstance(
+        output[0], str
+    ), "Single generator output list should contain strings"
+
+
+def test_generators_test_single_many():
+    random_generations = random.randint(2, 12)
+    g = Single(DEFAULT_GENERATOR_NAME)
+    output = g.generate(prompt="test", generations_this_call=random_generations)
+    assert isinstance(
+        output, list
+    ), "Single generator .generate() should send back a list"
+    assert (
+        len(output) == random_generations
+    ), "Single.generate() with generations_this_call should return equal generations"
+    for i in range(0, random_generations):
+        assert isinstance(
+            output[i], str
+        ), "Single generator output list should contain strings (all positions)"
+
+
+def test_generators_test_single_too_many():
+    g = Single(DEFAULT_GENERATOR_NAME)
+    with pytest.raises(ValueError):
+        output = g._call_model(prompt="test", generations_this_call=2)
+    assert "Single._call_model should refuse to process generations_this_call > 1"
+
+
+def test_generators_test_blank_one():
+    g = Blank(DEFAULT_GENERATOR_NAME)
+    output = g.generate(prompt="test")
+    assert isinstance(
+        output, list
+    ), "Blank generator .generate() should send back a list"
+    assert (
+        len(output) == 1
+    ), "Blank generator .generate() without generations_this_call should return a list of length 1"
+    assert isinstance(
+        output[0], str
+    ), "Blank generator output list should contain strings"
+    assert (
+        output[0] == ""
+    ), "Blank generator .generate() output list should contain strings"
+
+
+def test_generators_test_blank_many():
+    g = Blank(DEFAULT_GENERATOR_NAME)
+    output = g.generate(prompt="test", generations_this_call=2)
+    assert isinstance(
+        output, list
+    ), "Blank generator .generate() should send back a list"
+    assert (
+        len(output) == 2
+    ), "Blank generator .generate() w/ generations_this_call=2 should return a list of length 2"
+    assert isinstance(
+        output[0], str
+    ), "Blank generator output list should contain strings (first position)"
+    assert isinstance(
+        output[1], str
+    ), "Blank generator output list should contain strings (second position)"
+    assert (
+        output[0] == ""
+    ), "Blank generator .generate() output list should contain strings (first position)"
+    assert (
+        output[1] == ""
+    ), "Blank generator .generate() output list should contain strings (second position)"


### PR DESCRIPTION
1. add `generators.base.Generator._prune_skip_sequences()` to cut content btw `Generator.skip_seq_start` and `Generator.skip_seq_end`
2. add `generators.base.Generator._post_generate_hook()` to allow postprocessing of output in generators
3. factor "test" generators out into their own module, for consistency w other plugin types
4. handle `openai` exceptions caused by interrupted thought (e.g. when hitting max_tokens)
5. add configurability to `OpenAICompatible`

## Verification

- [ ] `python -m pytest tests/generators/test_generators_base.py`
- [ ] `python -m pytest tests/generators/test_generators.py`
- [ ] **Verify** Run something with `test.Repeat`, it should work as normal (`output==prompt`)
- [ ] **Verify** Configure `skip_seq_start` and `skip_seq_end`, content int he middle should be pruned
- [ ] **Docs** updated in `docs/source/garak.generators.base.rst`
