### PR TITLE
Support stripping until end think token given empty skip_seq_start in config

### DIFF
--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -100,26 +100,39 @@ class Generator(Configurable):
             re.escape(self.skip_seq_start) + ".*?" + re.escape(self.skip_seq_end)
         )
         rx_missing_final = re.escape(self.skip_seq_start) + ".*?$"
+        rx_missing_start = ".*?" + re.escape(self.skip_seq_end)
+        
+        if self.skip_seq_start == "":
+            complete_seqs_removed = [
+                (
+                    re.sub(rx_missing_start, "", o, flags=re.DOTALL | re.MULTILINE)
+                    if o is not None
+                    else None
+                )
+                for o in outputs
+            ]
+            return complete_seqs_removed
 
-        complete_seqs_removed = [
-            (
-                re.sub(rx_complete, "", o, flags=re.DOTALL | re.MULTILINE)
-                if o is not None
-                else None
-            )
-            for o in outputs
-        ]
+        else:
+            complete_seqs_removed = [
+                (
+                    re.sub(rx_complete, "", o, flags=re.DOTALL | re.MULTILINE)
+                    if o is not None
+                    else None
+                )
+                for o in outputs
+            ]
 
-        partial_seqs_removed = [
-            (
-                re.sub(rx_missing_final, "", o, flags=re.DOTALL | re.MULTILINE)
-                if o is not None
-                else None
-            )
-            for o in complete_seqs_removed
-        ]
+            partial_seqs_removed = [
+                (
+                    re.sub(rx_missing_final, "", o, flags=re.DOTALL | re.MULTILINE)
+                    if o is not None
+                    else None
+                )
+                for o in complete_seqs_removed
+            ]
 
-        return partial_seqs_removed
+            return partial_seqs_removed
 
     def generate(
         self, prompt: str, generations_this_call: int = 1

--- a/tests/generators/test_generators.py
+++ b/tests/generators/test_generators.py
@@ -152,3 +152,22 @@ def test_skip_seq():
     test_truncated_think_no_answer = "<think>thinking a bit</think><think>this process required a lot of details that is processed by"
     r = g.generate(test_truncated_think_no_answer)
     assert r[0] == "", "truncated skip strings should be omitted"
+
+    test_has_only_end_think = "some thinking</think>" + target_string
+    r = g.generate(test_has_only_end_think)
+    assert r[0] == test_has_only_end_think, "for non empty skip_seq_start, if skip_seq_start is not found and skip_seq_end is found, no stripping should be done"
+
+    g.skip_seq_start = ""
+    g.skip_seq_end = "</think>"
+    r = g.generate(test_has_only_end_think)
+    assert r[0] == target_string, "for empty skip_seq_start, if skip_seq_start is not found and skip_seq_end is found, strip from start of output till skip_seq_end"
+    
+    test_multiple_end_thinks = "some thinking</think><think>some more thinking</think>" + target_string
+    r = g.generate(test_multiple_end_thinks)
+    assert r[0] == target_string, "for empty skip_seq_start, if skip_seq_start is not found and multiple skip_seq_end is found, strip from start of output till last skip_seq_end"
+
+    test_multiple_end_thinks_discontinuous = "some thinking</think>" + target_string +"<think>some more thinking</think>"
+    r = g.generate(test_multiple_end_thinks_discontinuous)
+    assert r[0] == "", "for empty skip_seq_start, if skip_seq_start is not found and multiple skip_seq_end is found, strip from start of output till last skip_seq_end"
+
+


### PR DESCRIPTION
For some distilled reasoning models such as `deepseek-ai/DeepSeek-R1-Distill-Llama-8B` and `deepseek-ai/DeepSeek-R1-Distill-Qwen-7B`, the model usually needs the start thinking token (`<think>`) to be present at the end of model input and the generated response typically looks like `"some thinking </think> response"`. If we want to strip the thinking tokens before running detectors, instead of removing the content between `<think>` and `</think>`, we need to strip from start of the response to  `</think>`.  
Currently if we set `skip_seq_start` to `""` the output becomes empty. This PR changes the behavior when `skip_seq_start = ""` to strip from start of response till the last occurrence of `skip_seq_end`.


## Verification

List the steps needed to make sure this thing works

- [x] Updated test `tests.generators.test_generators.test_skip_seq` to test for the desired stripping behavior. Test passes. 

- [x] Sample config for testing:
```yaml
run:
  generations: 5

plugins:
  probe_spec: grandma.Slurs
  extended_detectors: true
  probes:
    encoding:
      payloads:
        - default
        - xss
        - slur_terms
  model_type: huggingface
  model_name: deepseek-ai/DeepSeek-R1-Distill-Llama-8B
  generators:
    huggingface: 
      temperature: 0.6
      top_p: 0.95 
      max_tokens: 1024
      use_chat: true
      skip_seq_start: ""
      skip_seq_end: "</think>"

system:
  parallel_attempts: 32
  lite: false
```
The change was verified by comparing hitlogs generated using the above config and with a variant where `skip_seq_start` and `skip_seq_end` are not specified. 
In both cases, `<think>` does not occur in any of the responses. When `skip_seq_start` and `skip_seq_end` are not specified, most responses contain `</think>` and when we specify `skip_seq_start = "", skip_seq_end: "</think>"`, none of the responses contain `</think>`, and none of them are empty (which is the result before the change). 
Additionally, also tested by comparing responses in hitlogs for probe `grandma.Slurs` using model `meta-llama/Llama-3.1-8B-Instruct` which does not produce thinking tokens to confirm that the logged responses are similar when `skip_seq_start` and `skip_seq_end` are not specified, when `skip_seq_start = "", skip_seq_end: "</think>"` and `skip_seq_start = "<think>", skip_seq_end: "</think>"`
Testing was done on A6000 and A100 GPUs.

- [x] All tests pass: `python -m pytest tests/`
```
2555 passed, 82 skipped in 636.91s (0:10:36)
```

## Note:

Black formatting was not done on this PR as it resulted in changes in a number of extra files unrelated to the PR:
