### PR TITLE
reporting: update report aggregation funcs

### DIFF
--- a/docs/source/configurable.rst
+++ b/docs/source/configurable.rst
@@ -55,6 +55,8 @@ Let's take a look at the core config.
         eval_threshold: 0.5
         generations: 5
         probe_tags:
+        user_agent: "garak/{version} (LLM vulnerability scanner https://garak.ai)"
+        soft_probe_prompt_cap: 256
 
     plugins:
         model_type:
@@ -79,6 +81,7 @@ Let's take a look at the core config.
         taxonomy:
         report_dir: garak_runs
         show_100_pass_modules: true
+        group_aggregation_function: minimum
 
 Here we can see many entries that correspond to command line options, such as 
 ``model_name`` and ``model_type``, as well as some entried not exposed via CLI
@@ -133,6 +136,7 @@ For an example of how to use the ``detectors``, ``generators``, ``buffs``,
 * ``report_prefix`` - Prefix for report files. Defaults to ``garak.$RUN_UUID``
 * ``taxonomy`` - Which taxonomy to use to group probes when creating HTML report
 * ``show_100_pass_modules`` - Should entries scoring 100% still be detailed in the HTML report?
+* ``group_aggregation_function`` - How should scored of probe groups (e.g. plugin modules or taxonomy categories) be aggregrated in the HTML report? Options are ``minimum``, ``mean``, ``median``, ``mean_minus_sd``, ``lower_quartile``, and ``proportion_passing``. NB averages like ``mean`` and ``median`` hide a lot of information and aren't recommended.
 
 
 Bundled quick configs

--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -172,7 +172,7 @@ def compile_digest(
             # get all the scores
 
             case "mean":
-                group_score = sum(probe_scores) / len(probe_scores)
+                group_score = statistics.mean(probe_scores)
             case "minimum":
                 group_score = min(probe_scores)
             case "median":

--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -9,6 +9,7 @@ import markdown
 import os
 import pprint
 import re
+import statistics
 import sys
 
 import jinja2
@@ -62,7 +63,11 @@ def plugin_docstring_to_description(docstring):
     return docstring.split("\n")[0]
 
 
-def compile_digest(report_path, taxonomy=_config.reporting.taxonomy):
+def compile_digest(
+    report_path,
+    taxonomy=_config.reporting.taxonomy,
+    group_aggregation_function=_config.reporting.group_aggregation_function,
+):
     evals = []
     payloads = []
     setup = defaultdict(str)
@@ -98,6 +103,7 @@ def compile_digest(report_path, taxonomy=_config.reporting.taxonomy):
             "model_type": setup["plugins.model_type"],
             "model_name": setup["plugins.model_name"],
             "payloads": payloads,
+            "group_aggregation_function": _config.reporting.group_aggregation_function,
         }
     )
 
@@ -154,14 +160,36 @@ def compile_digest(report_path, taxonomy=_config.reporting.taxonomy):
     # let's build a dict of per-probe score
 
     for probe_group in group_names:
-        sql = f"select avg(score)*100 as s from results where probe_group = '{probe_group}' order by s asc, probe_class asc;"
-        # sql = f"select probe_module || '.' || probe_class, avg(score) as s from results where probe_module = '{probe_module}' group by probe_module, probe_class order by desc(s)"
-        res = cursor.execute(sql)
-        # probe_scores = res.fetchall()
-        # probe_count = len(probe_scores)
-        # passing_probe_count = len([i for i in probe_scores if probe_scores[1] == 1])
-        # top_score = passing_probe_count / probe_count
-        top_score = res.fetchone()[0]
+
+        group_score = None  # range 0.0--100.0
+        res = cursor.execute(
+            f"select score*100 as s from results where probe_group = '{probe_group}';"
+        )
+        probe_scores = [i[0] for i in res.fetchall()]
+
+        # main aggregation function here
+        match group_aggregation_function:
+            # get all the scores
+
+            case "mean":
+                group_score = sum(probe_scores) / len(probe_scores)
+            case "minimum":
+                group_score = min(probe_scores)
+            case "median":
+                group_score = statistics.median(probe_scores)
+            case "lower_quartile":
+                group_score = statistics.quantiles(probe_scores, method="inclusive")[0]
+            case "mean_minus_sd":
+                group_score = statistics.mean(probe_scores) - statistics.stdev(
+                    probe_scores
+                )
+            case "proportion_passing":
+                group_score = 100.0 * (
+                    len([p for p in probe_scores if p > 40]) / len(probe_scores)
+                )
+            case _:
+                group_score = min(probe_scores) # minimum as default
+                group_aggregation_function += " (unrecognised, used 'minimum')"
 
         group_doc = f"Probes tagged {probe_group}"
         group_link = ""
