### PR TITLE
support `module.classname` config specification for plugins

### DIFF
--- a/garak/configurable.py
+++ b/garak/configurable.py
@@ -33,6 +33,7 @@ class Configurable:
             spec_type = namespace_parts[-2]
             namespace = namespace_parts[-1]
             classname = self.__class__.__name__
+            namespaced_klass = f"{namespace}.{classname}"
             plugins_config = {}
             if isinstance(local_root, dict) and spec_type in local_root:
                 plugins_config = local_root[spec_type]
@@ -43,16 +44,12 @@ class Configurable:
                 # generators: `nim`/`openai`/`huggingface`
                 # probes: `dan`/`gcg`/`xss`/`tap`/`promptinject`
                 attributes = plugins_config[namespace]
-                namespaced_klass = f"{namespace}.{classname}"
                 self._apply_config(attributes)
                 if classname in attributes:
                     self._apply_config(attributes[classname])
-                elif namespaced_klass in plugins_config:
-                    # for compatibility remove after
-                    logging.warning(
-                        f"Deprecated configuration key found: {namespaced_klass}"
-                    )
-                    self._apply_config(plugins_config[namespaced_klass])
+            elif namespaced_klass in plugins_config:
+                # maintain support for this as consistent with cli options at this time
+                self._apply_config(plugins_config[namespaced_klass])
         self._apply_missing_instance_defaults()
         if hasattr(self, "ENV_VAR"):
             if not hasattr(self, "key_env_var"):

--- a/tests/test_configurable.py
+++ b/tests/test_configurable.py
@@ -50,6 +50,15 @@ def test_config_root_only(generator_sub_config):
         assert getattr(m, k) == v
 
 
+# when a parameter is provided in config_root by `module.classname` set on the resulting object
+def test_config_root_module_classname(generator_sub_config):
+    module_config = generator_sub_config.generators.pop("mock")
+    generator_sub_config.generators["mock.mockConfigurable"] = module_config
+    m = mockConfigurable(config_root=generator_sub_config)
+    for k, v in generator_sub_config.generators["mock.mockConfigurable"].items():
+        assert getattr(m, k) == v
+
+
 # when a parameter is provided in config_root as a dict set on the resulting object
 def test_config_root_as_dict(generator_sub_config):
     config = {"generators": generator_sub_config.generators}


### PR DESCRIPTION
Original config support was intended to maintain this support in a deprecated format. Planned feature functionality suggests this should officially be maintained and is helpful to have aligned with how the cli accepts plugin values.


## Verification

List the steps needed to make sure this thing works

- [ ] Supporting configuration such as generator configuration file `hf_RigoChat_gpu.yaml`
``` yaml
plugins:
  generators:
    huggingface.Model:
      name: IIC/RigoChat-7b-v2
      hf_args:
        device: cuda
        trust_remote_code: true
        torch_dtype: float16
```
- [ ] `garak -m huggingface.Model -p test.Test --config hf_RigoChat_gpu.yaml`
- [ ] **Verify** via log review that the model configuration applies on instantiation. 

Specific Hardware:
* requires `cuda` capable GPU for the example config however `mps` could be substituted on arm based macOS.
