### PR TITLE
update: more meaningful values in tier enums

### DIFF
--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -25,10 +25,10 @@ import garak.resources.theme
 
 
 class Tier(IntEnum):
-    TIER_1 = 10
-    TIER_2 = 20
-    TIER_3 = 30
-    TIER_9 = 99
+    TIER_1 = 1
+    TIER_2 = 2
+    TIER_3 = 3
+    TIER_9 = 9
 
 
 class Probe(Configurable):


### PR DESCRIPTION
Alter the values behind putative `TIER` enums to ensure cache entries have meaningful values. NB (a) there's no roadmap requirement to have further tiers (b) the enum setup is intended to abstract away these values & make them readily changeable later