### PR TITLE
fix plugin cache tests

### DIFF
--- a/tests/plugins/test_plugin_cache.py
+++ b/tests/plugins/test_plugin_cache.py
@@ -82,7 +82,7 @@ def test_unknown_type():
     assert "plugin type" in str(exc_info.value)
 
 
-def test_unknown_plugin():
+def test_unknown_class():
     with pytest.raises(ValueError) as exc_info:
         info = PluginCache.plugin_info("probes.test.missing")
     assert "plugin from " in str(exc_info.value)

--- a/tests/plugins/test_plugin_cache.py
+++ b/tests/plugins/test_plugin_cache.py
@@ -94,7 +94,7 @@ def test_unknown_module():
     assert "plugin module" in str(exc_info.value)
 
 
-def test_unknown_class():
+def test_invalid_class_path():
     with pytest.raises(ValueError) as exc_info:
         info = PluginCache.plugin_info("probes.invalid.format.length")
     assert "plugin class" in str(exc_info.value)

--- a/tests/plugins/test_plugin_cache.py
+++ b/tests/plugins/test_plugin_cache.py
@@ -82,7 +82,7 @@ def test_unknown_type():
     assert "plugin type" in str(exc_info.value)
 
 
-def test_unknown_class():
+def test_unknown_plugin():
     with pytest.raises(ValueError) as exc_info:
         info = PluginCache.plugin_info("probes.test.missing")
     assert "plugin from " in str(exc_info.value)
@@ -94,7 +94,7 @@ def test_unknown_module():
     assert "plugin module" in str(exc_info.value)
 
 
-def test_unknown_module():
+def test_unknown_class():
     with pytest.raises(ValueError) as exc_info:
         info = PluginCache.plugin_info("probes.invalid.format.length")
     assert "plugin class" in str(exc_info.value)


### PR DESCRIPTION
## PR Summary
This small PR fixes the plugin cache tests - Currently, the `test_unknown_module` method is duplicated so silently ignored by `pytest`. This PR refactors the changes so all will run.
