### PR TITLE
feature: deferred loading and requirement pruning

### DIFF
--- a/garak/_plugins.py
+++ b/garak/_plugins.py
@@ -448,7 +448,7 @@ def load_plugin(path, break_on_fail=True, config_root=_config) -> object:
             exc_info=e,
         )
         if break_on_fail:
-            raise ModuleNotFoundError(e) from e
+            raise GarakException(e) from e
         else:
             return False
 
@@ -469,4 +469,4 @@ def _import_failed(import_module: str, calling_module: str):
     hint = f"💡 Try 'pip install {import_module}' to get it."
     logging.critical(msg)
     print(msg + "\n" + hint)
-    raise GarakException(msg)
+    raise ModuleNotFoundError(msg)

--- a/garak/_plugins.py
+++ b/garak/_plugins.py
@@ -448,7 +448,7 @@ def load_plugin(path, break_on_fail=True, config_root=_config) -> object:
             exc_info=e,
         )
         if break_on_fail:
-            raise GarakException(e) from e
+            raise ModuleNotFoundError(e) from e
         else:
             return False
 

--- a/garak/_plugins.py
+++ b/garak/_plugins.py
@@ -438,14 +438,6 @@ def load_plugin(path, break_on_fail=True, config_root=_config) -> object:
         if plugin_instance is None:
             plugin_instance = klass(config_root=config_root)
             PluginProvider.storeInstance(plugin_instance, config_root)
