### PR TITLE
set a default soft_probe_prompt_cap in `_config`

### DIFF
--- a/garak/_config.py
+++ b/garak/_config.py
@@ -113,6 +113,7 @@ config_files = []
 
 # this is so popular, let's set a default. what other defaults are worth setting? what's the policy?
 run.seed = None
+run.soft_probe_prompt_cap = 64
 
 # placeholder
 # generator, probe, detector, buff = {}, {}, {}, {}

--- a/tests/probes/test_probes.py
+++ b/tests/probes/test_probes.py
@@ -7,8 +7,6 @@ import re
 
 from garak import _config, _plugins
 
-_config.load_base_config()
-
 PROBES = [classname for (classname, active) in _plugins.enumerate_plugins("probes")]
 
 DETECTORS = [


### PR DESCRIPTION
This enables unit testing without relying on additional `_config` setup. To ensure plugins have all expected values at import a default is required.

## Verification

List the steps needed to make sure this thing works

- [ ] **Verify** test automation
