### PR TITLE
enhance response type support from local NeMo-Guardrails

### DIFF
--- a/garak/generators/guardrails.py
+++ b/garak/generators/guardrails.py
@@ -44,7 +44,12 @@ class NeMoGuardrails(Generator):
         with redirect_stderr(io.StringIO()) as f:  # quieten the tqdm
             result = self.rails.generate(prompt)
 
-        return [result]
+        if isinstance(result, str):
+            return [result]
+        elif isinstance(result, dict):
+            return [result.get("content", None)]
+        else:
+            return [None]
 
 
 DEFAULT_CLASS = "NeMoGuardrails"


### PR DESCRIPTION
The `LLMRails.generate()` function can return various types currently:
```
Union[str, dict, GenerationResponse, Tuple[dict, dict]]
```

Expand current support for `str` to also allow `dict` response. Unsupported types will return `[None]` by default.

Failure as seen prior to revision:
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Projects/nvidia/garak/garak/__main__.py", line 14, in <module>
    main()
  File "/Projects/nvidia/garak/garak/__main__.py", line 9, in main
    cli.main(sys.argv[1:])
  File "/Projects/nvidia/garak/garak/cli.py", line 594, in main
    command.probewise_run(
  File "/Projects/nvidia/garak/garak/command.py", line 237, in probewise_run
    probewise_h.run(generator, probe_names, evaluator, buffs)
  File "/Projects/nvidia/garak/garak/harnesses/probewise.py", line 107, in run
    h.run(model, [probe], detectors, evaluator, announce_probe=False)
  File "/Projects/nvidia/garak/garak/harnesses/base.py", line 123, in run
    attempt_results = probe.probe(model)
                      ^^^^^^^^^^^^^^^^^^
  File "/Projects/nvidia/garak/garak/probes/base.py", line 219, in probe
    attempts_completed = self._execute_all(attempts_todo)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Projects/nvidia/garak/garak/probes/base.py", line 197, in _execute_all
    result = self._execute_attempt(this_attempt)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Projects/nvidia/garak/garak/probes/base.py", line 156, in _execute_attempt
    this_attempt.outputs = self.generator.generate(
                           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Projects/nvidia/garak/garak/generators/base.py", line 184, in generate
    self._verify_model_result(output_one)
  File "/Projects/nvidia/garak/garak/generators/base.py", line 85, in _verify_model_result
    isinstance(result[0], str) or result[0] is None
AssertionError: _call_model's item must be a string or None
```

## Verification

List the steps needed to make sure this thing works

- [ ] using a local config
- [ ] `OPENAI_API_KEY=<API_KEY> garak -m guardrails -n ../nemoguardrails/examples/configs/sample -p realtoxicityprompts.RTPBlank`
- [ ] **Verify** execution complets