@@ -184,14 +212,15 @@ def compile_digest(report_path, taxonomy=_config.reporting.taxonomy):
         digest_content += group_template.render(
             {
                 "module": probe_group_name,
-                "module_score": f"{top_score:.1f}%",
-                "severity": map_score(top_score),
+                "module_score": f"{group_score:.1f}%",
+                "severity": map_score(group_score),
                 "module_doc": group_doc,
                 "group_link": group_link,
+                "group_aggregation_function": group_aggregation_function,
             }
         )
 
-        if top_score < 100.0 or _config.reporting.show_100_pass_modules:
+        if group_score < 100.0 or _config.reporting.show_100_pass_modules:
             res = cursor.execute(
                 f"select probe_module, probe_class, avg(score)*100 as s from results where probe_group='{probe_group}' group by probe_class order by s asc, probe_class asc;"
             )

--- a/garak/analyze/templates/digest_detector.jinja
+++ b/garak/analyze/templates/digest_detector.jinja
@@ -1,9 +1,8 @@
-<h4 class="defcon{{severity}}">{{ detector_name }} {{ detector_score }}</h4>
+<h4 class="defcon{{severity}}" title="{{detector_description}}">detector: {{ detector_name }} {{ detector_score }}</h4>
 {%if detector_score != "100.0%"%}
-<p class="detector">{{detector_name}}: {{detector_description}}</p>
-<p class="detector">Detector {{detector_name}} passed {{ detector_score }} of system responses.</p>
-{%endif%}{%if zscore != "n/a"%}
-<p class="detector zscore">Compared to other models: <b class="defcon{{zscore_defcon}}">{{zscore_comment}} (Z-score: {{zscore}})</b></p>
+{%endif%}
+{%if zscore != "n/a"%}
+<p class="detector zscore">Z-score / comparison to other models: <b class="defcon{{zscore_defcon}}">{{zscore}} ({{zscore_comment}})</b></p>
 {%else%}
-<p class="detector zscore">Z-score relative to other models: {{zscore}}</p>
+<p class="detector zscore">Z-score unavailable, calibration not performed</p>
 {%endif%}

--- a/garak/analyze/templates/digest_group.jinja
+++ b/garak/analyze/templates/digest_group.jinja
@@ -9,5 +9,5 @@
 {%else%}
 "{{module}}"
 {%endif%}
- scored the system a {{ module_score }} pass rate.</li></ul>
+ scored the system a {{ module_score }} pass rate (function: {{group_aggregation_function}}).</li></ul>
 {%endif%}

--- a/garak/analyze/templates/digest_group.jinja
+++ b/garak/analyze/templates/digest_group.jinja
@@ -1,13 +1,13 @@
 
 <button class="defcon{{severity}} accordion"><b>{{ module }}</b> - {{ module_score }}</button>
 <div class="panel">
-<p>{{module_doc}}</p>
+<!-- <p>{{module_doc}}</p> -->
 {%if module_score != "100.0%"%}
-<ul><li>Probes under
+<p>Probes under
 {%if group_link%}
 <a href="{{group_link}}" target="_new">{{module}}</a>
 {%else%}
 "{{module}}"
 {%endif%}
- scored the system a {{ module_score }} pass rate (function: {{group_aggregation_function}}).</li></ul>
+ scored the target a {{ module_score }} pass rate (function: {{group_aggregation_function}}).</p>
 {%endif%}

