### PR TITLE
cache workflow resources

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,19 +23,19 @@ permissions:
 jobs:
   linux:
     name: Nightly Linux
-    if: github.repository_owner == 'NVIDIA'
+    if: github.repository_owner == 'NVIDIA' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/test_linux.yml
   windows:
     name: Nightly Windows
-    if: github.repository_owner == 'NVIDIA'
+    if: github.repository_owner == 'NVIDIA' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/test_windows.yml
   macos:
     name: Nightly MacOS
-    if: github.repository_owner == 'NVIDIA'
+    if: github.repository_owner == 'NVIDIA' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/test_macos.yml
     with:
       store-cache: true
   package_test:
     name: Nightly Packaging
-    if: github.repository_owner == 'NVIDIA'
+    if: github.repository_owner == 'NVIDIA' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/remote_package_install.yml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,6 +33,8 @@ jobs:
     name: Nightly MacOS
     if: github.repository_owner == 'NVIDIA'
     uses: ./.github/workflows/test_macos.yml
+    with:
+      store-cache: true
   package_test:
     name: Nightly Packaging
     if: github.repository_owner == 'NVIDIA'

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -23,6 +23,9 @@ permissions:
   security-events: none
   statuses: none
 
+env:
+  XDG_CACHE_HOME: ${{ github.workspace }}/.cache
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -35,11 +38,22 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Restore test cache artifacts
+        id: cache-artifacts-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .cache/garak/data
+            .cache/huggingface
+          key: hf-cache-shared
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           python -m pip cache purge
+
       - name: Test with pytest
         run: |
           python -m pytest tests/

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -46,7 +46,7 @@ jobs:
           path: |
             .cache/garak/data
             .cache/huggingface
-          key: hf-cache-shared
+          key: garak-test-resources-shared
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -55,7 +55,7 @@ jobs:
           path: |
             .cache/garak/data
             .cache/huggingface
-          key: hf-cache-shared
+          key: garak-test-resources-shared
 
       - name: Install dependencies
         run: |
@@ -83,4 +83,4 @@ jobs:
             .cache/garak/data
             .cache/huggingface
           enableCrossOsArchive: true
-          key: hf-cache-shared
+          key: garak-test-resources-shared

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      store-cache:
+        description: "Store resource cache"
+        required: false
+        type: boolean
+
 
 permissions:
   actions: none
@@ -22,6 +28,9 @@ permissions:
   repository-projects: none
   security-events: none
   statuses: none
+
+env:
+  XDG_CACHE_HOME: ${{ github.workspace }}/.cache
 
 jobs:
   build_macos:
@@ -39,6 +48,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Restore test cache artifacts
+        id: cache-artifacts-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .cache/garak/data
+            .cache/huggingface
+          key: hf-cache-shared
+
       - name: Install dependencies
         run: |
           brew install libmagic
@@ -51,3 +69,18 @@ jobs:
         run: |
           cd garak
           python -m pytest tests/
+
+      - name: Prepare resources for cache
+        run: |
+          rm -rf .cache/huggingface/hub/*facebook*
+          rm -rf .cache/huggingface/hub/*Helsinki*
+
+      - name: Save test cache
+        if: inputs.store-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .cache/garak/data
+            .cache/huggingface
+          enableCrossOsArchive: true
+          key: hf-cache-shared

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -23,6 +23,9 @@ permissions:
   security-events: none
   statuses: none
 
+env:
+  XDG_CACHE_HOME: ${{ github.workspace }}/.cache
+
 jobs:
   build_windows:
     runs-on: windows-latest
@@ -38,6 +41,16 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Restore test cache artifacts
+        id: cache-artifacts-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .cache/garak/data
+            .cache/huggingface
+          enableCrossOsArchive: true
+          key: hf-cache-shared
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -50,7 +50,7 @@ jobs:
             .cache/garak/data
             .cache/huggingface
           enableCrossOsArchive: true
-          key: hf-cache-shared
+          key: garak-test-resources-shared
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Implements a shared cache for most, though not all, huggingface models used in automation tests.

This reduces the traffic to hugginface for github actions by creating a `hf-cache-shared` action by leveraging the `XDG_CACHE_HOME` to place the cache in a consistent location relative to the runner working directory.

Due to the 10GB limit of all caches per repo this cache file is updated during the nightly test run and any PR will use the cache to reduce the models required to be retrieved from huggingface for each test execution.

This also enables manual execution of the `Nightly` task in forks of the repository.