### PR TITLE
feature: max_workers / give kinda helpful message if too many open files

### DIFF
--- a/docs/source/configurable.rst
+++ b/docs/source/configurable.rst
@@ -46,6 +46,8 @@ Let's take a look at the core config.
         parallel_attempts: false
         lite: true
         show_z: false
+        enable_experimental: false
+        max_workers: 500
 
     run:
         seed:
@@ -93,7 +95,7 @@ such as ``show_100_pass_modules``.
 * ``narrow_output`` - Support output on narrower CLIs
 * ``show_z`` - Display Z-scores and visual indicators on CLI. It's good, but may be too much info until one has seen garak run a couple of times
 * ``enable_experimental`` - Enable experimental function CLI flags. Disabled by default. Experimental functions may disrupt your installation and provide unusual/unstable results. Can only be set by editing core config, so a git checkout of garak is recommended for this.
-* ``soft_probe_prompt_cap`` - For probes that auto-scale their prompt count, the preferred limit of prompts per probe
+* ``max_workers`` - Cap on how many parallel workers can be requested. When raising this in order to use higher parallelisation, keep an eye on system resources (e.g. `ulimit -n 4026` on Linux)
 
 ``run`` config items
 """"""""""""""""""""
@@ -104,6 +106,7 @@ such as ``show_100_pass_modules``.
 * ``seed`` - An optional random seed
 * ``eval_threshold`` - At what point in the 0..1 range output by detectors does a result count as a successful attack / hit
 * ``user_agent`` - What HTTP user agent string should garak use? ``{version}`` can be used to signify where garak version ID should go
+* ``soft_probe_prompt_cap`` - For probes that auto-scale their prompt count, the preferred limit of prompts per probe
 
 ``plugins`` config items
 """"""""""""""""""""""""

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -64,6 +64,16 @@ def main(arguments=None) -> None:
 
     import argparse
 
+    def worker_count_validation(workers):
+        iworkers = int(workers)
+        if iworkers <= 0:
+            raise argparse.ArgumentTypeError("Need >0 workers (int)" % workers)
+        if iworkers > _config.system.max_workers:
+            raise argparse.ArgumentTypeError(
+                "Parallel worker count capped at %s (config.system.max_workers)" % _config.system.max_workers
+            )
+        return iworkers
+
     parser = argparse.ArgumentParser(
         prog="python -m garak",
         description="LLM safety & security scanning tool",
@@ -92,15 +102,15 @@ def main(arguments=None) -> None:
     )
     parser.add_argument(
         "--parallel_requests",
-        type=int,
+        type=worker_count_validation,
         default=_config.system.parallel_requests,
         help="How many generator requests to launch in parallel for a given prompt. Ignored for models that support multiple generations per call.",
     )
     parser.add_argument(
         "--parallel_attempts",
-        type=int,
+        type=worker_count_validation,
         default=_config.system.parallel_attempts,
-        help="How many probe attempts to launch in parallel.",
+        help="How many probe attempts to launch in parallel. Raise this for faster runs when using non-local models.",
     )
     parser.add_argument(
         "--skip_unknown",

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -373,7 +373,9 @@ def main(arguments=None) -> None:
     def worker_count_validation(workers):
         iworkers = int(workers)
         if iworkers <= 0:
-            raise ValueError("Need >0 workers (int)" % workers)
+            raise ValueError(
+                "Need a number > 0 for --parallel_attempts, --parallel_requests"
+            )
         if iworkers > _config.system.max_workers:
             raise ValueError(
                 "Parallel worker count capped at %s (config.system.max_workers), try a lower value for --parallel_attempts or --parallel_requests"

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -376,7 +376,7 @@ def main(arguments=None) -> None:
             raise ValueError("Need >0 workers (int)" % workers)
         if iworkers > _config.system.max_workers:
             raise ValueError(
-                "Parallel worker count capped at %s (config.system.max_workers)"
+                "Parallel worker count capped at %s (config.system.max_workers), try a lower value for --parallel_attempts or --parallel_requests"
                 % _config.system.max_workers
             )
         return iworkers

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -383,15 +383,20 @@ def main(arguments=None) -> None:
             )
         return iworkers
 
-    if _config.system.parallel_attempts is not False:
-        _config.system.parallel_attempts = worker_count_validation(
-            _config.system.parallel_attempts
-        )
+    try:
+        if _config.system.parallel_attempts is not False:
+            _config.system.parallel_attempts = worker_count_validation(
+                _config.system.parallel_attempts
+            )
 
-    if _config.system.parallel_requests is not False:
-        _config.system.parallel_requests = worker_count_validation(
-            _config.system.parallel_requests
-        )
+        if _config.system.parallel_requests is not False:
+            _config.system.parallel_requests = worker_count_validation(
+                _config.system.parallel_requests
+            )
+    except ValueError as e:
+        logging.exception(e)
+        print(e)
+        exit(1)  # exit non zero indicated parsing error
 
     if hasattr(_config.run, "seed") and isinstance(_config.run.seed, int):
         import random

--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -30,7 +30,7 @@ class Generator(Configurable):
     }
 
     _run_params = {"deprefix", "seed"}
