### PR TITLE
update: revert default `_config.run.generations` to `5`

### DIFF
--- a/garak/resources/garak.core.yaml
+++ b/garak/resources/garak.core.yaml
@@ -13,7 +13,7 @@ run:
   seed:
   deprefix: true
   eval_threshold: 0.5
-  generations: 3
+  generations: 5
   probe_tags:
   user_agent: "garak/{version} (LLM vulnerability scanner https://garak.ai)"
   soft_probe_prompt_cap: 256


### PR DESCRIPTION
testing shows some significant instability in places moving to generations=3, revert to generations=5
