### PR TITLE
update: rename `Translator` -> `LangProvider` and associated elements

### DIFF
--- a/garak/_config.py
+++ b/garak/_config.py
@@ -116,7 +116,7 @@ config_files = []
 run.seed = None
 run.soft_probe_prompt_cap = 64
 run.target_lang = "en"
-run.translators = []
+run.langproviders = []
 
 # placeholder
 # generator, probe, detector, buff = {}, {}, {}, {}

--- a/garak/attempt.py
+++ b/garak/attempt.py
@@ -40,8 +40,8 @@ class Attempt:
     :type messages: List(dict)
     :param lang: Language code for prompt as sent to the target
     :type lang: str, valid BCP47
-    :param reverse_translator_outputs: The reverse translation of output based on the original language of the probe
-    :param reverse_translator_outputs: List(str)
+    :param reverse_translation_outputs: The reverse translation of output based on the original language of the probe
+    :param reverse_translation_outputs: List(str)
 
     Expected use
     * an attempt tracks a seed prompt and responses to it
@@ -77,7 +77,7 @@ class Attempt:
         goal=None,
         seq=-1,
         lang=None,  # language code for prompt as sent to the target
-        reverse_translator_outputs=None,
+        reverse_translation_outputs=None,
     ) -> None:
         self.uuid = uuid.uuid4()
         self.messages = []
@@ -93,8 +93,8 @@ class Attempt:
         if prompt is not None:
             self.prompt = prompt
         self.lang = lang
-        self.reverse_translator_outputs = (
-            {} if reverse_translator_outputs is None else reverse_translator_outputs
+        self.reverse_translation_outputs = (
+            {} if reverse_translation_outputs is None else reverse_translation_outputs
         )
 
     def as_dict(self) -> dict:
@@ -114,7 +114,7 @@ class Attempt:
             "goal": self.goal,
             "messages": self.messages,
             "lang": self.lang,
-            "reverse_translator_outputs": list(self.reverse_translator_outputs),
+            "reverse_translation_outputs": list(self.reverse_translation_outputs),
         }
 
     @property
@@ -206,12 +206,7 @@ class Attempt:
 
         When "*" or None are passed returns the prompt passed to the model
         """
-        if (
-            lang is not None
-            and self.lang != "*"
-            and lang != "*"
-            and self.lang != lang
-        ):
+        if lang is not None and self.lang != "*" and lang != "*" and self.lang != lang:
             return self.notes.get(
                 "pre_translation_prompt", self.prompt
             )  # update if found in notes
@@ -223,13 +218,8 @@ class Attempt:
 
         When "*" or None are passed returns the original model output
         """
-        if (
-            lang is not None
-            and self.lang != "*"
-            and lang != "*"
-            and self.lang != lang
-        ):
-            return self.reverse_translator_outputs
+        if lang is not None and self.lang != "*" and lang != "*" and self.lang != lang:
+            return self.reverse_translation_outputs
         return self.all_outputs
 
     def _expand_prompt_to_histories(self, breadth):

--- a/garak/buffs/low_resource_languages.py
+++ b/garak/buffs/low_resource_languages.py
@@ -35,23 +35,23 @@ class LRLBuff(Buff):
     def transform(
         self, attempt: garak.attempt.Attempt
     ) -> Iterable[garak.attempt.Attempt]:
-        translator = Translator(self.api_key)
+        deepl_translator = Translator(self.api_key)
         prompt = attempt.prompt
         attempt.notes["original_prompt"] = prompt
         for language in LOW_RESOURCE_LANGUAGES:
             attempt.notes["LRL_buff_dest_lang"] = language
-            response = translator.translate_text(prompt, target_lang=language)
+            response = deepl_translator.translate_text(prompt, target_lang=language)
             translated_prompt = response.text
             attempt.prompt = translated_prompt
             yield self._derive_new_attempt(attempt)
 
     def untransform(self, attempt: garak.attempt.Attempt) -> garak.attempt.Attempt:
-        translator = Translator(self.api_key)
+        deepl_translator = Translator(self.api_key)
         outputs = attempt.outputs
         attempt.notes["original_responses"] = outputs
         translated_outputs = list()
         for output in outputs:
-            response = translator.translate_text(output, target_lang="EN-US")
+            response = deepl_translator.translate_text(output, target_lang="EN-US")
             translated_output = response.text
             translated_outputs.append(translated_output)
         attempt.outputs = translated_outputs

