### PR TITLE
Add -no-cnv flag support to ggml generators

### DIFF
--- a/garak/generators/ggml.py
+++ b/garak/generators/ggml.py
@@ -56,6 +56,7 @@ class GgmlGenerator(Generator):
             "--top-p": self.top_p,
             "--temp": self.temperature,
             "-s": self.seed,
+            "-no-cnv": None,
         }
 
     def __init__(self, name="", config_root=_config):
@@ -108,8 +109,8 @@ class GgmlGenerator(Generator):
         ]
         # test all params for None type
         for key, value in self.command_params().items():
+            command.append(key)
             if value is not None:
-                command.append(key)
                 command.append(value)
         command = [str(param) for param in command]
         if _config.system.verbose > 1:


### PR DESCRIPTION
By default, garak ggml generators invoke the ggml main binary (now llama-cli) in interactive mode, causing the process to hang and never return control to garak.

To allow for future compatibility with cli arguments to the ggml binary extra flags and parameters can be passed via configuration.

* add `-no-cnv` as a default added flag
* allow supply of a list of additional flags
* allow supply of additional arguement and value pairs
* keep suppression of projected params when set to `None`

## Verification

List the steps needed to make sure this thing works

- [ ] Test local `GgmlGenerator` configuration
- [ ] Test suppression of `GgmlGenerator` `-no-cnv` flag with following config:
``` json
{
  "ggml": {
    "GgmlGenerator": {
      "extra_ggml_flags": null
    }
  }
}
