### PR TITLE
reporting: aggregate probe as min

### DIFF
--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -224,9 +224,9 @@ def compile_digest(
 
         if group_score < 100.0 or _config.reporting.show_100_pass_modules:
             res = cursor.execute(
-                f"select probe_module, probe_class, avg(score)*100 as s from results where probe_group='{probe_group}' group by probe_class order by s asc, probe_class asc;"
+                f"select probe_module, probe_class, min(score)*100 as s from results where probe_group='{probe_group}' group by probe_class order by s asc, probe_class asc;"
             )
-            for probe_module, probe_class, score in res.fetchall():
+            for probe_module, probe_class, probe_score in res.fetchall():
                 pm = importlib.import_module(f"garak.probes.{probe_module}")
                 probe_description = plugin_docstring_to_description(
                     getattr(pm, probe_class).__doc__
@@ -234,13 +234,13 @@ def compile_digest(
                 digest_content += probe_template.render(
                     {
                         "plugin_name": f"{probe_module}.{probe_class}",
-                        "plugin_score": f"{score:.1f}%",
-                        "severity": map_score(score),
+                        "plugin_score": f"{probe_score:.1f}%",
+                        "severity": map_score(probe_score),
                         "plugin_descr": probe_description,
                     }
                 )
                 # print(f"\tplugin: {probe_module}.{probe_class} - {score:.1f}%")
-                if score < 100.0 or _config.reporting.show_100_pass_modules:
+                if probe_score < 100.0 or _config.reporting.show_100_pass_modules:
                     res = cursor.execute(
                         f"select detector, score*100 from results where probe_group='{probe_group}' and probe_class='{probe_class}' order by score asc, detector asc;"
                     )

--- a/garak/analyze/templates/digest_group.jinja
+++ b/garak/analyze/templates/digest_group.jinja
@@ -9,5 +9,5 @@
 {%else%}
 "{{group}}"
 {%endif%}
- scored the target a {{ group_score }} pass rate (function: {{group_aggregation_function}}).</p>
+ scored the target a {{ group_score }} pass rate ({{group_aggregation_function}}).</p>
 {%endif%}

--- a/garak/analyze/templates/digest_probe.jinja
+++ b/garak/analyze/templates/digest_probe.jinja
@@ -1,1 +1,1 @@
-<h3 class="defcon{{severity}}" title="{{plugin_descr}}">probe: {{ plugin_name }} {{ plugin_score }}</h3>
+<h3 class="defcon{{severity}}" title="{{plugin_descr}}">probe: {{ plugin_name }} - min. {{ plugin_score }}</h3>


### PR DESCRIPTION
probe-level results over multiple detectors were aggregated as mean in html report

this cuts too much signal out when detectors pick up failures

aggregate as minimum instead 

e.g. when detectors report 100% and 0% pass, aggregate result on top line shows now minimum, 0%

![image](https://github.com/user-attachments/assets/8ab08dac-7332-420f-9c02-202c5fff06f0)
