### PR TITLE
WIP: add best-of-n jailbreaking

### DIFF
--- a/garak/buffs/best_of_n.py
+++ b/garak/buffs/best_of_n.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+""" Buff that uses Best-of-N Jailbreaking to generate multiple attempts. """
+import random
+from collections.abc import Iterable
+
+import garak.attempt
+from garak import _config
+from garak.buffs.base import Buff
+
+
+def apply_word_scrambling(text: str, prob: float) -> str:
+    """
+    Scrambles the middle characters of words longer than 3 characters in the input text.
+    The probability of scrambling is determined by sigma.
+
+    Example:
+    Input: "The quick brown fox jumps"
+    Output: "The qiuck bwron fox jpums"
+    """
+    words = text.split()
+    scrambled_words = []
+    for word in words:
+        if len(word) > 3 and random.random() < prob:
+            chars = list(word)
+            middle_chars = chars[1:-1]
+            random.shuffle(middle_chars)
+            scrambled_word = chars[0] + "".join(middle_chars) + chars[-1]
+            scrambled_words.append(scrambled_word)
+        else:
+            scrambled_words.append(word)
+    return " ".join(scrambled_words)
+
+
+def apply_random_capitalization(text: str, prob: float) -> str:
+    """
+    Randomly capitalizes letters in the input text.
+
+    Input: "The quick brown fox jumps"
+    Output: "The qUick bRoWn fOx jUmps"
+    """
+    new_text = []
+    for c in text:
+        if c.isalpha() and random.random() < prob:
+            if "a" <= c <= "z":
+                new_text.append(chr(ord(c) - 32))  # Convert to uppercase
+            elif "A" <= c <= "Z":
+                new_text.append(chr(ord(c) + 32))  # Convert to lowercase
+        else:
+            new_text.append(c)
+    return "".join(new_text)
+
+
+def apply_ascii_noising(text: str, prob: float) -> str:
+    """
+    Perturbs the ASCII characters of the input text.
+
+    Example:
+    Input: "The quick brown fox jumps"
+    Output: "Tge quick brown fox junps"
+    """
+    new_text = []
+    for c in text:
+        if c.isprintable() and random.random() < prob:
+            perturbation = random.choice([-1, 1])
+            new_char_code = ord(c) + perturbation
+            # Ensure new character is printable ASCII
+            if 32 <= new_char_code <= 126:
+                new_text.append(chr(new_char_code))
+            else:
+                new_text.append(c)
+        else:
+            new_text.append(c)
+    return "".join(new_text)
+
+
+class BestOfNBuff(Buff):
+    """Best of N buff
+
+    Uses random transformations to generate multiple jailbreak attempts"""
+
+    doc_uri = "https://arxiv.org/abs/2412.03556"
+
+    def __init__(self, config_root=_config, num_attempts=100, word_scrambling_prob=0.6, random_capitalization_prob=0.6, ascii_noising_prob=0.06):
+        super().__init__(config_root=config_root)
+        self.num_attempts = num_attempts
+        self.word_scrambling_prob = word_scrambling_prob
+        self.random_capitalization_prob = random_capitalization_prob
+        self.ascii_noising_prob = ascii_noising_prob
+
+    def transform(
+        self, attempt: garak.attempt.Attempt
+    ) -> Iterable[garak.attempt.Attempt]:
+        prompt = attempt.prompt
+        attempt.notes["original_prompt"] = prompt
+        for _ in range(self.num_attempts):
+            new_prompt = apply_word_scrambling(prompt, self.word_scrambling_prob)
+            new_prompt = apply_random_capitalization(new_prompt, self.random_capitalization_prob)
+            new_prompt = apply_ascii_noising(new_prompt, self.ascii_noising_prob)
+            attempt.prompt = new_prompt
+            yield self._derive_new_attempt(attempt)


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your repository to `main` upstream.

## Verification

List the steps needed to make sure this thing works

- [ ] Supporting configuration such as generator configuration file
``` json
{
    "huggingface": {
        "torch_type": "float32"
    }
}
```
- [ ] `garak -m <model_type> -n <model_name>`
- [ ] Run the tests and ensure they pass `python -m pytest tests/`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/NVIDIA/garak/blob/61ce5c4ae3caac08e0abd1d069d223d8a66104bd/garak/generators/rest.py#L24-L100))

If you are opening a PR for a new plugin that targets a **specific** piece of hardware or requires a **complex or hard-to-find** testing environment, we recommend that you send us as much detail as possible.

Specific Hardware Examples:
* GPU related
  * Specific support required `cuda` / `mps` ( Please not `cuda` via `ROCm` if related )
  * Minium GPU Memory

Complex Software Examples:
* Expensive proprietary software
* Software with an extensive installation process
* Software without an English language UI
