### PR TITLE
reporting: change default aggregation

### DIFF
--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -180,14 +180,20 @@ def compile_digest(
             case "median":
                 group_score = statistics.median(probe_scores)
             case "lower_quartile":
-                group_score = statistics.quantiles(probe_scores, method="inclusive")[0]
+                if len(probe_scores) == 1:
+                    group_score = probe_scores[0]
+                else:
+                    group_score = statistics.quantiles(probe_scores, method="inclusive")[0]
             case "mean_minus_sd":
-                group_score = statistics.mean(probe_scores) - statistics.stdev(
-                    probe_scores
-                )
+                if len(probe_scores) == 1:
+                    group_score = probe_scores[0]
+                else:
+                    group_score = statistics.mean(probe_scores) - statistics.stdev(
+                        probe_scores
+                    )
             case "proportion_passing":
                 group_score = 100.0 * (
-                    len([p for p in probe_scores if p > 40]) / len(probe_scores)
+                    len([p for p in probe_scores if p > garak.analyze.ABSOLUTE_DEFCON_BOUNDS.BELOW_AVG * 100]) / len(probe_scores)
                 )
             case _:
                 group_score = min(probe_scores)  # minimum as default

--- a/garak/analyze/templates/digest_group.jinja
+++ b/garak/analyze/templates/digest_group.jinja
@@ -1,13 +1,13 @@
 
-<button class="defcon{{severity}} accordion"><b>{{ group }}</b>{% if show_group_score %} - {{ group_score }}{%endif%}</button>
+<button class="defcon{{severity}} accordion"><b>{{ group }}</b>{% if show_top_group_score %} <span title="{{group_aggregation_function}}">- {{ group_score }} </span>{%endif%}</button>
 <div class="panel">
 <!-- <p>{{doc}}</p> -->
 {%if group_score != "100.0%"%}
-<p>Probes under
+<p>
 {%if group_link%}
 <a href="{{group_link}}" target="_new">{{group}}</a>
 {%else%}
 "{{group}}"
 {%endif%}
- scored the target a {{ group_score }} pass rate ({{group_aggregation_function}}).</p>
+</p>
 {%endif%}

--- a/garak/analyze/templates/digest_header.jinja
+++ b/garak/analyze/templates/digest_header.jinja
@@ -119,7 +119,7 @@ payload load: {{payload}}
 </div>
 
 {%if model_name %}
-<h2>results: {{model_type}} / {{model_name}}</h2>
+<h2>Results: {{model_type}} / {{model_name}}</h2>
 {%else%}
-<h2>results:</h2>
+<h2>Results:</h2>
 {%endif%}

--- a/garak/resources/garak.core.yaml
+++ b/garak/resources/garak.core.yaml
@@ -42,4 +42,4 @@ reporting:
   report_dir: garak_runs
   show_100_pass_modules: true
   show_top_group_score: true
-  group_aggregation_function: mean
+  group_aggregation_function: lower_quartile


### PR DESCRIPTION
Reporting tweaks:

* change default module-level aggregation to lower quartile
* note aggregation method in tooltip
* fix group template name to match passed variable
* remove extraneous text in group template
* capitalise report heading