### PR TITLE
Fix ambiguous series value error when running --report

### DIFF
--- a/garak/report.py
+++ b/garak/report.py
@@ -2,6 +2,7 @@
 
 import importlib
 import json
+import numpy as np
 import pandas as pd
 
 from datetime import date
@@ -77,9 +78,10 @@ class Report:
             evals[i]["probe_tags"] = plugin_instance.tags
 
         evals_df = pd.DataFrame.from_dict(evals)
-        self.evaluations = evals_df.assign(
-            score=lambda x: (x["passed"] / x["total"] * 100) if x["total"] > 0 else 0
-        )
+        evals_df["score"] = np.where(evals_df["total"] != 0,
+                                     evals_df["passed"] / evals_df["total"],
+                                     0)
+        self.evaluations = evals_df
         self.scores = self.evaluations[["probe", "score"]].groupby("probe").mean()
         return self
 

--- a/garak/report.py
+++ b/garak/report.py
@@ -77,11 +77,11 @@ class Report:
             plugin_instance = getattr(mod, plugin_class_name)()
             evals[i]["probe_tags"] = plugin_instance.tags
 
-        evals_df = pd.DataFrame.from_dict(evals)
-        evals_df["score"] = np.where(evals_df["total"] != 0,
-                                     evals_df["passed"] / evals_df["total"],
-                                     0)
-        self.evaluations = evals_df
+        self.evaluations = pd.DataFrame.from_dict(evals)
+        self.evaluations["score"] = np.where(
+            self.evaluations["total"] != 0,
+            self.evaluations["passed"] / self.evaluations["total"],
+            0)
         self.scores = self.evaluations[["probe", "score"]].groupby("probe").mean()
         return self
 

--- a/garak/report.py
+++ b/garak/report.py
@@ -80,7 +80,7 @@ class Report:
         self.evaluations = pd.DataFrame.from_dict(evals)
         self.evaluations["score"] = np.where(
             self.evaluations["total"] != 0,
-            self.evaluations["passed"] / self.evaluations["total"],
+            100 * self.evaluations["passed"] / self.evaluations["total"],
             0)
         self.scores = self.evaluations[["probe", "score"]].groupby("probe").mean()
         return self


### PR DESCRIPTION
## Actual issue
[This commit](https://github.com/NVIDIA/garak/commit/0495d11809a0695adc380ca1d1e023bf1a2d8090) introduced a bug: while it avoids the ZeroDivisionError exception that would be raised if total is =0 for one of the probes, it introduces another bug with the usage of pandas.

## How to reproduce

After running a test with some probe, run the report evaluations on the output file.

Python script:
```
from garak.report import Report
r = Report(report_location='garak.report.jsonl')
r.get_evaluations()
---------------------------------------------------------------------------
ValueError    
[...] I remove the traceback 

ValueError: The truth value of a Series is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```

There is also a CLI with `-r` on the `.jsonl` result file.

```
garak -r garak.report.jsonl
garak LLM vulnerability scanner v0.11.0.pre1 ( https://github.com/NVIDIA/garak ) at 2025-04-18T15:08:29.804967
/Users/.../venv/lib/python3.11/site-packages/pydantic/_internal/_config.py:373: UserWarning: Valid config keys have changed in V2:
* 'fields' has been removed
  warnings.warn(message, UserWarning)
📜 Converting garak reports garak.report.jsonl
The truth value of a Series is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```


## The fix
Use `numpy.where` for that conditional division.

## Verification
It seems there is no coverage for the `--report`/`-r` feature, so I just ran the python script above 