-    _system_params = {"parallel_requests"}
+    _system_params = {"parallel_requests", "max_workers"}
 
     active = True
     generator_family_name = None
@@ -168,8 +168,8 @@ class Generator(Configurable):
 
                 pool_size = min(
                     generations_this_call,
-                    _config.system.parallel_requests,
-                    _config.system.max_workers,
+                    self.parallel_requests,
+                    self.max_workers,
                 )
 
                 try:

--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -166,7 +166,11 @@ class Generator(Configurable):
                 )
                 multi_generator_bar.set_description(self.fullname[:55])
 
-                pool_size = min(generations_this_call, _config.system.parallel_requests)
+                pool_size = min(
+                    generations_this_call,
+                    _config.system.parallel_requests,
+                    _config.system.max_workers,
+                )
 
                 try:
                     with Pool(pool_size) as pool:

--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -178,7 +178,7 @@ class Generator(Configurable):
                             multi_generator_bar.update(1)
                 except OSError as o:
                     if o.errno == 24:
-                        msg = "Parallelisation limit hit. Try reducing parallel_attempts or raising limit (e.g. ulimit -n 4096)"
+                        msg = "Parallelisation limit hit. Try reducing parallel_requests or raising limit (e.g. ulimit -n 4096)"
                         logging.critical(msg)
                         raise GarakException(msg) from o
                     else:

--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -166,8 +166,10 @@ class Generator(Configurable):
                 )
                 multi_generator_bar.set_description(self.fullname[:55])
 
+                pool_size = min(generations_this_call, _config.system.parallel_requests)
+
                 try:
-                    with Pool(_config.system.parallel_requests) as pool:
+                    with Pool(pool_size) as pool:
                         for result in pool.imap_unordered(
                             self._call_model, [prompt] * generations_this_call
                         ):

--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -180,7 +180,11 @@ class Probe(Configurable):
             attempt_bar = tqdm.tqdm(total=len(attempts), leave=False)
             attempt_bar.set_description(self.probename.replace("garak.", ""))
 
-            pool_size = min(_config.system.parallel_attempts, len(attempts))
+            pool_size = min(
+                len(attempts),
+                _config.system.parallel_attempts,
+                _config.system.max_workers,
+            )
 
             try:
                 with Pool(pool_size) as attempt_pool:

--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -18,6 +18,7 @@ import tqdm
 
 from garak import _config
 from garak.configurable import Configurable
+from garak.exception import GarakException
 import garak.attempt
 import garak.resources.theme
 
@@ -179,17 +180,25 @@ class Probe(Configurable):
             attempt_bar = tqdm.tqdm(total=len(attempts), leave=False)
             attempt_bar.set_description(self.probename.replace("garak.", ""))
 