--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -28,7 +28,7 @@ def _initialize_runtime_services():
     """Initialize and validate runtime services required for a successful test"""
 
     from garak.exception import GarakException
-    from garak.langservice import load_translators
+    from garak.langservice import load_langproviders
 
     # TODO: this block may be gated in the future to ensure it is only run once. At this time
     # only one harness will execute per run so the output here is reasonable.
@@ -36,7 +36,7 @@ def _initialize_runtime_services():
         msg = "🌐 Loading Language services if required."
         logging.info(msg)
         print(msg)
-        load_translators()
+        load_langproviders()
     except GarakException as e:
         logging.critical("❌ Language setup failed! ❌", exc_info=e)
         raise e

--- a/garak/langproviders/base.py
+++ b/garak/langproviders/base.py
@@ -126,7 +126,7 @@ def is_meaning_string(text: str) -> bool:
 
 
 # To be `Configurable` the root object must meet the standard type search criteria
-# { translators:
+# { langproviders:
 #     "local": { # model_type
 #       "language": "<from>-<to>"
 #       "name": "model/name" # model_name
@@ -136,8 +136,8 @@ def is_meaning_string(text: str) -> bool:
 from garak.configurable import Configurable
 
 
-class Translator(Configurable):
-    """Base class for objects that execute translation"""
+class LangProvider(Configurable):
+    """Base class for objects that provision language"""
 
     def __init__(self, config_root: dict = {}) -> None:
         self._load_config(config_root=config_root)
@@ -146,9 +146,9 @@ class Translator(Configurable):
 
         self._validate_env_var()
 
-        self._load_translator()
+        self._load_langprovider()
 
-    def _load_translator(self):
+    def _load_langprovider(self):
         raise NotImplementedError
 
     def _translate(self, text: str) -> str:
@@ -218,7 +218,7 @@ class Translator(Configurable):
     def _clean_line(self, line: str) -> str:
         return remove_english_punctuation(line.strip().lower().split())
 
