### PR TITLE
Multiprocess enabled logging config

### DIFF
--- a/garak/__init__.py
+++ b/garak/__init__.py
@@ -8,13 +8,13 @@ import logging
 import os
 from garak import _config
 
-GARAK_LOG_PATH_VAR = "GARAK_LOG_PATH"
+GARAK_LOG_FILE_VAR = "GARAK_LOG_FILE"
 
 # allow for a file path configuration from the ENV and set for child processes
-_log_filename = os.getenv(GARAK_LOG_PATH_VAR, default=None)
+_log_filename = os.getenv(GARAK_LOG_FILE_VAR, default=None)
 if _log_filename is None:
     _log_filename = _config.transient.data_dir / "garak.log"
-    os.environ[GARAK_LOG_PATH_VAR] = str(_log_filename)
+    os.environ[GARAK_LOG_FILE_VAR] = str(_log_filename)
 
 _config.transient.log_filename = _log_filename
 

--- a/garak/__init__.py
+++ b/garak/__init__.py
@@ -3,3 +3,23 @@
 __version__ = "0.10.3.post1"
 __app__ = "garak"
 __description__ = "LLM vulnerability scanner"
+
+import logging
+import os
+from garak import _config
+
+GARAK_LOG_PATH_VAR = "GARAK_LOG_PATH"
+
+# allow for a file path configuration from the ENV and set for child processes
+_log_filename = os.getenv(GARAK_LOG_PATH_VAR, default=None)
+if _log_filename is None:
+    _log_filename = _config.transient.data_dir / "garak.log"
+    os.environ[GARAK_LOG_PATH_VAR] = str(_log_filename)
+
+_config.transient.log_filename = _log_filename
+
+logging.basicConfig(
+    filename=_log_filename,
+    level=logging.DEBUG,
+    format="%(asctime)s  %(levelname)s  %(message)s",
+)

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -55,6 +55,7 @@ class BuffManager:
 class TransientConfig(GarakSubConfig):
     """Object to hold transient global config items not set externally"""
 
+    log_filename = None
     report_filename = None
     reportfile = None
     hitlogfile = None
@@ -158,18 +159,24 @@ def _load_yaml_config(settings_filenames) -> dict:
             if settings is not None:
                 if _key_exists(settings, "api_key"):
                     if platform.system() == "Windows":
-                        msg = (f"A possibly secret value (`api_key`) was detected in {settings_filename}. "
-                               f"We recommend removing potentially sensitive values from config files or "
-                               f"ensuring the file is readable only by you.")
+                        msg = (
+                            f"A possibly secret value (`api_key`) was detected in {settings_filename}. "
+                            f"We recommend removing potentially sensitive values from config files or "
+                            f"ensuring the file is readable only by you."
+                        )
                         logging.warning(msg)
                         print(f"⚠️  {msg}")
                     else:
-                        logging.info(f"API key found in {settings_filename}. Checking readability...")
+                        logging.info(
+                            f"API key found in {settings_filename}. Checking readability..."
+                        )
                         res = os.stat(settings_filename)
                         if res.st_mode & stat.S_IROTH or res.st_mode & stat.S_IRGRP:
-                            msg = (f"A possibly secret value (`api_key`) was detected in {settings_filename}, "
-                                   f"which is readable by users other than yourself. "
-                                   f"Consider changing permissions on this file to only be readable by you.")
+                            msg = (
+                                f"A possibly secret value (`api_key`) was detected in {settings_filename}, "
+                                f"which is readable by users other than yourself. "
+                                f"Consider changing permissions on this file to only be readable by you."
+                            )
                             logging.warning(msg)
                             print(f"⚠️  {msg}")
                 config = _combine_into(settings, config)

--- a/garak/command.py
+++ b/garak/command.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Portions Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-""" Definitions of commands and actions that can be run in the garak toolkit"""
+"""Definitions of commands and actions that can be run in the garak toolkit"""
 
 import logging
 import json
@@ -24,23 +24,8 @@ def hint(msg, logging=None):
 def start_logging():
     from garak import _config
 
-    log_filename = _config.transient.data_dir / "garak.log"
+    log_filename = _config.transient.log_filename
 
-    logging.basicConfig(
-        filename=log_filename,
-        level=logging.DEBUG,
-        format="%(asctime)s  %(levelname)s  %(message)s",
-    )
-    # garaklogger = logging.FileHandler("garak.log", encoding="utf-8")
-    # garakformatter = logging.Formatter("%(asctime)s  %(levelname)s  %(message)s")
-    # garaklogger.setFormatter(garakformatter)
-    # garaklogger.setLevel(logging.DEBUG)
-
-    # rootlogger = logging.getLogger()
-    # for h in rootlogger.handlers[:]:
-    #    rootlogger.removeHandler(h)
-    # rootlogger.addHandler(garaklogger)
-    # logging.root = rootlogger
     logging.info("invoked")
 
     return log_filename

--- a/garak/detectors/fileformats.py
+++ b/garak/detectors/fileformats.py
@@ -94,7 +94,7 @@ class FileIsExecutable(FileDetector):
         except (ImportError, ModuleNotFoundError) as e:
             logging.info(
                 "detectors.fileformats: failed importing python-magic, try installing libmagic, e.g. `brew install libmagic`",
-                e,
+                exc_info=e,
             )
             self.magic = None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,10 @@
 import pytest
 import os
+
+# suppress all logging unless location defined in ENV
+if os.getenv("GARAK_LOG_PATH", None) is None:
+    os.environ["GARAK_LOG_PATH"] = str(os.devnull)
+
 from garak import _config, _plugins
 
 # force a local cache file to exist when this top level import is loaded

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,8 @@ import pytest
 import os
 
 # suppress all logging unless location defined in ENV
-if os.getenv("GARAK_LOG_PATH", None) is None:
-    os.environ["GARAK_LOG_PATH"] = str(os.devnull)
+if os.getenv("GARAK_LOG_FILE", None) is None:
+    os.environ["GARAK_LOG_FILE"] = str(os.devnull)
 
 from garak import _config, _plugins
 


### PR DESCRIPTION
To ensure logging is setup in all threads add setup to `__init__.py` for the parent `garak` module.

* start logging context on first import of `garak`
* allow logging location to be provided in ENV var
* update error log in `FileIsExecutable` for proper exception serialization

## Verification

List the steps needed to make sure this thing works

- [ ] `python -m garak -m nim -n meta/llama-3.1-70b-instruct --parallel_requests 16 -p lmrc`
- [ ] **Verify** the requests are now logged in `garak.log` under when `GARAK_LOG_FILE` was not set in the ENV
- [ ] `GARAK_LOG_FILE=local.log python -m garak -m nim -n meta/llama-3.1-70b-instruct --parallel_requests 16 -p lmrc`
- [ ] **Verify** the reported log file is `local.log`

Reviewers please consider where in documentation we could add reference to `GARAK_LOG_FILE`.