### PR TITLE
cap `litellm` max version to avoid their windows bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ dependencies = [
   "ecoji>=0.1.1",
   "deepl==1.17.0",
   "fschat>=0.2.36",
-  "litellm>=1.41.21,!=1.67.2",
+  "litellm>=1.41.21,<1.67.2",
   "jsonpath-ng>=1.6.1",
   "huggingface_hub>=0.21.0",
   'python-magic-bin>=0.4.14; sys_platform == "win32"',

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ zalgolib>=0.2.2
 ecoji>=0.1.1
 deepl==1.17.0
 fschat>=0.2.36
-litellm>=1.41.21,!=1.67.2
+litellm>=1.41.21,<1.67.2
 jsonpath-ng>=1.6.1
 huggingface_hub>=0.21.0
 python-magic-bin>=0.4.14; sys_platform == "win32"


### PR DESCRIPTION
cf #1179

LiteLLM hasn't fixed this bug yet, capping max version