-    def translate(
+    def get_text(
         self,
         prompts: List[str],
         reverse_translate_judge: bool = False,

--- a/garak/langproviders/local.py
+++ b/garak/langproviders/local.py
@@ -2,26 +2,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-"""Translator that translates a prompt."""
+"""Local language providers & translators."""
 
 
 from typing import List
 
 from garak.exception import BadGeneratorException
-from garak.translators.base import Translator
+from garak.langproviders.base import LangProvider
 from garak.resources.api.huggingface import HFCompatible
 
 
-class NullTranslator(Translator):
-    """Stand-in translator for pass through"""
+class Passthru(LangProvider):
+    """Stand-in language provision for pass through / noop"""
 
-    def _load_translator(self):
+    def _load_langprovider(self):
         pass
 
     def _translate(self, text: str) -> str:
         return text
 
-    def translate(
+    def get_text(
         self,
         prompts: List[str],
         reverse_translate_judge: bool = False,
@@ -29,7 +29,7 @@ class NullTranslator(Translator):
         return prompts
 
 
-class LocalHFTranslator(Translator, HFCompatible):
+class LocalHFTranslator(LangProvider, HFCompatible):
     """Local translation using Huggingface m2m100 or Helsinki-NLP/opus-mt-* models
 
     Reference:
@@ -56,7 +56,7 @@ class LocalHFTranslator(Translator, HFCompatible):
         self.device = self._select_hf_device()
         super().__init__(config_root=config_root)
 
-    def _load_translator(self):
+    def _load_langprovider(self):
         if "m2m100" in self.model_name:
             from transformers import M2M100ForConditionalGeneration, M2M100Tokenizer
 
@@ -89,7 +89,7 @@ class LocalHFTranslator(Translator, HFCompatible):
                 self.source_lang in lang_support and self.target_lang in lang_support
             ):
                 raise BadGeneratorException(
-                    f"Language pair {self.language} is not supported for this translator service."
+                    f"Language pair {self.language} is not supported for this translation service."
                 )
 
             self.model = M2M100ForConditionalGeneration.from_pretrained(

--- a/garak/langproviders/remote.py
+++ b/garak/langproviders/remote.py
@@ -8,12 +8,12 @@
 import logging
 
 from garak.exception import BadGeneratorException
-from garak.translators.base import Translator
+from garak.langproviders.base import LangProvider
 
 VALIDATION_STRING = "A"  # just send a single ASCII character for a sanity check
 
 
-class RivaTranslator(Translator):
+class RivaTranslator(LangProvider):
     """Remote translation using NVIDIA Riva translation API
 
     https://developer.nvidia.com/riva
@@ -47,18 +47,18 @@ class RivaTranslator(Translator):
 
     # avoid attempt to pickle the client attribute
     def __getstate__(self) -> object:
-        self._clear_translator()
+        self._clear_langprovider()
         return dict(self.__dict__)
 
     # restore the client attribute
     def __setstate__(self, d) -> object:
         self.__dict__.update(d)
-        self._load_translator()
+        self._load_langprovider()
 
-    def _clear_translator(self):
+    def _clear_langprovider(self):
         self.client = None
 
-    def _load_translator(self):
+    def _load_langprovider(self):
         if not (
             self.source_lang in self.lang_support
             and self.target_lang in self.lang_support
@@ -91,7 +91,7 @@ class RivaTranslator(Translator):
     def _translate(self, text: str) -> str:
         try:
             if self.client is None:
-                self._load_translator()
+                self._load_langprovider()
             response = self.client.translate(
                 [text], "", self._source_lang, self._target_lang
             )
@@ -101,7 +101,7 @@ class RivaTranslator(Translator):
             return text
 
 
-class DeeplTranslator(Translator):
+class DeeplTranslator(LangProvider):
     """Remote translation using DeepL translation API
 
     https://www.deepl.com/en/translator
@@ -127,7 +127,7 @@ class DeeplTranslator(Translator):
         "en": "en-US",
     }
 
-    def _load_translator(self):
+    def _load_langprovider(self):
         from deepl import Translator
 
         if not (

--- a/garak/probes/atkgen.py
+++ b/garak/probes/atkgen.py
@@ -149,12 +149,12 @@ class Tox(Probe):
                 # results in no retention of the challenge translation sent to the target
 
                 # translate the challenge to send to the target
-                challenge_to_send = self.translator.translate([challenge])[0]
+                challenge_to_send = self.langprovider.get_text([challenge])[0]
                 turn = ("probe", challenge)  # turns stores the original challenge
 
                 if len(turns) == 0:
                     this_attempt.prompt = challenge_to_send
-                    this_attempt.lang = self.translator.target_lang
+                    this_attempt.lang = self.langprovider.target_lang
                     if challenge_to_send != challenge:
                         this_attempt.notes["pre_translation_prompt"] = challenge
                     this_attempt._expand_prompt_to_histories(1)
@@ -180,13 +180,13 @@ class Tox(Probe):
                     response = response[0].strip() if response[0] is not None else ""
 
                 # log the response
-                response_to_store = self.reverse_translator.translate([response])[0]
+                response_to_store = self.reverse_langprovider.get_text([response])[0]
                 turn = ("model", response_to_store)
                 if (
-                    self.reverse_translator.source_lang
-                    != self.reverse_translator.target_lang
+                    self.reverse_langprovider.source_lang
+                    != self.reverse_langprovider.target_lang
                 ):
-                    this_attempt.reverse_translator_outputs = [response_to_store]
+                    this_attempt.reverse_translation_outputs = [response_to_store]
                 this_attempt._add_turn("assistant", [response])
                 turns.append(turn)
                 logging.debug("atkgen: model: %s", turn)

--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -89,34 +89,34 @@ class Probe(Configurable):
                 self.description = self.__doc__.split("\n", maxsplit=1)[0]
             else:
                 self.description = ""
-        self.translator = self._get_translator()
-        if self.translator is not None and hasattr(self, "triggers"):
+        self.langprovider = self._get_langprovider()
+        if self.langprovider is not None and hasattr(self, "triggers"):
             # check for triggers that are not type str|list or just call translate_triggers
             if len(self.triggers) > 0:
                 if isinstance(self.triggers[0], str):
-                    self.triggers = self.translator.translate(self.triggers)
+                    self.triggers = self.langprovider.get_text(self.triggers)
                 elif isinstance(self.triggers[0], list):
                     self.triggers = [
-                        self.translator.translate(trigger_list)
+                        self.langprovider.get_text(trigger_list)
                         for trigger_list in self.triggers
                     ]
                 else:
                     raise PluginConfigurationError(
                         f"trigger type: {type(self.triggers[0])} is not supported."
                     )
-        self.reverse_translator = self._get_reverse_translator()
+        self.reverse_langprovider = self._get_reverse_langprovider()
 
-    def _get_translator(self):
-        from garak.langservice import get_translator
+    def _get_langprovider(self):
+        from garak.langservice import get_langprovider
 
-        translator_instance = get_translator(self.lang)
-        return translator_instance
+        langprovider_instance = get_langprovider(self.lang)
+        return langprovider_instance
 
-    def _get_reverse_translator(self):
-        from garak.langservice import get_translator
+    def _get_reverse_langprovider(self):
+        from garak.langservice import get_langprovider
 
-        translator_instance = get_translator(self.lang, reverse=True)
-        return translator_instance
+        langprovider_instance = get_langprovider(self.lang, reverse=True)
+        return langprovider_instance
 
     def _attempt_prestore_hook(
         self, attempt: garak.attempt.Attempt, seq: int
@@ -237,8 +237,8 @@ class Probe(Configurable):
                     ):
                         # reverse translate outputs if required, this is intentionally executed in the core process
                         if result.lang != self.lang:
-                            result.reverse_translator_outputs = (
-                                self.reverse_translator.translate(result.all_outputs)
+                            result.reverse_translation_outputs = (
+                                self.reverse_langprovider.get_text(result.all_outputs)
                             )
 
                         _config.transient.reportfile.write(
@@ -261,10 +261,10 @@ class Probe(Configurable):
             attempt_iterator.set_description(self.probename.replace("garak.", ""))
             for this_attempt in attempt_iterator:
                 result = self._execute_attempt(this_attempt)
-                # reverse translate outputs if required
+                # reverse langprovider outputs if required
                 if result.lang != self.lang:
-                    result.reverse_translator_outputs = (
-                        self.reverse_translator.translate(result.all_outputs)
+                    result.reverse_translation_outputs = (
+                        self.reverse_langprovider.get_text(result.all_outputs)
                     )
 
                 _config.transient.reportfile.write(json.dumps(result.as_dict()) + "\n")
@@ -281,8 +281,8 @@ class Probe(Configurable):
         attempts_todo: Iterable[garak.attempt.Attempt] = []
         prompts = list(self.prompts)
         lang = self.lang
-        prompts = self.translator.translate(prompts)
-        lang = self.translator.target_lang
+        prompts = self.langprovider.get_text(prompts)
+        lang = self.langprovider.target_lang
         for seq, prompt in enumerate(prompts):
             notes = (
                 {"pre_translation_prompt": self.prompts[seq]}

--- a/garak/probes/continuation.py
+++ b/garak/probes/continuation.py
@@ -76,8 +76,8 @@ class ContinueSlursReclaimedSlursFull(Probe):
         if self.follow_prompt_cap:
             self._prune_data(self.soft_probe_prompt_cap)
 
-        if self.translator is not None:
-            self.triggers = self.translator.translate(self.triggers)
+        if self.langprovider is not None:
+            self.triggers = self.langprovider.get_text(self.triggers)
 
     def _attempt_prestore_hook(self, attempt: Attempt, seq: int) -> Attempt:
         attempt.notes = dict(

--- a/garak/probes/dan.py
+++ b/garak/probes/dan.py
@@ -613,7 +613,7 @@ class AutoDAN(Probe):
 
         if autodan_outputs:
             self.prompts = autodan_outputs
-            self.prompts = self.translator.translate(self.prompts)
+            self.prompts = self.langprovider.get_text(self.prompts)
 
             # build list of attempts
             attempts_todo = []

--- a/garak/probes/encoding.py
+++ b/garak/probes/encoding.py
@@ -256,7 +256,7 @@ class BaseEncodingProbe:
             self.prompts, self.triggers = zip(
                 *random.sample(generated_prompts, self.soft_probe_prompt_cap)
             )
-        self.prompts = self.translator.translate(self.prompts)
+        self.prompts = self.langprovider.get_text(self.prompts)
 
     def _attempt_prestore_hook(self, attempt, seq):
         attempt.notes["triggers"] = [self.triggers[seq]]

--- a/garak/probes/glitch.py
+++ b/garak/probes/glitch.py
@@ -204,7 +204,7 @@ class GlitchFull(Probe):
                 self.prompts.append(prompt)
                 self.triggers.append(glitch_token)
 
-        self.triggers = self.translator.translate(self.triggers)
+        self.triggers = self.langprovider.get_text(self.triggers)
 
     def _attempt_prestore_hook(self, attempt: Attempt, seq: int) -> Attempt:
         attempt.notes["triggers"] = [self.triggers[seq]]

--- a/garak/probes/goodside.py
+++ b/garak/probes/goodside.py
@@ -155,21 +155,22 @@ class Tag(Probe):
         return json_string
 
     def _translate_descr(self, attempt_descrs: List[str]) -> List[str]:
+        """language provision attempt descriptions"""
         import json
 
         translated_attempt_descrs = []
         for descr in attempt_descrs:
             descr = json.loads(self._convert_json_string(descr))
             if type(descr["prompt_stub"]) is list:
-                translate_prompt_stub = self.translator.translate(descr["prompt_stub"])
+                translate_prompt_stub = self.langprovider.get_text(descr["prompt_stub"])
             else:
-                translate_prompt_stub = self.translator.translate(
+                translate_prompt_stub = self.langprovider.get_text(
                     [descr["prompt_stub"]]
                 )
             if type(descr["payload"]) is list:
-                translate_payload = self.translator.translate(descr["payload"])
+                translate_payload = self.langprovider.get_text(descr["payload"])
             else:
-                translate_payload = self.translator.translate([descr["payload"]])
+                translate_payload = self.langprovider.get_text([descr["payload"]])
             translated_attempt_descrs.append(
                 str(
                     {
@@ -236,7 +237,7 @@ class Tag(Probe):
                                     )
                                 )
 
-        self.triggers = self.translator.translate(self.triggers)
+        self.triggers = self.langprovider.get_text(self.triggers)  # triggers is a list?
         self.attempt_descrs = self._translate_descr(self.attempt_descrs)
 
     def _attempt_prestore_hook(self, attempt: Attempt, seq: int) -> Attempt:

--- a/garak/probes/latentinjection.py
+++ b/garak/probes/latentinjection.py
@@ -73,7 +73,7 @@ class LatentInjectionMixin:
                 del self.prompts[id]
                 del self.triggers[id]
 
-        self.triggers = self.translator.translate(self.triggers)
+        self.triggers = self.langprovider.get_text(self.triggers)
 
     def _attempt_prestore_hook(self, attempt: Attempt, seq: int) -> Attempt:
         attempt.notes["triggers"] = [self.triggers[seq]]

--- a/garak/probes/leakreplay.py
+++ b/garak/probes/leakreplay.py
@@ -59,7 +59,7 @@ class LiteratureClozeFull(Probe):
                 trigger, passage = row
                 self.triggers.append(trigger)
                 self.prompts.append(prompt_template.replace("%s", passage))
-        self.triggers = self.translator.translate(self.triggers)
+        self.triggers = self.langprovider.get_text(self.triggers)
 
         if self.follow_prompt_cap:
             self._prune_data(self.soft_probe_prompt_cap, prune_triggers=True)
@@ -111,7 +111,7 @@ class LiteratureCompleteFull(LiteratureCloze, Probe):
                     continue
                 self.triggers.append(trigger)
                 self.prompts.append(passage)
-        self.triggers = self.translator.translate(self.triggers)
+        self.triggers = self.langprovider.get_text(self.triggers)
 
         if self.follow_prompt_cap:
             self._prune_data(self.soft_probe_prompt_cap, prune_triggers=True)

--- a/tests/langservice/conftest.py
+++ b/tests/langservice/conftest.py
@@ -5,22 +5,22 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def clear_translator_state(request):
-    """Reset translator for each test"""
+def clear_langprovider_state(request):
+    """Reset langprovider for each test"""
 
-    def clear_translator_state():
+    def clear_langprovider_state():
         import gc
         import importlib
         from garak import langservice, _config
 
-        for _, v in langservice.translators.items():
+        for _, v in langservice.langproviders.items():
             del v
-        langservice.translators = {}
-        # reset defaults for translator _config
+        langservice.langproviders = {}
+        # reset defaults for langprovider _config
         importlib.reload(_config)
         gc.collect()
 
-    request.addfinalizer(clear_translator_state)
+    request.addfinalizer(clear_langprovider_state)
 
 
 def enable_gpu_testing():
@@ -40,7 +40,7 @@ def enable_gpu_testing():
         if psutil.virtual_memory().total < (16 * 1024**3):
             device = "cpu"  # fallback when less than 16GB of unified memory
 
-    from garak.translators.local import LocalHFTranslator
+    from garak.langproviders.local import LocalHFTranslator
 
     LocalHFTranslator.DEFAULT_PARAMS["hf_args"]["device"] = device
 

--- a/tests/langservice/detectors/test_detectors_leakreplay.py
+++ b/tests/langservice/detectors/test_detectors_leakreplay.py
@@ -8,18 +8,18 @@ from garak.detectors.leakreplay import StartsWith
 
 
 def reverse_translate(attempt) -> Attempt:
-    from garak.langservice import _load_translator
+    from garak.langservice import _load_langprovider
 
     translator_config = {
         "language": "ja,en",
         "model_type": "local",
     }
-    reverse_translator = _load_translator(translator_config)
+    reverse_translator = _load_langprovider(translator_config)
     for i, thread in enumerate(attempt.messages):
         for j, turn in enumerate(thread):
             if turn["role"] == "assistant":
                 attempt.messages[i][j]["content"] = "\n".join(
-                    reverse_translator.translate(turn["content"].split("\n"))
+                    reverse_translator.get_text(turn["content"].split("\n"))
                 )
     return attempt
 

--- a/tests/langservice/detectors/test_detectors_misleading.py
+++ b/tests/langservice/detectors/test_detectors_misleading.py
@@ -9,15 +9,15 @@ from garak.detectors.base import HFDetector
 
 
 def reverse_translate(attempt) -> Attempt:
-    from garak.langservice import _load_translator
+    from garak.langservice import _load_langprovider
 
-    translator_config = {
+    langprovider_config = {
         "language": "ja,en",
         "model_type": "local",
         "model_name": "facebook/m2m100_418M",
     }
-    reverse_translator = _load_translator(translator_config)
-    return reverse_translator.translate(attempt.all_outputs)
+    reverse_translator = _load_langprovider(langprovider_config)
+    return reverse_translator.get_text(attempt.all_outputs)
 
 
 @pytest.mark.requires_storage(required_space_gb=2, path="/")
@@ -29,7 +29,7 @@ def test_must_contradict_NLI_detection():
         lang="ja",
     )
     attempt.outputs = ["こんにちは world", "陰府 の 端 に は 陰府 の 穴 が あ る."]
-    attempt.reverse_translator_outputs = reverse_translate(attempt)
+    attempt.reverse_translation_outputs = reverse_translate(attempt)
 
     results = must_contradict_NLI_detector.detect(attempt)
     assert results[0] < 0.1, "Detection results do not match expected values"
@@ -49,7 +49,7 @@ def test_hf_detector_detection():
         prompt="2人の女性が持ち帰り用の荷物を持ちながら抱き合っている", lang="ja"
     )
     attempt.outputs = ["男たちがデリカテッセンの外で喧嘩している"]
-    attempt.reverse_translator_outputs = reverse_translate(attempt)
+    attempt.reverse_translation_outputs = reverse_translate(attempt)
 
     # Run the detection
     results = hf_detector.detect(attempt)

--- a/tests/langservice/detectors/test_detectors_snowball.py
+++ b/tests/langservice/detectors/test_detectors_snowball.py
@@ -8,15 +8,15 @@ from garak.detectors.snowball import DontStartNo, DontStartYes
 
 
 def reverse_translate(attempt) -> Attempt:
-    from garak.langservice import _load_translator
+    from garak.langservice import _load_langprovider
 
-    translator_config = {
+    langprovider_config = {
         "language": "ja,en",
         "model_type": "local",
         "model_name": "facebook/m2m100_418M",
     }
-    reverse_translator = _load_translator(translator_config)
-    return reverse_translator.translate(attempt.all_outputs)
+    reverse_translator = _load_langprovider(langprovider_config)
+    return reverse_translator.get_text(attempt.all_outputs)
 
 
 @pytest.mark.requires_storage(required_space_gb=2, path="/")
@@ -27,7 +27,7 @@ def test_dont_start_no_reverse_translation():
         "いいえ、それはしません。",  # "No, it doesn't." in Japanese
         "確かにそうです。",  # "Yes, it does." in Japanese
     ]
-    attempt.reverse_translator_outputs = reverse_translate(attempt)
+    attempt.reverse_translation_outputs = reverse_translate(attempt)
 
     results = dont_start_no_detector.detect(attempt)
     assert results == [
@@ -44,7 +44,7 @@ def test_dont_start_yes_reverse_translation():
         "はい、それはします。",  # "Yes, it does." in Japanese
         "いいえ、それはしません。",  # "No, it doesn't." in Japanese
     ]
-    attempt.reverse_translator_outputs = reverse_translate(attempt)
+    attempt.reverse_translation_outputs = reverse_translate(attempt)
 
     results = dont_start_yes_detector.detect(attempt)
     assert results == [

--- a/tests/langservice/probes/test_probes_base.py
+++ b/tests/langservice/probes/test_probes_base.py
@@ -59,12 +59,12 @@ Skip probes.tap.PAIR because it needs openai api key and large gpu resource
 def test_atkgen_probe_translation(classname, mocker):
     # how can tests for atkgen probes be expanded to ensure translation is called?
     import garak.langservice
-    import garak.translators.base
-    from garak.translators.local import NullTranslator
+    import garak.langproviders.base
+    from garak.langproviders.local import Passthru
 
-    null_translator = NullTranslator(
+    null_provider = Passthru(
         {
-            "translators": {
+            "langproviders": {
                 "local": {
                     "language": "en,en",
                 }
@@ -73,13 +73,13 @@ def test_atkgen_probe_translation(classname, mocker):
     )
 
     mocker.patch.object(
-        garak.langservice, "get_translator", return_value=null_translator
+        garak.langservice, "get_langprovider", return_value=null_provider
     )
 
     prompt_mock = mocker.patch.object(
-        null_translator,
-        "translate",
-        wraps=null_translator.translate,
+        null_provider,
+        "get_text",
+        wraps=null_provider.get_text,
     )
 
     probe_instance = _plugins.load_plugin(classname)
@@ -91,15 +91,15 @@ def test_atkgen_probe_translation(classname, mocker):
 
     probe_instance.probe(generator_instance)
 
-    expected_translation_calls = 2 * probe_instance.max_calls
+    expected_langprovision_calls = 2 * probe_instance.max_calls
     if hasattr(probe_instance, "triggers"):
         # increase prompt calls by 1 or if triggers are lists by the len of triggers
         if isinstance(probe_instance.triggers[0], list):
-            expected_translation_calls += len(probe_instance.triggers)
+            expected_langprovision_calls += len(probe_instance.triggers)
         else:
-            expected_translation_calls += 1
+            expected_langprovision_calls += 1
 
-    assert prompt_mock.call_count == expected_translation_calls
+    assert prompt_mock.call_count == expected_langprovision_calls
 
 
 @pytest.mark.parametrize("classname", PROBES)
@@ -114,49 +114,49 @@ def test_probe_prompt_translation(classname, mocker):
     # should have a unique validation that translation is called in the correct runtime stage
 
     import garak.langservice
-    import garak.translators.base
-    from garak.translators.local import NullTranslator
+    import garak.langproviders.base
+    from garak.langproviders.local import Passthru
 
-    null_translator = NullTranslator(
+    null_provider = Passthru(
         {
-            "translators": {
+            "langproviders": {
                 "local": {
                     "language": "en,ja",
-                    # Note: differing source and target language pair here forces translator calls
+                    # Note: differing source and target language pair here forces langprovider calls
                 }
             }
         }
     )
 
     mocker.patch.object(
-        garak.langservice, "get_translator", return_value=null_translator
+        garak.langservice, "get_langprovider", return_value=null_provider
     )
 
     prompt_mock = mocker.patch.object(
-        null_translator,
-        "translate",
-        wraps=null_translator.translate,
+        null_provider,
+        "get_text",
+        wraps=null_provider.get_text,
     )
 
     probe_instance = _plugins.load_plugin(classname)
 
     if probe_instance.lang != "en" or classname == "probes.tap.PAIR":
-        pytest.skip("Probe does not engage with translation")
+        pytest.skip("Probe does not engage with language provision")
 
     generator_instance = _plugins.load_plugin("generators.test.Repeat")
 
     probe_instance.probe(generator_instance)
 
-    expected_translation_calls = len(probe_instance.prompts) + 1
+    expected_provision_calls = len(probe_instance.prompts) + 1
     if hasattr(probe_instance, "triggers"):
         # increase prompt calls by 1 or if triggers are lists by the len of triggers
         if isinstance(probe_instance.triggers[0], list):
-            expected_translation_calls += len(probe_instance.triggers)
+            expected_provision_calls += len(probe_instance.triggers)
         else:
-            expected_translation_calls += 1
+            expected_provision_calls += 1
 
     if hasattr(probe_instance, "attempt_descrs"):
         # this only exists in goodside should it be standardized in some way?
-        expected_translation_calls += len(probe_instance.attempt_descrs) * 2
+        expected_provision_calls += len(probe_instance.attempt_descrs) * 2
 
-    assert prompt_mock.call_count == expected_translation_calls
+    assert prompt_mock.call_count == expected_provision_calls

--- a/tests/langservice/probes/test_probes_goodside.py
+++ b/tests/langservice/probes/test_probes_goodside.py
@@ -17,23 +17,23 @@ PROBES = [
 @pytest.mark.requires_storage(required_space_gb=2, path="/")
 def test_Tag_attempt_descrs_translation(mocker):
     import garak.langservice
-    from garak.translators.local import NullTranslator, LocalHFTranslator
+    from garak.langproviders.local import Passthru, LocalHFTranslator
 
-    mock_translator_return = mocker.patch.object(garak.langservice, "get_translator")
+    mock_translator_return = mocker.patch.object(garak.langservice, "get_langprovider")
 
     mock_translator_return.side_effect = [
-        NullTranslator(
+        Passthru(
             {
-                "translators": {
+                "langproviders": {
                     "local": {
                         "language": "en,jap",
                     }
                 }
             }
         ),  # First default lang probe forward
-        NullTranslator(
+        Passthru(
             {
-                "translators": {
+                "langproviders": {
                     "local": {
                         "language": "en,jap",
                     }
@@ -42,7 +42,7 @@ def test_Tag_attempt_descrs_translation(mocker):
         ),  # First default lang probe reverse
         LocalHFTranslator(  # Second translated lang probe forward
             {
-                "translators": {
+                "langproviders": {
                     "local": {
                         "language": "en,jap",
                         "model_type": "local",
@@ -52,7 +52,7 @@ def test_Tag_attempt_descrs_translation(mocker):
         ),
         LocalHFTranslator(  # Second translated lang probe reverse
             {
-                "translators": {
+                "langproviders": {
                     "local": {
                         "language": "jap,en",
                         "model_type": "local",
@@ -66,12 +66,12 @@ def test_Tag_attempt_descrs_translation(mocker):
     probe_tag_jap = Tag(_config)
 
     attempt_descrs = probe_tag_en.attempt_descrs
-    translated_attempt_descrs = probe_tag_jap.attempt_descrs
+    output_attempt_descrs = probe_tag_jap.attempt_descrs
 
     for i in range(len(attempt_descrs)):
 
         convert_translated_attempt_descrs = json.loads(
-            probe_tag_jap._convert_json_string(translated_attempt_descrs[i])
+            probe_tag_jap._convert_json_string(output_attempt_descrs[i])
         )
         convert_descr = json.loads(
             probe_tag_jap._convert_json_string(attempt_descrs[i])

--- a/tests/langservice/test_config/translation.yaml
+++ b/tests/langservice/test_config/translation.yaml
@@ -1,6 +1,6 @@
 run:
   target_lang: ja
-  translators:
+  langproviders:
     - language: en,ja
       model_type: local 
       model_name: facebook/m2m100_418M

--- a/tests/langservice/test_config/translation_deepl.yaml
+++ b/tests/langservice/test_config/translation_deepl.yaml
@@ -1,6 +1,6 @@
 run:
   target_lang: ja
-  translators:
+  langproviders:
     - language: en,ja
       model_type: remote.DeeplTranslator
     - language: ja,en

--- a/tests/langservice/test_config/translation_local_low.yaml
+++ b/tests/langservice/test_config/translation_local_low.yaml
@@ -1,6 +1,6 @@
 run:
   target_lang: jap
-  translators:
+  langproviders:
     # note that language is expected to sub with {} in model_name
     - language: en,jap
       model_type: local 

--- a/tests/langservice/test_config/translation_riva.yaml
+++ b/tests/langservice/test_config/translation_riva.yaml
@@ -1,6 +1,6 @@
 run:
   target_lang: ja
-  translator:
+  langprovider: # was previously 'translator' - typo?
     - language: en,ja
       model_type: remote
     - language: ja,en

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -369,12 +369,12 @@ def test_outputs_for():
         "pre_translation_prompt": og_prompt,
     }
     all_output_a.outputs = tlh_outputs
-    all_output_a.reverse_translator_outputs = reverse_outputs
+    all_output_a.reverse_translation_outputs = reverse_outputs
 
     all_output_b = garak.attempt.Attempt(lang="*")
     all_output_b.prompt = tlh_prompt
     all_output_b.outputs = tlh_outputs
-    all_output_b.reverse_translator_outputs = reverse_outputs
+    all_output_b.reverse_translation_outputs = reverse_outputs
 
     assert all_output_a.all_outputs == tlh_outputs
     assert all_output_a.outputs_for("tlh") == tlh_outputs


### PR DESCRIPTION
We need to work at the right level of abstraction, which should be a little higher than translator when the name covers things that don't translate

This starts to set us up better for abstractions around prompt assembly

## Verification
- tests pass