### PR TITLE
ux: give more verbose message for CLI typos

### DIFF
--- a/garak/_plugins.py
+++ b/garak/_plugins.py
@@ -406,7 +406,13 @@ def load_plugin(path, break_on_fail=True, config_root=_config) -> object:
     except Exception as e:
         logging.warning("Exception failed import of %s", module_path, exc_info=e)
         if break_on_fail:
-            raise ValueError("Didn't successfully import " + module_name) from e
+            raise ValueError(
+                "❌ Didn't successfully import "
+                + category
+                + " plugin: '"
+                + module_name
+                + "'\n- Check spelling and garak log"
+            ) from e
         else:
             return False
 


### PR DESCRIPTION
Mistyping something like a generator name gave a pretty cryptic message

Make this clear, suggest an action, and follow our CLI design language

## Verification

List the steps needed to make sure this thing works

- [ ] `garak -m teset.Repeat -p phrasing,grandma` - the output should make it clear that (a) a generator was the offending item (b) what the string was that led to the failure (c) there are a coupla of next steps