### PR TITLE
replicate generator pickle support improvements

### DIFF
--- a/garak/generators/replicate.py
+++ b/garak/generators/replicate.py
@@ -45,7 +45,23 @@ class ReplicateGenerator(Generator):
         if self.api_key is not None:
             # ensure the token is in the expected runtime env var
             os.environ[self.ENV_VAR] = self.api_key
-        self.replicate = importlib.import_module("replicate")
+        self.client = importlib.import_module("replicate")
+
+    # avoid attempt to pickle the client attribute
+    def __getstate__(self) -> object:
+        self._clear_client()
+        return dict(self.__dict__)
+
+    # restore the client attribute
+    def __setstate__(self, d) -> object:
+        self.__dict__.update(d)
+        self._load_client()
+
+    def _load_client(self):
+        self.client = importlib.import_module("replicate")
+
+    def _clear_client(self):
+        self.client = None
 
     @backoff.on_exception(
         backoff.fibo, replicate.exceptions.ReplicateError, max_value=70
@@ -53,7 +69,9 @@ class ReplicateGenerator(Generator):
     def _call_model(
         self, prompt: str, generations_this_call: int = 1
     ) -> List[Union[str, None]]:
-        response_iterator = self.replicate.run(
+        if self.client is None:
+            self.client = importlib.import_module("replicate")
+        response_iterator = self.client.run(
             self.name,
             input={
                 "prompt": prompt,
@@ -79,7 +97,9 @@ class InferenceEndpoint(ReplicateGenerator):
     def _call_model(
         self, prompt, generations_this_call: int = 1
     ) -> List[Union[str, None]]:
-        deployment = self.replicate.deployments.get(self.name)
+        if self.client is None:
+            self.client = importlib.import_module("replicate")
+        deployment = self.client.deployments.get(self.name)
         prediction = deployment.predictions.create(
             input={
                 "prompt": prompt,

--- a/tests/generators/test_muiltiprocessing_support.py
+++ b/tests/generators/test_muiltiprocessing_support.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import pytest
+import importlib
+
+
+# TODO: expand this when all `parallel_capable` generators can be evaluated
+# GENERATORS = [
+#     classname
+#     for (classname, active) in _plugins.enumerate_plugins("generators")
+#     if _plugins.plugin_info(classname)["parallel_capable"]
+# ]
+GENERATORS = [
+    "generators.huggingface.InferenceAPI",
+    "generators.huggingface.InferenceEndpoint",
+    "generators.mistral.MistralGenerator",
+    "generators.nvcf.NvcfChat",
+    "generators.nvcf.NvcfCompletion",
+    "generators.replicate.InferenceEndpoint",
+    "generators.replicate.ReplicateGenerator",
+]
+
+MODEL_NAME = "gpt-3.5-turbo-instruct"
+ENV_VAR = os.path.abspath(
+    __file__
+)  # use test path as hint encase env changes are missed
+
+
+def build_test_instance(module_klass):
+    if hasattr(module_klass, "ENV_VAR"):
+        stored_env = os.getenv(module_klass.ENV_VAR, None)
+        os.environ[module_klass.ENV_VAR] = ENV_VAR
+    class_instance = module_klass(name=MODEL_NAME)
+    if stored_env is not None:
+        os.environ[module_klass.ENV_VAR] = stored_env
+    else:
+        del os.environ[module_klass.ENV_VAR]
+    return class_instance
+
+
+# helper method to pass mock config
+def generate_in_subprocess(*args):
+    generator = args[0]
+    return generator.name
+
+
+@pytest.mark.parametrize("classname", GENERATORS)
+def test_multiprocessing(classname):
+    parallel_attempts = 4
+    iterations = 2
+    namespace = classname[: classname.rindex(".")]
+    full_namespace = f"garak.{namespace}"
+    klass_name = classname[classname.rindex(".") + 1 :]
+    mod = importlib.import_module(full_namespace)
+    klass = getattr(mod, klass_name)
+    generator = build_test_instance(klass)
+    params = [
+        generator,
+        generator,
+        generator,
+    ]
+
+    for _ in range(iterations):
+        from multiprocessing import Pool
+
+        with Pool(parallel_attempts) as attempt_pool:
+            for result in attempt_pool.imap_unordered(generate_in_subprocess, params):
+                assert result is not None


### PR DESCRIPTION
fix #1160 

Following patterns established in `openai` add `_load` and `_clear` methods for client objects.  A number of other generators have be identified for potential enhancement for objects that cannot pickle in generators. These additional generators will be addressed separately.

## Verification

List the steps needed to make sure this thing works

- [ ] Test multiprocess generation
```
python3 -m garak -m replicate -n deepseek-ai/deepseek-v3 --p lmrc --parallel_requests 2 -g 3
```
- [ ] CI automation additions pass
