### PR TITLE
add arm64 runner to Linux testing

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -28,10 +28,11 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
         python-version: ["3.10","3.12"]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
This original goal of adding this was to gain visibility into dependencies that required extra env support on `arm64` vs `amd64` however the tooling required is in all runners by default.

For now, at the least, this will validate that arm64 can be supported.

## Verification

List the steps needed to make sure this thing works

- [ ] add CI/CD automation jobs pass