-            with Pool(self.parallel_attempts) as attempt_pool:
-                for result in attempt_pool.imap_unordered(
-                    self._execute_attempt, attempts
-                ):
-                    _config.transient.reportfile.write(
-                        json.dumps(result.as_dict()) + "\n"
-                    )
-                    attempts_completed.append(
-                        result
-                    )  # these will be out of original order
-                    attempt_bar.update(1)
+            try:
+                with Pool(_config.system.parallel_attempts) as attempt_pool:
+                    for result in attempt_pool.imap_unordered(
+                        self._execute_attempt, attempts
+                    ):
+                        _config.transient.reportfile.write(
+                            json.dumps(result.as_dict()) + "\n"
+                        )
+                        attempts_completed.append(
+                            result
+                        )  # these will be out of original order
+                        attempt_bar.update(1)
+            except OSError as o:
+                if o.errno == 24:
+                    msg = "Parallelisation limit hit. Try reducing parallel_attempts or raising limit (e.g. ulimit -n 4096)"
+                    logging.critical(msg)
+                    raise GarakException(msg) from o
+                else:
+                    raise (o)
 
         else:
             attempt_iterator = tqdm.tqdm(attempts, leave=False)

--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -180,8 +180,10 @@ class Probe(Configurable):
             attempt_bar = tqdm.tqdm(total=len(attempts), leave=False)
             attempt_bar.set_description(self.probename.replace("garak.", ""))
 
+            pool_size = min(_config.system.parallel_attempts, len(attempts))
+
             try:
-                with Pool(_config.system.parallel_attempts) as attempt_pool:
+                with Pool(pool_size) as attempt_pool:
                     for result in attempt_pool.imap_unordered(
                         self._execute_attempt, attempts
                     ):

--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -4,7 +4,7 @@
 """Base classes for probes.
 
 Probe plugins must inherit one of these. `Probe` serves as a template showing
-what expectations there are for inheriting classes. """
+what expectations there are for inheriting classes."""
 
 import copy
 import json
@@ -55,7 +55,7 @@ class Probe(Configurable):
     DEFAULT_PARAMS = {}
 
     _run_params = {"generations", "soft_probe_prompt_cap", "seed"}
-    _system_params = {"parallel_attempts"}
+    _system_params = {"parallel_attempts", "max_workers"}
 
     def __init__(self, config_root=_config):
         """Sets up a probe.
@@ -182,8 +182,8 @@ class Probe(Configurable):
 
             pool_size = min(
                 len(attempts),
-                _config.system.parallel_attempts,
-                _config.system.max_workers,
+                self.parallel_attempts,
+                self.max_workers,
             )
 
             try:

--- a/garak/resources/garak.core.yaml
+++ b/garak/resources/garak.core.yaml
@@ -7,7 +7,7 @@ system:
   lite: true
   show_z: false
   enable_experimental: false
-  max_workers: 1000
+  max_workers: 500
 
 run:
   seed:

--- a/garak/resources/garak.core.yaml
+++ b/garak/resources/garak.core.yaml
@@ -7,6 +7,7 @@ system:
   lite: true
   show_z: false
   enable_experimental: false
+  max_workers: 1000
 
 run:
   seed:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -833,3 +833,30 @@ def test_api_key_in_config():
 
     _config.plugins.generators["a"]["b"]["c"]["api_key"] = "something"
     assert _config._key_exists(_config.plugins.generators, "api_key")
+
+
+# test max_workers applies when used in site config
+@pytest.mark.usefixtures("allow_site_config")
+def test_site_yaml_overrides_max_workers(capsys):
+    importlib.reload(_config)
+
+    with open(
+        _config.transient.config_dir / "garak.site.yaml", "w", encoding="utf-8"
+    ) as f:
+        f.write("---\nsystem:\n  max_workers: 2\n")
+        f.flush()
+        garak.cli.main(["--list_config"])
+
+    assert (
+        _config.system.max_workers == 2
+    ), "Site config worker count should override core config if loaded correctly"
+
+    importlib.reload(_config)
+
+    with pytest.raises(ValueError):
+        garak.cli.main("--parallel_attempts 3 -m test -p test.Test".split())
+        result = capsys.readouterr()
+        assert (
+            result.split("\n")[-1]
+            == "ValueError: Parallel worker count capped at 2 (config.system.max_workers)"
+        )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -853,10 +853,12 @@ def test_site_yaml_overrides_max_workers(capsys):
 
     importlib.reload(_config)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(SystemExit) as exc_info:
         garak.cli.main("--parallel_attempts 3 -m test -p test.Test".split())
         result = capsys.readouterr()
         assert (
             result.split("\n")[-1]
             == "ValueError: Parallel worker count capped at 2 (config.system.max_workers)"
         )
