### PR TITLE
Bump datasets version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ requires-python = ">=3.10"
 dependencies = [
   "base2048>=0.1.3",
   "transformers>=4.43.0",
-  "datasets>=2.18.0",
+  "datasets>=3.0.0",
   "colorama>=0.4.3",
   "tqdm>=4.64.0",
   "cohere>=4.5.1,<5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ requires-python = ">=3.10"
 dependencies = [
   "base2048>=0.1.3",
   "transformers>=4.43.0",
-  "datasets>=2.14.6,<2.17",
+  "datasets>=2.18.0",
   "colorama>=0.4.3",
   "tqdm>=4.64.0",
   "cohere>=4.5.1,<5",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 base2048>=0.1.3
 transformers>=4.43.0
-datasets>=2.18.0
+datasets>=3.0.0
 colorama>=0.4.3
 tqdm>=4.64.0
 cohere>=4.5.1,<5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 base2048>=0.1.3
 transformers>=4.43.0
-datasets>=2.14.6,<2.17
+datasets>=2.18.0
 colorama>=0.4.3
 tqdm>=4.64.0
 cohere>=4.5.1,<5


### PR DESCRIPTION
Add support for `datasets>2.17`. This PR resolves issue [#1136](https://github.com/NVIDIA/garak/issues/1136).

Change is to support version 3.0.0 and upwards.