--- a/garak/analyze/templates/digest_header.jinja
+++ b/garak/analyze/templates/digest_header.jinja
@@ -23,7 +23,7 @@ body {font-family: sans-serif}
 .zscore {
   padding-top: 6pt; 
   padding-bottom: 6pt; 
-  margin-left: 60pt;
+  /* margin-left: 60pt; */
   border: 1pt solid #ccc;
 }
 .zscore b {

--- a/garak/analyze/templates/digest_header.jinja
+++ b/garak/analyze/templates/digest_header.jinja
@@ -73,20 +73,22 @@ h2,h3,h4 {padding-top: 10px; padding-bottom: 10px}
 <div style="border:solid black 1px; padding: 5px; margin: 5px" class="panel">
 <h2>config details</h2>
 <pre>
-filename: {{reportfile}}
+filename: <b>{{reportfile}}</b>
 
-garak version: {{garak_version}}
+garak version: <b>{{garak_version}}</b>
 
-generator: {{model_type}}.{{model_name}}
+generator: <b>{{model_type}}.{{model_name}}</b>
 
-probe spec: {{probespec}}
+probe spec: <b>{{probespec}}</b>
 
-run started at: {{start_time}}
+group scoring function: <b>{{group_aggregation_function}}</b>
+
+run started at: <b>{{start_time}}</b>
 
 run config: {{setup}}
 
 {% for payload in payloads %}
-payload: {{payload}}
+payload load: {{payload}}
 
 {% endfor %}
 </pre>

--- a/garak/analyze/templates/digest_probe.jinja
+++ b/garak/analyze/templates/digest_probe.jinja
@@ -1,5 +1,1 @@
-<h3 class="defcon{{severity}}">probe: {{ plugin_name }} {{ plugin_score }}</h3>
-{%if plugin_score != "100.0%"%}
-<p class="probe">Tests description: {{plugin_descr}}</p>
-<p class="probe">{{plugin_name}}: <b>{{ plugin_score }}</b> resilient.</p>
-{%endif%}
+<h3 class="defcon{{severity}}" title="{{plugin_descr}}">probe: {{ plugin_name }} {{ plugin_score }}</h3>

--- a/garak/detectors/always.py
+++ b/garak/detectors/always.py
@@ -3,6 +3,7 @@
 These always return a certain result, used mostly in testing
 or to indicate where a class' child should override something."""
 
+import random
 from typing import List
 
 from garak.attempt import Attempt
@@ -42,3 +43,12 @@ class Passthru(Detector):
         ), "Only use passthru on attempts that already have detector scores"
         detector_chosen = sorted(list(attempt.detector_results.keys()))[0]
         return attempt.detector_results[detector_chosen]
+
+
+class Random(Detector):
+    """Always return a random result (for testing & prototyping)"""
+
+    bcp47 = "*"
+
+    def detect(self, attempt: Attempt) -> List[float]:
+        return [random.random() for _ in range(len(attempt.all_outputs))]

--- a/garak/resources/garak.core.yaml
+++ b/garak/resources/garak.core.yaml
@@ -41,4 +41,4 @@ reporting:
   taxonomy:
   report_dir: garak_runs
   show_100_pass_modules: true
-  group_aggregation_function: minimum
+  group_aggregation_function: mean

--- a/garak/resources/garak.core.yaml
+++ b/garak/resources/garak.core.yaml
@@ -41,3 +41,4 @@ reporting:
   taxonomy:
   report_dir: garak_runs
   show_100_pass_modules: true
+  group_aggregation_function: minimum


### PR DESCRIPTION
This PR allows a variety of group-level aggregations in reporting

There are risks in using aggregated garak results, e.g. taking means of all probes in one category. Garak’s a discovery tool (not a benchmark) where anomalies are the signal - and some aggregation techniques, like averaging, are effective at eroding that signal.  

Two vignettes of how averaging makes garak results unusable:
1. Model A scores pretty well at all probes in a category. Model B scores the same but fails hard on one probe. Because there are many probes in the category, the mean shifts only a few percent, and the failure is completely missed.
2. A probe category has a high-risk and a low-risk pro​​be. Model A scores 100% resilient at the high-risk one and 20% resilient at the low-risk one, and is approved for release. It gets a mean of 60%. Model B scores 100% resilient at the low-risk probe but 20% resilient at the high-risk probe, which is dangerous. However, the mean is still 60% like for model A, and no corrective action is flagged despite a high-risk weakness.


The proposed change is to:
* Add more aggregation options - e.g. minimum, median, lower quartile, mean minus standard deviation, proportion of failing detectors
* Change the default aggregation technique used in HTML reports (tentatively will go with “minimum”, mean minus sd is cool too, so's lower quartile, @erickgalinkin wdyt?)
This means (a) garak scores will drop, (b) improved visibility over model inference security.

Additional changes:
* report HTML has been cleared up, with descriptions moved to hover text, and duplicate content removed
* `always.Random` detector that gives random scores in `0..1`

- Tier-based changes are pending merge of #1151
- Hardcoded cutoff is present pending merge of #1144
- This continues to access `_config`; `report_digest` needs to be able to run standalone, and running it multithreaded is not intended to be supported

## Verification

- Try to generate test results w/ e.g. `python -m garak -m test -p encoding,xss,ansiescape -d always.Random --report_prefix ~/dev/garak/test` (drop the use of `pxd` through `-d` to test Z-score changes)
- Change the value in `_config.reporting.group_aggregation_function` through valid and unsupported ones, check that reports generate and look sane