### PR TITLE
Task: 2025 Q2 scoring calibration 

### DIFF
--- a/garak/configs/bag.yaml
+++ b/garak/configs/bag.yaml
@@ -6,7 +6,7 @@ run:
   generations: 3
 
 plugins:
-  probe_spec: continuation,dan.DanInTheWild,dan.Ablation_Dan_11_0,encoding.InjectAscii85,encoding.InjectBase16,encoding.InjectBase2048,encoding.InjectBase32,encoding.InjectBase64,encoding.InjectBraille,encoding.InjectEcoji,encoding.InjectHex,encoding.InjectMorse,encoding.InjectNato,encoding.InjectROT13,encoding.InjectUU,goodside,grandma,av_spam_scanning,leakreplay,lmrc,malwaregen,misleading,packagehallucination,realtoxicityprompts,divergence,snowball,suffix,tap,xss
+  probe_spec: continuation,dan.DanInTheWild,dan.Ablation_Dan_11_0,encoding.InjectAscii85,encoding.InjectBase16,encoding.InjectBase2048,encoding.InjectBase32,encoding.InjectBase64,encoding.InjectBraille,encoding.InjectEcoji,encoding.InjectHex,encoding.InjectMorse,encoding.InjectNato,encoding.InjectROT13,encoding.InjectUU,exploitation.JinjaTemplatePythonInjection,exploitation.SQLInjectionEcho,exploitation.SQLInjectionSystem,goodside,grandma,av_spam_scanning,leakreplay,lmrc,malwaregen,misleading,packagehallucination,realtoxicityprompts,divergence,snowball,suffix,tap,xss
   extended_detectors: false
   probes:
     encoding:

--- a/garak/configs/bag.yaml
+++ b/garak/configs/bag.yaml
@@ -1,0 +1,24 @@
+system:
+  parallel_attempts: 32
+  lite: false
+
+run:
+  generations: 3
+
+plugins:
+  probe_spec: continuation,dan.DanInTheWild,dan.Ablation_Dan_11_0,encoding.InjectAscii85,encoding.InjectBase16,encoding.InjectBase2048,encoding.InjectBase32,encoding.InjectBase64,encoding.InjectBraille,encoding.InjectEcoji,encoding.InjectHex,encoding.InjectMorse,encoding.InjectNato,encoding.InjectROT13,encoding.InjectUU,goodside,grandma,av_spam_scanning,leakreplay,lmrc,malwaregen,misleading,packagehallucination,realtoxicityprompts,divergence,snowball,suffix,tap,xss
+  extended_detectors: false
+  probes:
+    encoding:
+      payloads:
+        - default
+        - xss
+        - slur_terms
+  detectors:
+    misleading:
+      MustContradictNLI:
+        hf_args:
+          device: cuda
+      MustRefuteClaimModel:
+        hf_args:
+          device: cuda

--- a/garak/data/calibration/bag.md
+++ b/garak/data/calibration/bag.md
@@ -29,6 +29,65 @@ We artificially bound standard deviations at a non-zero minimum, to represent th
 
 The first benchmark is in summer 2024. We think something between twice-yearly and quarterly updates provides a good trade off between using recent models, and keeping results relevant long enough to be comparable.
 
+## Summer 2025
+
+### Bag contents
+
+| 10^n category | 2^n category |   provider  |              model name              | params (B) |
+|:-------------:|:------------:|:-----------:|:------------------------------------:|:----------:|
+|       1       |       6      | abacusai    | dracarys-llama-3.1-70b-instruct      |     70     |
+|       1       |       5      | ai21labs    | jamba-1.5-mini-instruct              |     52     |
+|       2       |       9      | deepseek-ai | deepseek-r1-distill-qwen-7b          |     671    |
+|       0       |       2      | deepseek-ai | deepseek-r1                          |     7.62   |
+|       1       |       4      | google      | gemma-3-1b-it                        |     27     |
+|       0       |       0      | google      | gemma-3-27b-it                       |     1      |
+|       0       |       3      | ibm-granite | granite-3.0-3b-a800m-instruct        |     8      |
+|       0       |       1      | ibm-granite | granite-3.0-8b-instruct              |     3      |
+|       1       |       6      | meta        | llama-3.1-405b-instruct              |     70     |
+|       2       |       8      | meta        | llama-3.3-70b-instruct               |     405    |
+|       2       |       7      | meta        | llama-4-maverick-17b-128e-instruct   |     109    |
+|       0       |       1      | microsoft   | phi-3.5-moe-instruct                 |     3.8    |
+|       1       |       5      | microsoft   | phi-4-mini-instruct                  |     60.8   |
+|       1       |       4      | mistralai   | mistral-small-24b-instruct           |     24     |
+|       2       |       7      | mistralai   | mixtral-8x22b-instruct-v0.1          |     141    |
+|       1       |       5      | nvidia      | llama-3.3-nemotron-super-49b-v1      |     49     |
+|       0       |       3      | nvidia      | mistral-nemo-minitron-8b-8k-instruct |     8      |
+|       2       |       7      | openai      | gpt-4o                               |     200    |
+|       2       |       6      | qwen        | qwen2.5-7b-instruct                  |     122    |
+|       0       |       2      | qwen        | qwen2.5-coder-32b-instruct           |     7      |
+|       1       |       5      | qwen        | qwq-32b                              |     32     |
+|       1       |       5      | writer      | palmyra-creative-122b                |     32     |
+|       0       |       2      | zyphra      | zamba2-7b-instruct                   |     7      |
+
+### Bag config
+
+```
+system:
+  parallel_attempts: 32
+  lite: false
+
+run:
+  generations: 3
+
+plugins:
+  probe_spec: continuation,dan.DanInTheWild,dan.Ablation_Dan_11_0,encoding.InjectAscii85,encoding.InjectBase16,encoding.InjectBase2048,encoding.InjectBase32,encoding.InjectBase64,encoding.InjectBraille,encoding.InjectEcoji,encoding.InjectHex,encoding.InjectMorse,encoding.InjectNato,encoding.InjectROT13,encoding.InjectUU,exploitation.JinjaTemplatePythonInjection,exploitation.SQLInjectionEcho,exploitation.SQLInjectionSystem,goodside,grandma,av_spam_scanning,leakreplay,lmrc,malwaregen,misleading,packagehallucination,realtoxicityprompts,divergence,snowball,suffix,tap,xss
+  extended_detectors: false
+  probes:
+    encoding:
+      payloads:
+        - default
+        - xss
+        - slur_terms
+  detectors:
+    misleading:
+      MustContradictNLI:
+        hf_args:
+          device: cuda
+      MustRefuteClaimModel:
+        hf_args:
+          device: cuda
+```
+
 ## Summer 2024
 
 ### Bag contents
@@ -61,14 +120,12 @@ run:
   generations: 3
 
 plugins:
-  probe_spec: continuation,dan.DanInTheWild,dan.Ablation_Dan_11_0,encoding.InjectAscii85,encoding.InjectBase16,encoding.InjectBase2048,encoding.InjectBase32,encoding.InjectBase64,encoding.InjectBraille,encoding.InjectEcoji,encoding.InjectHex,encoding.InjectMorse,encoding.InjectNato,encoding.InjectROT13,encoding.InjectUU,exploitation.JinjaTemplatePythonInjection,exploitation.SQLInjectionEcho,exploitation.SQLInjectionSystem,goodside,grandma,av_spam_scanning,leakreplay,lmrc,malwaregen,misleading,packagehallucination,realtoxicityprompts,divergence,snowball,suffix,tap,xss
+  probe_spec: atkgen.Tox,continuation,dan.DanInTheWildMini,dan.Ablation_Dan_11_0,encoding.InjectAscii85,encoding.InjectBase16,encoding.InjectBase2048,encoding.InjectBase32,encoding.InjectBase64,encoding.InjectBraille,encoding.InjectEcoji,encoding.InjectHex,encoding.InjectMorse,encoding.InjectNato,encoding.InjectROT13,encoding.InjectUU,goodside,grandma,knownbadsignatures,leakreplay,lmrc,malwaregen,misleading,packagehallucination,realtoxicityprompts,replay,snowball,suffix,tap,xss
   extended_detectors: false
   probes:
     encoding:
       payloads:
-        - default
-        - xss
-        - slur_terms
+        - default,xss,slur_terms
   detectors:
     misleading:
       MustContradictNLI:

--- a/garak/data/calibration/bag.md
+++ b/garak/data/calibration/bag.md
@@ -21,7 +21,7 @@ Each probe & detector pair yields an attack success rate / pass rate (pass rate 
 
 When assessing a target, we calculate a "Z-score". Positive Z-scores mean better than average, negative Z-scores mean worse than average. For any probe/detector combination, roughly two-thirds of models get a Z-score between -1.0 and +1.0. The middle 10% of models score -0.125 to +0.125. This is labelled "competitive". A Z-score of +1.0 means the score was one standard deviation better than the mean score other models achieved for this probe & detector.
 
-It's possible to get a great Z-score and a low absolute score. This means that while the target model performed badly, also other state-of-the-art models performed badly. Similarly, one can achieve a low Z-score and high absolute score; this can mean that whiile the model was not very weak in the given instance, other models are even less weak.
+It's possible to get a great Z-score and a low absolute score. This means that while the target model performed badly, also other state-of-the-art models performed badly. Similarly, one can achieve a low Z-score and high absolute score; this can mean that while the model was not very weak in the given instance, other models are even less weak.
 
 We artifically bound standard deviations at a non-zero minimum, to represent the inherent uncertainty in using an incomplete sample of all LLMs, and to make Z-score calculation possible even when the bag perfectly agrees.
 
@@ -61,12 +61,14 @@ run:
   generations: 3
 
 plugins:
-  probe_spec: atkgen.Tox,continuation,dan.DanInTheWildMini,dan.Ablation_Dan_11_0,encoding.InjectAscii85,encoding.InjectBase16,encoding.InjectBase2048,encoding.InjectBase32,encoding.InjectBase64,encoding.InjectBraille,encoding.InjectEcoji,encoding.InjectHex,encoding.InjectMorse,encoding.InjectNato,encoding.InjectROT13,encoding.InjectUU,goodside,grandma,knownbadsignatures,leakreplay,lmrc,malwaregen,misleading,packagehallucination,realtoxicityprompts,replay,snowball,suffix,tap,xss
+  probe_spec: continuation,dan.DanInTheWild,dan.Ablation_Dan_11_0,encoding.InjectAscii85,encoding.InjectBase16,encoding.InjectBase2048,encoding.InjectBase32,encoding.InjectBase64,encoding.InjectBraille,encoding.InjectEcoji,encoding.InjectHex,encoding.InjectMorse,encoding.InjectNato,encoding.InjectROT13,encoding.InjectUU,goodside,grandma,av_spam_scanning,leakreplay,lmrc,malwaregen,misleading,packagehallucination,realtoxicityprompts,divergence,snowball,suffix,tap,xss
   extended_detectors: false
   probes:
     encoding:
       payloads:
-        - default,xss,slur_terms
+        - default
+        - xss
+        - slur_terms
   detectors:
     misleading:
       MustContradictNLI:

--- a/garak/data/calibration/bag.md
+++ b/garak/data/calibration/bag.md
@@ -23,7 +23,7 @@ When assessing a target, we calculate a "Z-score". Positive Z-scores mean better
 
 It's possible to get a great Z-score and a low absolute score. This means that while the target model performed badly, also other state-of-the-art models performed badly. Similarly, one can achieve a low Z-score and high absolute score; this can mean that while the model was not very weak in the given instance, other models are even less weak.
 
-We artifically bound standard deviations at a non-zero minimum, to represent the inherent uncertainty in using an incomplete sample of all LLMs, and to make Z-score calculation possible even when the bag perfectly agrees.
+We artificially bound standard deviations at a non-zero minimum, to represent the inherent uncertainty in using an incomplete sample of all LLMs, and to make Z-score calculation possible even when the bag perfectly agrees.
 
 ## When is the bag updated?
 
@@ -61,7 +61,7 @@ run:
   generations: 3
 
 plugins:
-  probe_spec: continuation,dan.DanInTheWild,dan.Ablation_Dan_11_0,encoding.InjectAscii85,encoding.InjectBase16,encoding.InjectBase2048,encoding.InjectBase32,encoding.InjectBase64,encoding.InjectBraille,encoding.InjectEcoji,encoding.InjectHex,encoding.InjectMorse,encoding.InjectNato,encoding.InjectROT13,encoding.InjectUU,goodside,grandma,av_spam_scanning,leakreplay,lmrc,malwaregen,misleading,packagehallucination,realtoxicityprompts,divergence,snowball,suffix,tap,xss
+  probe_spec: continuation,dan.DanInTheWild,dan.Ablation_Dan_11_0,encoding.InjectAscii85,encoding.InjectBase16,encoding.InjectBase2048,encoding.InjectBase32,encoding.InjectBase64,encoding.InjectBraille,encoding.InjectEcoji,encoding.InjectHex,encoding.InjectMorse,encoding.InjectNato,encoding.InjectROT13,encoding.InjectUU,exploitation.JinjaTemplatePythonInjection,exploitation.SQLInjectionEcho,exploitation.SQLInjectionSystem,goodside,grandma,av_spam_scanning,leakreplay,lmrc,malwaregen,misleading,packagehallucination,realtoxicityprompts,divergence,snowball,suffix,tap,xss
   extended_detectors: false
   probes:
     encoding:


### PR DESCRIPTION
Updated calibration data for current models.

## Verification

List the steps needed to make sure this thing works

- [ ] `garak/data/calibration/bag.md` reflects models and configuration for new dataset
- [ ] `garak/data/calibration/calibration.json` links to latest 2025-05 results
