### PR TITLE
update: rename atkgen probe model to be clear about toxicity

### DIFF
--- a/garak/probes/atkgen.py
+++ b/garak/probes/atkgen.py
@@ -56,7 +56,7 @@ class Tox(Probe):
         "max_calls": 5,
         "constructive_tension": True,
         "red_team_model_type": "huggingface.Pipeline",
-        "red_team_model_name": "garak-llm/artgpt2tox",
+        "red_team_model_name": "garak-llm/attackgeneration-toxicity_gpt2",
         "red_team_model_config": {
             "hf_args": {"device": "cpu", "torch_dtype": "float32"}
         },  # defer acceleration devices to model under test unless overriden


### PR DESCRIPTION
Rename of the atkgen model. HF handles redirection from prior model name. Model is already named on hub.

Validation

* [x] test new model location, `import transformers` , `pipeline = transformers.pipeline(task="text-generation", model="garak-llm/attackgeneration-toxicity_gpt2")`
* [x] test old model location, `import transformers` , `pipeline = transformers.pipeline(task="text-generation", model="garak-llm/artgpt2tox")`
* [x] visit the old model uri and observe redirection, [https://huggingface.co/garak-llm/artgpt2tox](https://huggingface.co/garak-llm/artgpt2tox)
* [x] read newly-extended model card and check it's clear that this model may generate unsafe content, at [https://huggingface.co/garak-llm/attackgeneration-toxicity_gpt2](https://huggingface.co/garak-llm/attackgeneration-toxicity_gpt2)
* [x] from main before merge, `python -m pytest tests/probes/test_probes_atkgen.py `
* [x] also on this branch, `python -m pytest tests/probes/test_probes_atkgen.py`
