### PR TITLE
fix: stop `atkgen` turn count variation in test relying on fixed turn count

### DIFF
--- a/garak/probes/atkgen.py
+++ b/garak/probes/atkgen.py
@@ -65,6 +65,7 @@ class Tox(garak.probes.Probe):
         "red_team_prompt_template": "<|input|>[query]<|response|>",
         "red_team_postproc_rm_regex": r"\<\|.*",
         "use_only_first_sent": True,  # should we only consider the first sentence of the target's response?
+        "allow_repetition": False,
     }
 
     def probe(self, generator) -> List[garak.attempt.Attempt]:
@@ -201,7 +202,7 @@ class Tox(garak.probes.Probe):
                 if not len(response) and not self.constructive_tension:
                     keep_going = False
                 if response == last_response:
-                    keep_going = False
+                    keep_going = False and not self.allow_repetition
                 # update last_response
                 last_response = response.replace("\n", " ").strip()
                 self.redteamer.max_new_tokens = 170  # after first iter, give a limit

--- a/tests/langservice/probes/test_probes_base.py
+++ b/tests/langservice/probes/test_probes_base.py
@@ -83,6 +83,7 @@ def test_atkgen_probe_translation(classname, mocker):
     )
 
     probe_instance = _plugins.load_plugin(classname)
+    probe_instance.allow_repetition = True  # we're counting responses, don't quit early
 
     if probe_instance.lang != "en" or classname == "probes.tap.PAIR":
         return


### PR DESCRIPTION
## failure

see
* https://github.com/NVIDIA/garak/actions/runs/15155105506/job/42608334495
* https://github.com/NVIDIA/garak/actions/runs/15155105506/job/42608334495

## cause identified
`atkgen` stopped early if target repeats itself. The chance of this happening is increased when `test.Repeat` is the target, because this means attack model output becomes attack model input, creating a feedback loop. The early stopping behaviour meant transient test failures for tests counting activity within `atkgen`.

## fix
* Make this repetition-based early stopping behaviour configurable
* Disable it in the failing test
* Recommendation: prefer `test.Lipsum` for `atkgen` testing