### PR TITLE
chore: The bare .active has too much blast radius

### DIFF
--- a/garak/analyze/templates/digest_header.jinja
+++ b/garak/analyze/templates/digest_header.jinja
@@ -74,7 +74,7 @@ span.dc {
 }
 
 /* Add a background color to the button if it is clicked on (add the .active class with JS), and when you move the mouse over it (hover) */
-.active, .accordion:hover {
+.accordion.active, .accordion:hover {
   background-color: #ccf;
 }
 


### PR DESCRIPTION
Without this change, a report cannot be embedded
in an HTML page that has anything else with
an `active` attribute.

Please ensure you are submitting **from a unique branch** in your repository to `main` upstream.

## Verification

List the steps needed to make sure this thing works

1. Get a report.html file.
2. In the body, after the H1, add an ol like the foll:
```
<h1>garak run: garak.report.jsonl</h1>
<ol>
  <li>plain</li>
  <li class="active">active, please do not automatically make me purple</li>
<ol>
```
