### PR TITLE
Add request delay functionality to garak

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -75,6 +75,12 @@ Some generators might need an API key to be set as an environment variable, and 
 ``--probes promptinject`` will use only the `PromptInject <https://github.com/agencyenterprise/promptinject>`_ framework's methods, for example. 
 You can also specify one specific plugin instead of a plugin family by adding the plugin name after a ``.``; for example, ``--probes lmrc.SlurUsage`` will use an implementation of checking for models generating slurs based on the `Language Model Risk Cards <https://arxiv.org/abs/2303.18190>`_ framework.
 
+To specify a delay between each request, use the ``--request_delay`` option followed by the number of seconds. For example, to set a delay of 2 seconds between each request:
+
+.. code-block:: console
+
+    garak --model_type huggingface --model_name gpt2 --probes dan.Dan_11_0 --request_delay 2
+
 
 Examples
 ^^^^^^^^
@@ -92,4 +98,3 @@ See if the Hugging Face version of GPT2 is vulnerable to DAN 11.0:
 .. code-block:: console
 
     garak --model_type huggingface --model_name gpt2 --probes dan.Dan_11_0
-

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -30,7 +30,7 @@ from garak import __version__ as version
 system_params = (
     "verbose narrow_output parallel_requests parallel_attempts skip_unknown".split()
 )
-run_params = "seed deprefix eval_threshold generations probe_tags interactive".split()
+run_params = "seed deprefix eval_threshold generations probe_tags interactive request_delay".split()
 plugins_params = "model_type model_name extended_detectors".split()
 reporting_params = "taxonomy report_prefix".split()
 project_dir_name = "garak"
@@ -77,6 +77,7 @@ transient = TransientConfig()
 
 system = GarakSubConfig()
 run = GarakSubConfig()
+run.request_delay = 0
 plugins = GarakSubConfig()
 reporting = GarakSubConfig()
 

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -85,6 +85,12 @@ def main(arguments=None) -> None:
         default=_config.reporting.report_prefix,
         help="Specify an optional prefix for the report and hit logs",
     )
+    parser.add.add_argument(
+        "--request_delay",
+        type=float,
+        default=_config.run.request_delay,
+        help="Specify the delay between each request in seconds",
+    )
     parser.add_argument(
         "--narrow_output",
         action="store_true",
@@ -109,6 +115,12 @@ def main(arguments=None) -> None:
     )
 
     ## RUN
+    parser.add.add_argument(
+        "--request_delay",
+        type=float,
+        default=_config.run.request_delay,
+        help="Specify the delay between each request in seconds",
+    )
     parser.add_argument(
         "--seed",
         "-s",

--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -10,11 +10,11 @@ This module ncludes the class Harness, which all `garak` harnesses must
 inherit from.
 """
 
-
 import json
 import logging
 import types
 from typing import List
+import time
 
 import tqdm
 
@@ -136,6 +136,8 @@ class Harness(Configurable):
                     attempt.detector_results[detector_probe_name] = list(
                         d.detect(attempt)
                     )
+                    if _config.run.request_delay > 0:
+                        time.sleep(_config.run.request_delay)
 
             for attempt in attempt_results:
                 attempt.status = garak.attempt.ATTEMPT_COMPLETE


### PR DESCRIPTION
Add functionality to run `garak with a specific delay between each request.

* **CLI Argument:**
  - Add `--request_delay` argument in `garak/cli.py` to specify the delay between requests.
  - Parse the `--request_delay` argument and store it in `_config.run`.

* **Configuration:**
  - Add `request_delay` to `run_params` in `garak/_config.py`.
  - Initialize `request_delay` in `run` with a default value of `0`.

* **Harness:**
  - Import `time` module in `garak/harnesses/base.py`.
  - Add a delay using `time.sleep` in the `run` method after each request if `request_delay` is set.

* **Documentation:**
  - Update `docs/source/usage.rst` to include instructions on using the `--request_delay` argument.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/NVIDIA/garak/pull/1102?shareId=c9e8bdce-be4f-4c42-ae74-563e20d0b5f5).