### PR TITLE
bug fix: enable extended detectors, module-specified encoding payloads by default

### DIFF
--- a/garak/resources/garak.core.yaml
+++ b/garak/resources/garak.core.yaml
@@ -23,7 +23,7 @@ plugins:
   model_name:
   probe_spec: all
   detector_spec: auto
-  extended_detectors: false
+  extended_detectors: true
   buff_spec:
   buffs_include_original_prompt: false
   buff_max: 
@@ -31,10 +31,6 @@ plugins:
   generators: {}
   buffs: {}
   harnesses: {}
-  probes:
-    encoding:
-      payloads:
-        - default
 
 reporting:
   report_prefix:


### PR DESCRIPTION
`garak.core.yaml` had two undesired behaviors:

1. `extended detectors=false` , should now be `true`
2. probes.encoding config overrode the defaults in the encoding.EncodingMixin class which had been updated to cover more payloads by default

## Verification

- [ ] default run uses extended detectors; try `python -m garak -m test -p grandma.Win11` - two detectors should run
- [ ] encoding probes should have more than 30 inferences with `generations=1`; try `python -m garak -m test -p encoding -g1` and check that scores are out of max `_config.run._soft_prompt_probe_cap` and not 30.
