### PR TITLE
remove modality redundant check

### DIFF
--- a/garak/probes/visual_jailbreak.py
+++ b/garak/probes/visual_jailbreak.py
@@ -113,10 +113,6 @@ class FigStep(FigStepFull, garak.probes.Probe):
     def probe(self, generator):
         if not isinstance(generator, Generator):
             raise ValueError("Incorrect class type of incoming argument `generator`.")
-        if not generator.modality["in"] == self.modality["in"]:
-            raise ValueError(
-                f"Incorrect generator input modality {generator.modality['in']}, expect {self.modality['in']} for this probe."
-            )
         self.prompts = [
             {
                 "text": prompt["text"],


### PR DESCRIPTION
Harness execution is currently responsible for checking modality support before attempting a probe, this check is now redundant and more strict than required.

## Verification

List the steps needed to make sure this thing works

- [ ] Supporting configuration for `gemma.json`
``` json
{
  "nim": {
    "max_tokens": 4000,
    "suppressed_params": [
      "n",
      "frequency_penalty",
      "presence_penalty",
      "timeout",
      "seed",
      "stop"
    ]
  }
}
```
- [ ] `python -m garak -m nim.NVMultimodal -n google/gemma-3-27b-it --generator_option_file gemma.json -p visual_jailbreak.FigStep`
- [ ] **Verify** the probe executes attempts
