### PR TITLE
extract text when processing multi-modal prompts

### DIFF
--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -279,14 +279,14 @@ class Probe(Configurable):
             prompts = self.langprovider.get_text(prompts)
         else:
             for prompt in prompts:
-                prompt["text"] = self.langprovider.get_text(prompt["text"])
+                if "text" in prompt:
+                    prompt["text"] = self.langprovider.get_text(prompt["text"])
         lang = self.langprovider.target_lang
         for seq, prompt in enumerate(prompts):
-            prompt_text = prompt
-            if not isinstance(prompt, str):
-                prompt_text = self.prompts[seq]["text"]
             notes = (
-                {"pre_translation_prompt": prompt_text} if lang != self.lang else None
+                {"pre_translation_prompt": self.prompts[seq]}
+                if lang != self.lang
+                else None
             )
             attempts_todo.append(self._mint_attempt(prompt, seq, notes, lang))
 

--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -274,13 +274,19 @@ class Probe(Configurable):
         attempts_todo: Iterable[garak.attempt.Attempt] = []
         prompts = list(self.prompts)
         lang = self.lang
-        prompts = self.langprovider.get_text(prompts)
+        # account for visual jailbreak until Turn/Conversation is supported
+        if isinstance(prompts[0], str):
+            prompts = self.langprovider.get_text(prompts)
+        else:
+            for prompt in prompts:
+                prompt["text"] = self.langprovider.get_text(prompt["text"])
         lang = self.langprovider.target_lang
         for seq, prompt in enumerate(prompts):
+            prompt_text = prompt
+            if not isinstance(prompt, str):
+                prompt_text = self.prompts[seq]["text"]
             notes = (
-                {"pre_translation_prompt": self.prompts[seq]}
-                if lang != self.lang
-                else None
+                {"pre_translation_prompt": prompt_text} if lang != self.lang else None
             )
             attempts_todo.append(self._mint_attempt(prompt, seq, notes, lang))
 


### PR DESCRIPTION
#943 introduces translation of `prompt` text as an action taken during execution of the base `Probe.probe()` implementation with an assumption that all prompt entries are `str` type.  The `visual_jailbreak` probe is a current outlier that builds a list of prompts with entires of `dict` type.

Different prompt types require different call patterns to language services.

## Verification

List the steps needed to make sure this thing works

- [ ] execute `visual_jailbreak` against a model with `target_lang` set to something other than `"en"`
- [ ] new automation tests pass