### PR TITLE
stop forcing generation count for mini phrasing probes

### DIFF
--- a/garak/probes/phrasing.py
+++ b/garak/probes/phrasing.py
@@ -17,7 +17,6 @@ class TenseMini:
     def _minify_prompts(self):
         random.shuffle(self.prompts)
         self.prompts = self.prompts[:200]
-        self.generations = 1
 
 
 class PastTense(Probe):


### PR DESCRIPTION
`minify` in `probes.phrasing` forced generations to 1. Seemed like a good idea at the time but is actually unintiutive and hard to troubleshoot. undoing this

## Verification

- [ ] `garak -m test.Blank -p phrasing.PastTenseMini -g 2` gives 400 and not 200 generations