+        assert exc_info.type == SystemExit
+        assert exc_info.value.code == 1


### PR DESCRIPTION
OS can get upset if parallel_attempts goes too high. Give a clearer error message about this.

```
(garak) 09:13:05 x1:~/dev/garak [main] $ python -m garak -m nim -n meta/llama-3.2-3b-instruct -p phrasing.PastTenseMini --parallel_attempts 1000 -g 5
garak LLM vulnerability scanner v0.10.2.post1 ( https://github.com/NVIDIA/garak ) at 2025-02-24T09:13:12.943850
📜 logging to /home/lderczynski/.local/share/garak/garak.log
🦜 loading generator: NIM: meta/llama-3.2-3b-instruct
📜 reporting to /home/lderczynski/.local/share/garak/garak_runs/garak.fb21a28e-16c8-4496-bd9e-b0f694333003.report.jsonl
🕵️  queue of probes: phrasing.PastTenseMini
probes.phrasing.PastTenseMini:   0%|                                                                                                                        | 0/200 [00:00<?, ?it/s]Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/lderczynski/dev/garak/garak/__main__.py", line 14, in <module>
    main()
  File "/home/lderczynski/dev/garak/garak/__main__.py", line 9, in main
    cli.main(sys.argv[1:])
  File "/home/lderczynski/dev/garak/garak/cli.py", line 594, in main
    command.probewise_run(
  File "/home/lderczynski/dev/garak/garak/command.py", line 237, in probewise_run
    probewise_h.run(generator, probe_names, evaluator, buffs)
  File "/home/lderczynski/dev/garak/garak/harnesses/probewise.py", line 107, in run
    h.run(model, [probe], detectors, evaluator, announce_probe=False)
  File "/home/lderczynski/dev/garak/garak/harnesses/base.py", line 123, in run
    attempt_results = probe.probe(model)
                      ^^^^^^^^^^^^^^^^^^
  File "/home/lderczynski/dev/garak/garak/probes/base.py", line 219, in probe
    attempts_completed = self._execute_all(attempts_todo)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lderczynski/dev/garak/garak/probes/base.py", line 181, in _execute_all
    with Pool(_config.system.parallel_attempts) as attempt_pool:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lderczynski/anaconda3/envs/garak/lib/python3.12/multiprocessing/context.py", line 119, in Pool
    return Pool(processes, initializer, initargs, maxtasksperchild,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lderczynski/anaconda3/envs/garak/lib/python3.12/multiprocessing/pool.py", line 215, in __init__
    self._repopulate_pool()
  File "/home/lderczynski/anaconda3/envs/garak/lib/python3.12/multiprocessing/pool.py", line 306, in _repopulate_pool
    return self._repopulate_pool_static(self._ctx, self.Process,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lderczynski/anaconda3/envs/garak/lib/python3.12/multiprocessing/pool.py", line 329, in _repopulate_pool_static
    w.start()
  File "/home/lderczynski/anaconda3/envs/garak/lib/python3.12/multiprocessing/process.py", line 121, in start
    self._popen = self._Popen(self)
                  ^^^^^^^^^^^^^^^^^
  File "/home/lderczynski/anaconda3/envs/garak/lib/python3.12/multiprocessing/context.py", line 282, in _Popen
    return Popen(process_obj)
           ^^^^^^^^^^^^^^^^^^
  File "/home/lderczynski/anaconda3/envs/garak/lib/python3.12/multiprocessing/popen_fork.py", line 19, in __init__
    self._launch(process_obj)
  File "/home/lderczynski/anaconda3/envs/garak/lib/python3.12/multiprocessing/popen_fork.py", line 65, in _launch
    child_r, parent_w = os.pipe()
                        ^^^^^^^^^
OSError: [Errno 24] Too many open files
```


## Verification

List the steps needed to make sure this thing works

- [ ] try `garak -m test -p test.Test --parallel_attempts 1000`, the new error should pop up on CLI and in log. If it doesn't, try a higher number, or reduce ulimit.