### PR TITLE
Testing: storage reduction

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -40,6 +40,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --no-cache-dir -r requirements.txt
+          python -m pip cache purge
+
       - name: Restore test cache artifacts
         id: cache-artifacts-restore
         uses: actions/cache/restore@v4
@@ -48,12 +54,6 @@ jobs:
             .cache/garak/data
             .cache/huggingface
           key: garak-test-resources-shared
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          python -m pip cache purge
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -48,6 +48,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install dependencies
+        run: |
+          brew install libmagic
+          cd garak
+          python -m pip install --upgrade pip
+          pip install --no-cache-dir -r requirements.txt
+          python -m pip cache purge
+
       - name: Restore test cache artifacts
         id: cache-artifacts-restore
         uses: actions/cache/restore@v4
@@ -56,14 +64,6 @@ jobs:
             .cache/garak/data
             .cache/huggingface
           key: garak-test-resources-shared
-
-      - name: Install dependencies
-        run: |
-          brew install libmagic
-          cd garak
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          python -m pip cache purge
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -74,6 +74,7 @@ jobs:
         run: |
           rm -rf .cache/huggingface/hub/*facebook*
           rm -rf .cache/huggingface/hub/*Helsinki*
+          rm -rf .cache/huggingface/hub/*roberta*
 
       - name: Save test cache
         if: inputs.store-cache

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -42,6 +42,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          cd garak
+          pip install --no-cache-dir -r requirements.txt
+          python -m pip cache purge
+
       - name: Restore test cache artifacts
         id: cache-artifacts-restore
         uses: actions/cache/restore@v4
@@ -51,13 +58,6 @@ jobs:
             .cache/huggingface
           enableCrossOsArchive: true
           key: garak-test-resources-shared
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          cd garak
-          pip install -r requirements.txt
-          python -m pip cache purge
 
       - name: Test with pytest
         run: |


### PR DESCRIPTION
* reduce storage needs by avoiding `pip cache dir` during dependency install
* move shared testing cache to after dependencies are in place to reduce early disk usage
* remove language service translation models after package tests complete

Impacts seen in testing reflected in cache purge:
ubuntu-latest + 3.10
Before:
```
Files removed: 1222 (3343.3 MB)
```

After:
```
Files removed: 30 (3.5 MB)
```

## Verification

- [ ] CI/CD automation does not cancel after dependency install due to lack of storage space 
