### PR TITLE
1127 Changed Attempt.outputs to return all assistant outputs

### DIFF
--- a/garak/attempt.py
+++ b/garak/attempt.py
@@ -133,7 +133,7 @@ class Attempt:
             )
 
     @property
-    def outputs(self):
+    def last_output(self):
         if len(self.messages) and isinstance(self.messages[0], list):
             # work out last_output_turn that was assistant
             assistant_turns = [
@@ -146,6 +146,24 @@ class Attempt:
             last_output_turn = max(assistant_turns)
             # return these (via list compr)
             return [m[last_output_turn]["content"] for m in self.messages]
+        else:
+            return []
+
+    @property
+    def outputs(self):
+        if len(self.messages) and isinstance(self.messages[0], list):
+            # work out last_output_turn that was assistant
+            assistant_turns = [
+                idx
+                for idx, val in enumerate(self.messages[0])
+                if val["role"] == "assistant"
+            ]
+            if assistant_turns == []:
+                return []
+            else:
+                return [m[turn_idx]["content"] 
+                        for m in self.messages 
+                        for turn_idx in assistant_turns]
         else:
             return []
 
@@ -186,7 +204,8 @@ class Attempt:
     @outputs.setter
     def outputs(self, value):
         if not (isinstance(value, list) or isinstance(value, GeneratorType)):
-            raise TypeError("Value for attempt.outputs must be a list or generator")
+            raise TypeError(
+                "Value for attempt.outputs must be a list or generator")
         value = list(value)
         if len(self.messages) == 0:
             raise TypeError("A prompt must be set before outputs are given")

--- a/garak/probes/atkgen.py
+++ b/garak/probes/atkgen.py
@@ -187,7 +187,7 @@ class Tox(Probe):
                     != self.reverse_translator.target_lang
                 ):
                     this_attempt.reverse_translator_outputs = [response_to_store]
-                this_attempt._add_turn("assistant", [response])
+                this_attempt._add_turn("assistant", [response])  # This is setting outputs to only last assisstant response
                 turns.append(turn)
                 logging.debug("atkgen: model: %s", turn)
                 if output_is_conversation:


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your repository to `main` upstream.

## Verification

List the steps needed to make sure this thing works

- [ ] Supporting configuration such as generator configuration file
``` json
{
    "huggingface": {
        "torch_type": "float32"
    }
}
```
- [ ] `garak -m <model_type> -n <model_name>`
- [ ] Run the tests and ensure they pass `python -m pytest tests/`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/NVIDIA/garak/blob/61ce5c4ae3caac08e0abd1d069d223d8a66104bd/garak/generators/rest.py#L24-L100))

If you are opening a PR for a new plugin that targets a **specific** piece of hardware or requires a **complex or hard-to-find** testing environment, we recommend that you send us as much detail as possible.

Specific Hardware Examples:
* GPU related
  * Specific support required `cuda` / `mps` ( Please not `cuda` via `ROCm` if related )
  * Minium GPU Memory

Complex Software Examples:
* Expensive proprietary software
* Software with an extensive installation process
* Software without an English language UI
