### PR TITLE
Detector improvements

### DIFF
--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -69,7 +69,7 @@ class Detector(Configurable):
         """Takes a list of Attempts; classifies them; returns a list of results
         in the range 0.0-1.0 where 0.0 represents no hit, 1.0 represents successful hit
         (i.e. vulnerability found)."""
-        return [0.5] * len(attempt.all_outputs)
+        raise NotImplementedError(f"Detection logic not defined for {self.__name__}")
 
 
 class HFDetector(Detector, HFCompatible):
@@ -181,7 +181,7 @@ class StringDetector(Detector):
         all_outputs = attempt.outputs_for(self.bcp47)
 
         for output in all_outputs:
-            if output is None:
+            if not output:
                 continue
             match = False
             for s in self.substrings:
@@ -220,7 +220,7 @@ class TriggerListDetector(Detector):
             if isinstance(triggers, str):
                 triggers = [triggers]
             for output in all_outputs:
-                if output is None:
+                if not output:
                     continue  # trigger is absent
                 match = False
                 for trigger in triggers:

--- a/garak/detectors/continuation.py
+++ b/garak/detectors/continuation.py
@@ -1,6 +1,6 @@
 """Continuation detector
 
-Checks if a given trigger word is continued in the output, including 
+Checks if a given trigger word is continued in the output, including
 considering how much of it is in the prompt already
 """
 
@@ -23,7 +23,7 @@ class Continuation(Detector):
             return results
 
         for output in attempt.all_outputs:
-            if output is None:
+            if not output:
                 continue
 
             # continuation models might not include the whole slur in their output, so we should build some context in

--- a/garak/detectors/divergence.py
+++ b/garak/detectors/divergence.py
@@ -86,7 +86,7 @@ class RepeatDiverges(Detector):
 
         repeat_word = attempt.notes["repeat_word"]
         for output in attempt.all_outputs:
-            if output is None:
+            if not output:
                 continue
             if not case_sensitive:
                 repeat_word = repeat_word.lower()

--- a/garak/detectors/encoding.py
+++ b/garak/detectors/encoding.py
@@ -56,7 +56,7 @@ class DecodeApprox(Detector):
         detector_results = []
         for q in attempt.all_outputs:
 
-            if q is None:
+            if not q:
                 continue
 
             best_match = 0.0

--- a/garak/detectors/leakreplay.py
+++ b/garak/detectors/leakreplay.py
@@ -19,7 +19,7 @@ class StartsWith(Detector):
         if "triggers" in attempt.notes:
             triggers = attempt.notes["triggers"]
             for output in attempt.all_outputs:
-                if output is None:
+                if not output:
                     continue
 
                 match = False

--- a/garak/detectors/malwaregen.py
+++ b/garak/detectors/malwaregen.py
@@ -45,7 +45,7 @@ class AnyCode(Detector):
     def detect(self, attempt: garak.attempt.Attempt) -> List[float]:
         results = []
         for output in attempt.all_outputs:
-            if output is None:
+            if not output:
                 continue
 
             lang_found = False

--- a/garak/detectors/promptinject.py
+++ b/garak/detectors/promptinject.py
@@ -24,7 +24,7 @@ class AttackRogueString(Detector):
             return results
 
         for output in attempt.all_outputs:
-            if output is None:
+            if not output:
                 continue
 
             score = 0.0

--- a/garak/detectors/xss.py
+++ b/garak/detectors/xss.py
@@ -32,7 +32,7 @@ class MarkdownExfilBasic(Detector):
     def detect(self, attempt: garak.attempt.Attempt) -> List[float]:
         results = []
         for output in attempt.all_outputs:
-            if output is None:
+            if not output:
                 continue
             results.append(1.0 if re.search(self.regex, output, re.I) else 0.0)
         return results
@@ -50,7 +50,7 @@ class MarkdownExfilContent(Detector):
     def detect(self, attempt: garak.attempt.Attempt) -> List[float]:
         results = []
         for output in attempt.all_outputs:
-            if output is None:
+            if not output:
                 continue
 
             found_exfil = (


### PR DESCRIPTION
Resolves #1114 

Change the logic across detectors to use `if not output` instead of `if output is None` so we catch the cases where:
1. The output is the empty string
2. The output is `None`

Many string detectors will fail to detect the presence of the relevant string (looking at you mitigation) and return a failure if the string is empty... because the relevant string is not present. This change should reduce false positives.