-        if len(extra_dependency_names) > 0:
-            for dependency_module_name in extra_dependency_names:
-                dependency_module_member = dependency_module_name.replace(".", "_")
-                setattr(
-                    plugin_instance,
-                    dependency_module_member,
-                    load_optional_module(dependency_module_name),
-                )
 
     except Exception as e:
         logging.warning(

--- a/garak/_plugins.py
+++ b/garak/_plugins.py
@@ -438,6 +438,15 @@ def load_plugin(path, break_on_fail=True, config_root=_config) -> object:
         if plugin_instance is None:
             plugin_instance = klass(config_root=config_root)
             PluginProvider.storeInstance(plugin_instance, config_root)
+        if len(extra_dependency_names) > 0:
+            for dependency_module_name in extra_dependency_names:
+                dependency_module_member = dependency_module_name.replace(".", "_")
+                setattr(
+                    plugin_instance,
+                    dependency_module_member,
+                    load_optional_module(dependency_module_name),
+                )
+
     except Exception as e:
         logging.warning(
             "Exception instantiating %s.%s: %s",

--- a/garak/_plugins.py
+++ b/garak/_plugins.py
@@ -440,3 +440,20 @@ def load_plugin(path, break_on_fail=True, config_root=_config) -> object:
             return False
 
     return plugin_instance
+
+
+def load_optional_module(module_name: str):
+    try:
+        m = importlib.import_module(module_name)
+    except ModuleNotFoundError:
+        requesting_module = Path(inspect.stack()[1].filename).name.replace(".py", "")
+        _import_failed(module_name, requesting_module)
+    return m
+
+
+def _import_failed(import_module: str, calling_module: str):
+    msg = f"⛔ Plugin '{calling_module}' requires Python module '{import_module}' but this isn't installed/available."
+    hint = f"💡 Try 'pip install {import_module}' to get it."
+    logging.critical(msg)
+    print(msg + "\n" + hint)
+    raise GarakException(msg)

--- a/garak/_plugins.py
+++ b/garak/_plugins.py
@@ -400,6 +400,18 @@ def load_plugin(path, break_on_fail=True, config_root=_config) -> object:
             ) from ve
         else:
             return False
+
+    full_plugin_name = ".".join((category, module_name, plugin_class_name))
+
+    # check cache for optional imports
+    extra_dependency_names = PluginCache.instance()[category][full_plugin_name][
+        "extra_dependency_names"
+    ]
+    if len(extra_dependency_names) > 0:
+        for dependency_module_name in extra_dependency_names:
+            if importlib.util.find_spec(dependency_module_name) is None:
+                _import_failed(dependency_module_name, full_plugin_name)
+
     module_path = f"garak.{category}.{module_name}"
     try:
         mod = importlib.import_module(module_path)

--- a/garak/buffs/base.py
+++ b/garak/buffs/base.py
@@ -27,6 +27,8 @@ class Buff(Configurable):
     doc_uri = ""
     lang = None  # set of languages this buff should be constrained to
     active = True
+    # list of strings naming modules required but not explicitly in garak by default
+    extra_dependency_names = []
 
     DEFAULT_PARAMS = {}
 

--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -27,6 +27,8 @@ class Detector(Configurable):
     accuracy = None
     active = True
     tags = []  # list of taxonomy categories per the MISP format
+    # list of strings naming modules required but not explicitly in garak by default
+    extra_dependency_names = []
 
     # support mainstream any-to-any large models
     # legal element for str list `modality['in']`: 'text', 'image', 'audio', 'video', '3d'

--- a/garak/exception.py
+++ b/garak/exception.py
@@ -36,3 +36,7 @@ class ConfigFailure(GarakException):
 
 class PayloadFailure(GarakException):
     """Problem instantiating/using payloads"""
+
+
+class GeneratorBackoffExceptionPlaceholder(GarakException):
+    """Placeholder used for lazy-loaded exceptions"""

--- a/garak/generators/azure.py
+++ b/garak/generators/azure.py
@@ -82,6 +82,7 @@ class AzureOpenAIGenerator(OpenAICompatible):
         return super()._validate_env_var()
 
     def _load_client(self):
+        self._load_deps()
         if self.model_name in openai_model_mapping:
             self.model_name = openai_model_mapping[self.model_name]
 

--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -44,9 +44,8 @@ class Generator(Configurable):
     supports_multiple_generations = (
         False  # can more than one generation be extracted per request?
     )
-    extra_dependency_names = (
-        []
-    )  # list of strings naming modules required but not explicitly in garak by default
+    # list of strings naming modules required but not explicitly in garak by default
+    extra_dependency_names = []
 
     def __init__(self, name="", config_root=_config):
         self._load_config(config_root)

--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -71,7 +71,7 @@ class Generator(Configurable):
         # load external dependencies. should be invoked at construction and
         # in _client_load (if used)
         for extra_dependency in self.extra_dependency_names:
-            extra_dep_name = extra_dependency.replace(".", "_")
+            extra_dep_name = extra_dependency.replace(".", "_").replace("-", "_")
             if (
                 not hasattr(self, extra_dep_name)
                 or getattr(self, extra_dep_name) is None

--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -44,6 +44,9 @@ class Generator(Configurable):
     supports_multiple_generations = (
         False  # can more than one generation be extracted per request?
     )
+    extra_dependency_names = (
+        []
+    )  # list of strings naming modules required but not explicitly in garak by default
 
     def __init__(self, name="", config_root=_config):
         self._load_config(config_root)
@@ -63,6 +66,13 @@ class Generator(Configurable):
             f"🦜 loading {Style.BRIGHT}{Fore.LIGHTMAGENTA_EX}generator{Style.RESET_ALL}: {self.generator_family_name}: {self.name}"
         )
         logging.info("generator init: %s", self)
+
+        for extra_dependency in self.extra_dependency_names:
+            setattr(
+                self,
+                extra_dependency,
+                garak._plugins.load_optional_module(extra_dependency),
+            )
 
     def _call_model(
         self, prompt: str, generations_this_call: int = 1
@@ -101,7 +111,7 @@ class Generator(Configurable):
         )
         rx_missing_final = re.escape(self.skip_seq_start) + ".*?$"
         rx_missing_start = ".*?" + re.escape(self.skip_seq_end)
-        
+
         if self.skip_seq_start == "":
             complete_seqs_removed = [
                 (

--- a/garak/generators/cohere.py
+++ b/garak/generators/cohere.py
@@ -14,6 +14,7 @@ import tqdm
 
 from garak import _config
 import garak._plugins
+from garak.exception import GeneratorBackoffExceptionPlaceholder
 from garak.generators.base import Generator
 
 
@@ -21,7 +22,7 @@ COHERE_GENERATION_LIMIT = (
     5  # c.f. https://docs.cohere.com/reference/generate 18 may 2023
 )
 
-cohere_exception = None
+cohere_exception = GeneratorBackoffExceptionPlaceholder
 
 
 class CohereGenerator(Generator):

--- a/garak/generators/cohere.py
+++ b/garak/generators/cohere.py
@@ -40,20 +40,20 @@ class CohereGenerator(Generator):
         "presence_penalty": 0.0,
         "stop": [],
     }
+    extra_dependency_names = ["cohere"]
 
     supports_multiple_generations = True
     generator_family_name = "Cohere"
 
     def __init__(self, name="command", config_root=_config):
 
-        global cohere_exception
-        self.cohere = garak._plugins.load_optional_module("cohere")
-        cohere_exception = self.cohere.error.CohereAPIError
-
         self.name = name
         self.fullname = f"Cohere {self.name}"
 
         super().__init__(self.name, config_root=config_root)
+
+        global cohere_exception
+        cohere_exception = self.cohere.error.CohereAPIError
 
         logging.debug(
             "Cohere generation request limit capped at %s", COHERE_GENERATION_LIMIT

--- a/garak/generators/groq.py
+++ b/garak/generators/groq.py
@@ -39,6 +39,7 @@ class GroqChat(OpenAICompatible):
     generator_family_name = "Groq"
 
     def _load_client(self):
+        self._load_deps()
         self.client = openai.OpenAI(base_url=self.uri, api_key=self.api_key)
         if self.name in ("", None):
             raise ValueError(

--- a/garak/generators/guardrails.py
+++ b/garak/generators/guardrails.py
@@ -16,27 +16,21 @@ class NeMoGuardrails(Generator):
 
     supports_multiple_generations = False
     generator_family_name = "Guardrails"
+    extra_dependency_names = ["nemoguardrails"]
 
     def __init__(self, name="", config_root=_config):
-        # another class that may need to skip testing due to non required dependency
-        try:
-            from nemoguardrails import RailsConfig, LLMRails
-            from nemoguardrails.logging.verbose import set_verbose
-        except ImportError as e:
-            raise NameError(
-                "You must first install NeMo Guardrails using `pip install nemoguardrails`."
-            ) from e
 
         self.name = name
         self._load_config(config_root)
         self.fullname = f"Guardrails {self.name}"
 
+        super().__init__(self.name, config_root=config_root)
+
+        set_verbose = self.nemoguardrails.logging.verbose.set_verbose
         # Currently, we use the model_name as the path to the config
         with redirect_stderr(io.StringIO()) as f:  # quieten the tqdm
-            config = RailsConfig.from_path(self.name)
-            self.rails = LLMRails(config=config)
-
-        super().__init__(self.name, config_root=config_root)
+            config = self.nemoguardrails.RailsConfig.from_path(self.name)
+            self.rails = self.nemoguardrails.LLMRails(config=config)
 
     def _call_model(
         self, prompt: str, generations_this_call: int = 1

--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -158,19 +158,14 @@ class OptimumPipeline(Pipeline, HFCompatible):
     generator_family_name = "NVIDIA Optimum Hugging Face 🤗 pipeline"
     supports_multiple_generations = True
     doc_uri = "https://huggingface.co/blog/optimum-nvidia"
+    extra_dependency_names = ["optimum"]
 
     def _load_client(self):
         if hasattr(self, "generator") and self.generator is not None:
             return
 
-        try:
-            from optimum.nvidia.pipelines import pipeline
-            from transformers import set_seed
-        except Exception as e:
-            logging.exception(e)
-            raise GarakException(
-                f"Missing required dependencies for {self.__class__.__name__}"
-            )
+        pipeline = self.optimum.nvidia.pipelines.pipeline
+        from transformers import set_seed
 
         if self.seed is not None:
             set_seed(self.seed)

--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -69,6 +69,7 @@ class Pipeline(Generator, HFCompatible):
         self._load_client()
 
     def _load_client(self):
+        self._load_deps()
         if hasattr(self, "generator") and self.generator is not None:
             return
 
@@ -103,6 +104,7 @@ class Pipeline(Generator, HFCompatible):
         self._set_hf_context_len(self.generator.model.config)
 
     def _clear_client(self):
+        self._clear_deps()
         self.generator = None
 
     def _format_chat_prompt(self, prompt: str) -> List[dict]:
@@ -160,6 +162,7 @@ class OptimumPipeline(Pipeline, HFCompatible):
     extra_dependency_names = ["optimum"]
 
     def _load_client(self):
+        self._load_deps()
         if hasattr(self, "generator") and self.generator is not None:
             return
 
@@ -199,6 +202,7 @@ class ConversationalPipeline(Pipeline, HFCompatible):
     supports_multiple_generations = True
 
     def _load_client(self):
+        self._load_deps()
         if hasattr(self, "generator") and self.generator is not None:
             return
 
@@ -448,6 +452,7 @@ class Model(Pipeline, HFCompatible):
     supports_multiple_generations = True
 
     def _load_client(self):
+        self._load_deps()
         if hasattr(self, "model") and self.model is not None:
             return
 
@@ -495,6 +500,7 @@ class Model(Pipeline, HFCompatible):
         self.generation_config.pad_token_id = self.model.config.eos_token_id
 
     def _clear_client(self):
+        self._clear_deps()
         self.model = None
         self.config = None
         self.tokenizer = None

--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -21,7 +21,6 @@ import warnings
 
 import backoff
 import torch
-from PIL import Image
 
 from garak import _config
 from garak.exception import ModelNameMissingError, GarakException
@@ -570,6 +569,8 @@ class LLaVA(Generator, HFCompatible):
     NB. This should be use with strict modality matching - generate() doesn't
     support text-only prompts."""
 
+    extra_dependency_names = ["PIL"]
+
     DEFAULT_PARAMS = Generator.DEFAULT_PARAMS | {
         "max_tokens": 4000,
         # "exist_tokens + max_new_tokens < 4K is the golden rule."
@@ -621,7 +622,7 @@ class LLaVA(Generator, HFCompatible):
 
         text_prompt = prompt["text"]
         try:
-            image_prompt = Image.open(prompt["image"])
+            image_prompt = self.PIL.Image.open(prompt["image"])
         except FileNotFoundError:
             raise FileNotFoundError(f"Cannot open image {prompt['image']}.")
         except Exception as e:

--- a/garak/generators/langchain.py
+++ b/garak/generators/langchain.py
@@ -8,9 +8,6 @@
 import logging
 from typing import List, Union
 
-
-import langchain.llms
-
 from garak import _config
 from garak.generators.base import Generator
 
@@ -43,7 +40,7 @@ class LangChainLLMGenerator(Generator):
         "presence_penalty": 0.0,
         "stop": [],
     }
-
+    extra_dependency_names = ["langchain.llms"]
     generator_family_name = "LangChain"
 
     def __init__(self, name="", config_root=_config):
@@ -55,7 +52,7 @@ class LangChainLLMGenerator(Generator):
 
         try:
             # this might need some special handling to allow tests
-            llm = getattr(langchain.llms, self.name)()
+            llm = getattr(self.langchain_llms, self.name)()
         except Exception as e:
             logging.error("Failed to import Langchain module: %s", repr(e))
             raise e

--- a/garak/generators/litellm.py
+++ b/garak/generators/litellm.py
@@ -35,10 +35,10 @@ from typing import List, Union
 import backoff
 
 from garak import _config
-from garak.exception import BadGeneratorException
+from garak.exception import BadGeneratorException, GeneratorBackoffExceptionPlaceholder
 from garak.generators.base import Generator
 
-litellm_apierror = None
+litellm_apierror = GeneratorBackoffExceptionPlaceholder
 
 # Based on the param support matrix below:
 # https://docs.litellm.ai/docs/completion/input
@@ -98,7 +98,7 @@ class LiteLLMGenerator(Generator):
         "skip_seq_start",
         "skip_seq_end",
         "stop",
-        "verbose"
+        "verbose",
     )
 
     def __init__(self, name: str = "", generations: int = 10, config_root=_config):

--- a/garak/generators/litellm.py
+++ b/garak/generators/litellm.py
@@ -98,6 +98,7 @@ class LiteLLMGenerator(Generator):
         "skip_seq_start",
         "skip_seq_end",
         "stop",
+        "verbose"
     )
 
     def __init__(self, name: str = "", generations: int = 10, config_root=_config):

--- a/garak/generators/mistral.py
+++ b/garak/generators/mistral.py
@@ -1,10 +1,11 @@
 DEFAULT_CLASS = "MistralGenerator"
 
 import backoff
+from garak.exception import GeneratorBackoffExceptionPlaceholder
 from garak.generators.base import Generator
 import garak._config as _config
 
-mistral_sdkerror = None
+mistral_sdkerror = GeneratorBackoffExceptionPlaceholder
 
 
 class MistralGenerator(Generator):

--- a/garak/generators/mistral.py
+++ b/garak/generators/mistral.py
@@ -34,9 +34,11 @@ class MistralGenerator(Generator):
         self._load_client()
 
     def _load_client(self):
+        self._load_deps()
         self.client = self.mistralai.Mistral(api_key=self.api_key)
 
     def _clear_client(self):
+        self._clear_deps()
         self.client = None
 
     def __init__(self, name="", config_root=_config):

--- a/garak/generators/nemo.py
+++ b/garak/generators/nemo.py
@@ -13,11 +13,11 @@ from typing import List, Union
 import backoff
 
 from garak import _config
-from garak.exception import APIKeyMissingError
+from garak.exception import APIKeyMissingError, GeneratorBackoffExceptionPlaceholder
 from garak.generators.base import Generator
 
-nemollm_serversideerror = None
-nemollm_toomanyrequestserror = None
+nemollm_serversideerror = GeneratorBackoffExceptionPlaceholder
+nemollm_toomanyrequestserror = GeneratorBackoffExceptionPlaceholder
 
 
 class NeMoGenerator(Generator):

--- a/garak/generators/nim.py
+++ b/garak/generators/nim.py
@@ -53,6 +53,7 @@ class NVOpenAIChat(OpenAICompatible):
     timeout = 60
 
     def _load_client(self):
+        self._load_deps()
         self.client = openai.OpenAI(base_url=self.uri, api_key=self.api_key)
         if self.name in ("", None):
             raise ValueError(
@@ -129,6 +130,7 @@ class NVOpenAICompletion(NVOpenAIChat):
     """
 
     def _load_client(self):
+        self._load_deps()
         self.client = openai.OpenAI(base_url=self.uri, api_key=self.api_key)
         self.generator = self.client.completions
 

--- a/garak/generators/octo.py
+++ b/garak/generators/octo.py
@@ -9,9 +9,10 @@ from typing import List, Union
 import backoff
 
 from garak import _config
+from garak.exception import GeneratorBackoffExceptionPlaceholder
 from garak.generators.base import Generator
 
-octoaiservererror = None
+octoaiservererror = GeneratorBackoffExceptionPlaceholder
 
 
 class OctoGenerator(Generator):

--- a/garak/generators/octo.py
+++ b/garak/generators/octo.py
@@ -32,7 +32,7 @@ class OctoGenerator(Generator):
 
     generator_family_name = "OctoAI"
     supports_multiple_generations = False
-    extra_dependency_names = ["octoai"]
+    extra_dependency_names = ["octoai-sdk"]
 
     def __init__(self, name="", config_root=_config):
 
@@ -42,12 +42,12 @@ class OctoGenerator(Generator):
 
         super().__init__(self.name, config_root=config_root)
         global octoaiservererror
-        octoaiservererror = self.octoai.errors.OctoAIServerError
+        octoaiservererror = self.octoai_sdk.errors.OctoAIServerError
 
         if self.seed is None:
             self.seed = 9
 
-        self.client = self.octoai.client.Client(token=self.api_key)
+        self.client = self.octoai_sdk.client.Client(token=self.api_key)
 
     @backoff.on_exception(backoff.fibo, octoaiservererror, max_value=70)
     def _call_model(

--- a/garak/generators/ollama.py
+++ b/garak/generators/ollama.py
@@ -5,10 +5,11 @@ from typing import List, Union
 import backoff
 
 from garak import _config
+from garak.exception import GeneratorBackoffExceptionPlaceholder
 from garak.generators.base import Generator
 from httpx import TimeoutException
 
-ollama_responseerror = None
+ollama_responseerror = GeneratorBackoffExceptionPlaceholder
 
 
 def _give_up(error):

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -158,6 +158,7 @@ class OpenAICompatible(Generator):
     def _load_client(self):
         # When extending `OpenAICompatible` this method is a likely location for target application specific
         # customization and must populate self.generator with an openai api compliant object
+        self._load_deps()
         self.client = openai.OpenAI(base_url=self.uri, api_key=self.api_key)
         if self.name in ("", None):
             raise ValueError(
@@ -168,6 +169,7 @@ class OpenAICompatible(Generator):
     def _clear_client(self):
         self.generator = None
         self.client = None
+        self._clear_deps()
 
     def _validate_config(self):
         pass

--- a/garak/generators/replicate.py
+++ b/garak/generators/replicate.py
@@ -15,9 +15,10 @@ from typing import List, Union
 import backoff
 
 from garak import _config
+from garak.exception import GeneratorBackoffExceptionPlaceholder
 from garak.generators.base import Generator
 
-replicate_error = None
+replicate_error = GeneratorBackoffExceptionPlaceholder
 
 
 class ReplicateGenerator(Generator):

--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -46,6 +46,8 @@ class Harness(Configurable):
     """Class to manage the whole process of probing, detecting and evaluating"""
 
     active = True
+    # list of strings naming modules required but not explicitly in garak by default
+    extra_dependency_names = []
 
     DEFAULT_PARAMS = {
         "strict_modality_match": False,

--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -63,6 +63,8 @@ class Probe(Configurable):
     # let mixins override this
     # tier: Tier = Tier.TIER_9
     tier: Tier = Tier.TIER_9
+    # list of strings naming modules required but not explicitly in garak by default
+    extra_dependency_names = []
 
     DEFAULT_PARAMS = {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ dependencies = [
   "colorama>=0.4.3",
   "tqdm>=4.64.0",
   "openai>=1.45.0,<2",
-  "replicate>=0.8.3",
   "google-api-python-client>=2.0",
   "backoff>=2.1.1",
   "rapidfuzz>=3.0.0",
@@ -70,9 +69,6 @@ dependencies = [
   "accelerate>=0.23.0",
   "avidtools==0.1.2",
   "stdlibs>=2022.10.9",
-  "langchain>=0.0.300",
-  "nemollm>=0.3.0",
-  "octoai-sdk>=0.8.0",
   "cmd2==2.4.3",
   "torch>=2.1.3",
   "sentencepiece>=0.1.99",
@@ -82,7 +78,6 @@ dependencies = [
   "ecoji>=0.1.1",
   "deepl==1.17.0",
   "fschat>=0.2.36",
-  "litellm>=1.41.21,<1.67.2",
   "jsonpath-ng>=1.6.1",
   "huggingface_hub>=0.21.0",
   'python-magic-bin>=0.4.14; sys_platform == "win32"',
@@ -90,11 +85,9 @@ dependencies = [
   "lorem==0.1.1",
   "xdg-base-dirs>=6.0.1",
   "wn==0.9.5",
-  "ollama>=0.4.7",
   "nvidia-riva-client==2.16.0",
   "langdetect==1.0.9",
   "tiktoken>=0.7.0",
-  "mistralai==1.5.2",
 ]
 
 [project.optional-dependencies]
@@ -116,6 +109,36 @@ calibration = [
 ]
 plugin_cohere = [
   "cohere>=4.5.1,<5"
+]
+plugin_langchain = [
+  "langchain>=0.0.300",
+]
+plugin_llava = [
+  "PIL",
+]
+plugin_litellm = [
+  "litellm>=1.41.21,<1.67.2",
+]
+plugin_mistralai = [
+  "mistralai==1.5.2",
+]
+plugin_nemoguardrails = [
+  "nemoguardrails",
+]
+plugin_nemollm = [
+  "nemollm>=0.3.0",
+]
+plugin_octoai = [
+  "octoai-sdk>=0.8.0",
+]
+plugin_ollama = [
+  "ollama>=0.4.7",
+]
+plugin_optimum = [
+  "optimum",
+]
+plugin_replicate = [
+  "replicate>=0.8.3",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ dependencies = [
   "datasets>=3.0.0",
   "colorama>=0.4.3",
   "tqdm>=4.64.0",
-  "cohere>=4.5.1,<5",
   "openai>=1.45.0,<2",
   "replicate>=0.8.3",
   "google-api-python-client>=2.0",
@@ -114,6 +113,9 @@ lint = [
 ]
 calibration = [
   "scipy>=1.14.0",
+]
+plugin_cohere = [
+  "cohere>=4.5.1,<5"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ transformers>=4.43.0
 datasets>=3.0.0
 colorama>=0.4.3
 tqdm>=4.64.0
-cohere>=4.5.1,<5
 openai>=1.45.0,<2
 replicate>=0.8.3
 google-api-python-client>=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ datasets>=3.0.0
 colorama>=0.4.3
 tqdm>=4.64.0
 openai>=1.45.0,<2
-replicate>=0.8.3
 google-api-python-client>=2.0
 backoff>=2.1.1
 rapidfuzz>=3.0.0
@@ -13,9 +12,6 @@ nltk>=3.8.1
 accelerate>=0.23.0
 avidtools==0.1.2
 stdlibs>=2022.10.9
-langchain>=0.0.300
-nemollm>=0.3.0
-octoai-sdk>=0.8.0
 cmd2==2.4.3
 torch>=2.1.3
 sentencepiece>=0.1.99
@@ -25,7 +21,6 @@ zalgolib>=0.2.2
 ecoji>=0.1.1
 deepl==1.17.0
 fschat>=0.2.36
-litellm>=1.41.21,<1.67.2
 jsonpath-ng>=1.6.1
 huggingface_hub>=0.21.0
 python-magic-bin>=0.4.14; sys_platform == "win32"
@@ -33,11 +28,9 @@ python-magic>=0.4.21; sys_platform != "win32"
 lorem==0.1.1
 xdg-base-dirs>=6.0.1
 wn==0.9.5
-ollama>=0.4.7
 nvidia-riva-client==2.16.0
 langdetect==1.0.9
 tiktoken>=0.7.0
-mistralai==1.5.2
 # tests
 pytest>=8.0
 pytest-mock>=3.14.0

--- a/tests/buffs/test_buffs.py
+++ b/tests/buffs/test_buffs.py
@@ -21,11 +21,14 @@ def test_buff_structure(classname):
     # any parameter that has a default must be supported
     unsupported_defaults = []
     if c._supported_params is not None:
-        if hasattr(g, "DEFAULT_PARAMS"):
+        if hasattr(c, "DEFAULT_PARAMS"):
             for k, _ in c.DEFAULT_PARAMS.items():
                 if k not in c._supported_params:
                     unsupported_defaults.append(k)
     assert unsupported_defaults == []
+    assert hasattr(c, "extra_dependency_names") and isinstance(
+        c.extra_dependency_names, list
+    ), "extra_dependency_names must be a list"
 
 
 @pytest.mark.parametrize("klassname", BUFFS)

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -127,3 +127,6 @@ def test_detector_metadata(classname):
         assert d.doc_uri.lower().startswith(
             "http"
         ), "doc uris should be fully-specified absolute HTTP addresses"
+    assert hasattr(d, "extra_dependency_names") and isinstance(
+        d.extra_dependency_names, list
+    ), "extra_dependency_names must be a list"

--- a/tests/generators/test_generators.py
+++ b/tests/generators/test_generators.py
@@ -69,6 +69,10 @@ def test_generator_structure(classname):
                 if k not in g._supported_params:
                     unsupported_defaults.append(k)
     assert unsupported_defaults == []
+    # extra dependency modules is a list
+    assert hasattr(g, "extra_dependency_names") and isinstance(
+        g.extra_dependency_names, list
+    ), "extra_dependency_names must be a list"
 
 
 TESTABLE_GENERATORS = [
@@ -155,19 +159,29 @@ def test_skip_seq():
 
     test_has_only_end_think = "some thinking</think>" + target_string
     r = g.generate(test_has_only_end_think)
-    assert r[0] == test_has_only_end_think, "for non empty skip_seq_start, if skip_seq_start is not found and skip_seq_end is found, no stripping should be done"
+    assert (
+        r[0] == test_has_only_end_think
+    ), "for non empty skip_seq_start, if skip_seq_start is not found and skip_seq_end is found, no stripping should be done"
 
     g.skip_seq_start = ""
     g.skip_seq_end = "</think>"
     r = g.generate(test_has_only_end_think)
-    assert r[0] == target_string, "for empty skip_seq_start, if skip_seq_start is not found and skip_seq_end is found, strip from start of output till skip_seq_end"
-    
-    test_multiple_end_thinks = "some thinking</think><think>some more thinking</think>" + target_string
+    assert (
+        r[0] == target_string
+    ), "for empty skip_seq_start, if skip_seq_start is not found and skip_seq_end is found, strip from start of output till skip_seq_end"
+
+    test_multiple_end_thinks = (
+        "some thinking</think><think>some more thinking</think>" + target_string
+    )
     r = g.generate(test_multiple_end_thinks)
-    assert r[0] == target_string, "for empty skip_seq_start, if skip_seq_start is not found and multiple skip_seq_end is found, strip from start of output till last skip_seq_end"
+    assert (
+        r[0] == target_string
+    ), "for empty skip_seq_start, if skip_seq_start is not found and multiple skip_seq_end is found, strip from start of output till last skip_seq_end"
 
-    test_multiple_end_thinks_discontinuous = "some thinking</think>" + target_string +"<think>some more thinking</think>"
+    test_multiple_end_thinks_discontinuous = (
+        "some thinking</think>" + target_string + "<think>some more thinking</think>"
+    )
     r = g.generate(test_multiple_end_thinks_discontinuous)
-    assert r[0] == "", "for empty skip_seq_start, if skip_seq_start is not found and multiple skip_seq_end is found, strip from start of output till last skip_seq_end"
-
-
+    assert (
+        r[0] == ""
+    ), "for empty skip_seq_start, if skip_seq_start is not found and multiple skip_seq_end is found, strip from start of output till last skip_seq_end"

--- a/tests/harnesses/test_harnesses.py
+++ b/tests/harnesses/test_harnesses.py
@@ -14,7 +14,7 @@ HARNESSES = [
 
 
 @pytest.mark.parametrize("classname", HARNESSES)
-def test_buff_structure(classname):
+def test_harness_structure(classname):
 
     m = importlib.import_module("garak." + ".".join(classname.split(".")[:-1]))
     c = getattr(m, classname.split(".")[-1])
@@ -22,11 +22,14 @@ def test_buff_structure(classname):
     # any parameter that has a default must be supported
     unsupported_defaults = []
     if c._supported_params is not None:
-        if hasattr(g, "DEFAULT_PARAMS"):
+        if hasattr(c, "DEFAULT_PARAMS"):
             for k, _ in c.DEFAULT_PARAMS.items():
                 if k not in c._supported_params:
                     unsupported_defaults.append(k)
     assert unsupported_defaults == []
+    assert hasattr(c, "extra_dependency_names") and isinstance(
+        c.extra_dependency_names, list
+    ), "extra_dependency_names must be a list"
 
 
 def test_harness_modality_match():

--- a/tests/probes/test_probes.py
+++ b/tests/probes/test_probes.py
@@ -93,6 +93,10 @@ def test_probe_metadata(classname):
     assert hasattr(p, "extra_dependency_names") and isinstance(
         p.extra_dependency_names, list
     ), "extra_dependency_names must be a list"
+    if p.active:
+        assert (
+            p.extra_dependency_names == []
+        ), "active must be False for Probes requiring external modules, so that they're not run by default"
 
 
 @pytest.mark.parametrize("plugin_name", PROBES)

--- a/tests/probes/test_probes.py
+++ b/tests/probes/test_probes.py
@@ -63,7 +63,7 @@ def test_probe_structure(classname):
     # any parameter that has a default must be supported
     unsupported_defaults = []
     if c._supported_params is not None:
-        if hasattr(g, "DEFAULT_PARAMS"):
+        if hasattr(c, "DEFAULT_PARAMS"):
             for k, _ in c.DEFAULT_PARAMS.items():
                 if k not in c._supported_params:
                     unsupported_defaults.append(k)
@@ -75,7 +75,9 @@ def test_probe_metadata(classname):
     p = _plugins.load_plugin(classname)
     assert isinstance(p.goal, str), "probe goals should be a text string"
     assert len(p.goal) > 0, "probes must state their general goal"
-    assert p.lang is not None and (p.lang == "*" or langcodes.tag_is_valid(p.lang)), "lang must be either * or a BCP47 code"
+    assert p.lang is not None and (
+        p.lang == "*" or langcodes.tag_is_valid(p.lang)
+    ), "lang must be either * or a BCP47 code"
     assert isinstance(
         p.doc_uri, str
     ), "probes should give a doc uri describing/citing the attack"
@@ -88,6 +90,9 @@ def test_probe_metadata(classname):
     assert isinstance(p.modality["in"], set), "modality descriptors must be sets"
     assert p.tier is not None, "probe tier must be specified"
     assert isinstance(p.tier, Tier), "probe tier must be one of type Tier'"
+    assert hasattr(p, "extra_dependency_names") and isinstance(
+        p.extra_dependency_names, list
+    ), "extra_dependency_names must be a list"
 
 
 @pytest.mark.parametrize("plugin_name", PROBES)

--- a/tests/test_reqs.py
+++ b/tests/test_reqs.py
@@ -1,12 +1,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import importlib
 import pytest
+import re
 
 try:
     import tomllib
 except:
     tomllib = None
+
+import garak._plugins
 
 
 @pytest.mark.skipif(
@@ -40,3 +44,75 @@ def test_requirements_txt_pyproject_toml():
     assert (
         reqtxt_reqs == pyproject_reqs
     )  # final check. this one is actually enough, but let's help us debug by finding which test fails, ok?
+
+
+PLUGIN_TYPES = ["probes", "detectors", "harnesses", "generators", "buffs"]
+
+
+def plugin_names():
+    plugin_names = set()
+    for plugin_type in PLUGIN_TYPES:
+        plugin_names.update(
+            [n for (n, active) in garak._plugins.enumerate_plugins(plugin_type)]
+        )
+    return plugin_names
+
+
+def split_out_module_name(pep508_descr: str):
+    return re.split(r"[\<\>\=\!]", pep508_descr)[0]
+
+
+def requirement_names():
+    with open("requirements.txt", "r", encoding="utf-8") as req_file:
+        reqtxt_reqs = req_file.readlines()
+        reqtxt_reqs = list(
+            filter(lambda x: not x.startswith("#"), map(str.strip, reqtxt_reqs))
+        )
+        requirement_names = set([split_out_module_name(r) for r in reqtxt_reqs])
+    return requirement_names
+
+
+def pyproject_optional_dep_names():
+    with open("pyproject.toml", "rb") as pyproject_file:
+        pyproject_toml = tomllib.load(pyproject_file)
+    optional_deps = set()
+    for test_group in pyproject_toml["project"]["optional-dependencies"]:
+        if test_group.startswith("plugin_"):
+            group_dep_names = [
+                split_out_module_name(r)
+                for r in pyproject_toml["project"]["optional-dependencies"][test_group]
+            ]
+            optional_deps.update(group_dep_names)
+    return optional_deps
+
+
+@pytest.mark.parametrize("plugin_name", plugin_names())
+def test_optional_extras_not_in_requirements(plugin_name: str):
+    m = importlib.import_module("garak." + ".".join(plugin_name.split(".")[:-1]))
+    plugin_class = getattr(m, plugin_name.split(".")[-1])
+    plugin_extra_dep_names = [
+        d.split(".")[0] for d in plugin_class.extra_dependency_names
+    ]
+    extra_deps_in_requirements = requirement_names().intersection(
+        plugin_extra_dep_names
+    )
+    assert len(extra_deps_in_requirements) == 0, (
+        "extra deps should not be in requirements.txt but %s overlaps"
+        % extra_deps_in_requirements
+    )
+
+
+@pytest.mark.parametrize("plugin_name", plugin_names())
+def test_optional_extras_not_in_pyproject(plugin_name: str):
+    m = importlib.import_module("garak." + ".".join(plugin_name.split(".")[:-1]))
+    plugin_class = getattr(m, plugin_name.split(".")[-1])
+    plugin_extra_dep_names = [
+        d.split(".")[0] for d in plugin_class.extra_dependency_names
+    ]
+    extra_deps_in_pyproject = pyproject_optional_dep_names().intersection(
+        plugin_extra_dep_names
+    )
+    assert len(extra_deps_in_pyproject) == len(plugin_extra_dep_names), (
+        "all extra dependences %s must be in optional plugin clause in pyproject.toml"
+        % plugin_extra_dep_names
+    )

--- a/tests/test_reqs.py
+++ b/tests/test_reqs.py
@@ -22,9 +22,13 @@ def test_requirements_txt_pyproject_toml():
     with open("pyproject.toml", "rb") as pyproject_file:
         pyproject_toml = tomllib.load(pyproject_file)
         pyproject_reqs = pyproject_toml["project"]["dependencies"]
-        for test_deps in pyproject_toml["project"]["optional-dependencies"].values():
-            for dep in test_deps:
-                pyproject_reqs.append(dep)
+        for test_group in pyproject_toml["project"]["optional-dependencies"]:
+            if not test_group.startswith("plugin_"):
+                test_deps = pyproject_toml["project"]["optional-dependencies"][
+                    test_group
+                ]
+                for dep in test_deps:
+                    pyproject_reqs.append(dep)
         pyproject_reqs.sort()
     # assert len(reqtxt_reqs) == len(pyproject_reqs) # same number of requirements
     assert (


### PR DESCRIPTION
Support construction-time loading of optional modules. Includes

* many generators now using this pattern
* pattern for loading modules at run-time and failing if absent
* optional requirements moved to pyproject.toml options **and pruned from requirements.txt**
* `_load_deps` and `_clear_deps` pattern, used in generator constructor and `_load_client` / `_clear_client`
* tests to check that optional deps are in the right place and not in the wrong place