### PR TITLE
Add resume functionality

### DIFF
--- a/garak/_config.py
+++ b/garak/_config.py
@@ -28,7 +28,7 @@ DICT_CONFIG_AFTER_LOAD = False
 from garak import __version__ as version
 
 system_params = (
-    "verbose narrow_output parallel_requests parallel_attempts skip_unknown".split()
+    "verbose narrow_output parallel_requests parallel_attempts skip_unknown resume".split()
 )
 run_params = "seed deprefix eval_threshold generations probe_tags interactive".split()
 plugins_params = "model_type model_name extended_detectors".split()

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -107,6 +107,13 @@ def main(arguments=None) -> None:
         action="store_true",
         help="allow skip of unknown probes, detectors, or buffs",
     )
+    parser.add_argument(
+        "--resume",
+        "-R",
+        type=str,
+        default=None,
+        help="resume previous unfinnished scan",
+    )
 
     ## RUN
     parser.add_argument(
@@ -366,6 +373,16 @@ def main(arguments=None) -> None:
         _config.plugins.detector_spec = args.detectors
     if "buffs" in args:
         _config.plugins.buff_spec = args.buffs
+
+    # Parse existing attempts
+    if _config.system.resume:
+        import json
+        _config.system.previous_attempts = []
+        with open(_config.system.resume, 'r') as fin:
+            for line in fin:
+                attempt_json = json.loads(line.strip())
+                if attempt_json['entry_type'] == 'attempt':
+                    _config.system.previous_attempts.append((attempt_json['seq'], attempt_json['prompt']))
 
     # base config complete
 

--- a/garak/command.py
+++ b/garak/command.py
@@ -74,15 +74,21 @@ def start_run():
                 f"Can't create reporting directory {report_path}, quitting"
             ) from e
 
-    filename = f"garak.{_config.transient.run_id}.report.jsonl"
-    if not _config.reporting.report_prefix:
-        filename = f"garak.{_config.transient.run_id}.report.jsonl"
+    if _config.system.resume:
+        _config.transient.report_filename = _config.system.resume
+        _config.transient.reportfile = open(
+            _config.transient.report_filename, "a", buffering=1, encoding="utf-8"
+        )
     else:
-        filename = _config.reporting.report_prefix + ".report.jsonl"
-    _config.transient.report_filename = str(report_path / filename)
-    _config.transient.reportfile = open(
-        _config.transient.report_filename, "w", buffering=1, encoding="utf-8"
-    )
+        filename = f"garak.{_config.transient.run_id}.report.jsonl"
+        if not _config.reporting.report_prefix:
+            filename = f"garak.{_config.transient.run_id}.report.jsonl"
+        else:
+            filename = _config.reporting.report_prefix + ".report.jsonl"
+        _config.transient.report_filename = str(report_path / filename)
+        _config.transient.reportfile = open(
+            _config.transient.report_filename, "w", buffering=1, encoding="utf-8"
+        )
     setup_dict = {"entry_type": "start_run setup"}
     for k, v in _config.__dict__.items():
         if k[:2] != "__" and type(v) in (

--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -209,7 +209,10 @@ class Probe(Configurable):
         attempts_todo: Iterable[garak.attempt.Attempt] = []
         prompts = list(self.prompts)
         for seq, prompt in enumerate(prompts):
-            attempts_todo.append(self._mint_attempt(prompt, seq))
+            if hasattr(_config.system, 'previous_attempts') and (seq, prompt) in _config.system.previous_attempts:
+                continue
+            else:
+                attempts_todo.append(self._mint_attempt(prompt, seq))
 
         # buff hook
         if len(_config.buffmanager.buffs) > 0:


### PR DESCRIPTION
Add functionality to resume a garak scan after it has stopped before finishing, for example, because an error.

CLI Argument:
     Add `--resume`, `-R` to specific the Garak JSONL report file that will be the reference.

Example usage:
`$ garak --model_type rest -G rest_config.json --resume ~/.local/share/garak/garak_runs/garak.e784d299-a838-4d20-b18a-6ef8055f9491.report.jsonl`

