### PR TITLE
docs: Address RST issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ garak_runs/
 runs/
 logs/
 .DS_Store
+
+docs/source/_build
+docs/source/html

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,8 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/source/_build
+docs/source/html
 
 # PyBuilder
 .pybuilder/
@@ -169,6 +171,3 @@ garak_runs/
 runs/
 logs/
 .DS_Store
-
-docs/source/_build
-docs/source/html

--- a/docs/source/basic.rst
+++ b/docs/source/basic.rst
@@ -9,7 +9,7 @@ organise this process.
 
 generators
 ----------
-:doc:`<generators>` wrap a target LLM or dialogue system. They take a prompt 
+:doc:`generators` wrap a target LLM or dialogue system. They take a prompt 
 and return the output. The rest is abstracted away. Generator classes
 deal with things like authentication, loading, connection management,
 backoff, and all the behind-the-scenes things that need to happen
@@ -17,14 +17,14 @@ to get that prompt/response interaction working.
 
 probes
 ------
-:doc:`<probes>` tries to exploit a weakness and elicit a failure. The probe
+:doc:`probes` tries to exploit a weakness and elicit a failure. The probe
 manages all the interaction with the generator. It determines how
 often to prompt, and what the content of the prompts is. Interaction 
 between probes and generators is mediated in an object called an attempt.
 
 attempt
 -------
-An :doc:`<attempt>` represents one unique try at breaking the target. A probe wraps
+An :doc:`attempt` represents one unique try at breaking the target. A probe wraps
 up each of its adversarial interactions in an attempt object, and passes this
 to the generator. The generator adds responses into the attempt and sends
 the attempt back. This is logged in ``garak`` reporting which contains (among other
@@ -36,7 +36,7 @@ detector.
 
 detectors
 ---------
-:doc:`<detectors>` attempt to identify a single failure mode. This could be 
+:doc:`detectors` attempt to identify a single failure mode. This could be 
 for example some unsafe contact, or failure to refuse a request. Detectors
 do this by examining outputs that are stored in a prompt, looking for a
 certain phenomenon. This could be a lack of refusal, or continuation of a
@@ -45,19 +45,19 @@ string in a certain way, or decoding an encoded prompt, for example.
 
 buffs
 -----
-:doc:`<buffs>` adjust prompts before they're sent to a generator. This could involve
+:doc:`buffs` adjust prompts before they're sent to a generator. This could involve
 translating them to another language, or adding paraphrases for probes that
 have only a few, static prompts.
 
 
 evaluators
 ----------
-When detectors have added judgments to attempts, :doc:`<evaluators>` converts the results
+When detectors have added judgments to attempts, :doc:`evaluators` converts the results
 to an object containing pass/fail data for a specific probe and detector pair.
 
 harnesses
 ---------
-The :doc:`<harnesses>` manage orchestration of a ``garak`` run. They select probes, then 
+The :doc:`harnesses` manage orchestration of a ``garak`` run. They select probes, then 
 detectors, and co-ordinate running probes, passing results to detectors, and 
 doing the final evaluation
 

--- a/docs/source/configurable.rst
+++ b/docs/source/configurable.rst
@@ -1,3 +1,4 @@
+# headings: = - ^ "
 Configuring ``garak``
 =====================
 
@@ -349,7 +350,7 @@ This function takes two parameters:
 ``load_plugin()`` returns a configured instance of the requested plugin.
 
 OpenAIGenerator config with dictionary
-""""""""""""""""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: python
 

--- a/docs/source/detectors.rst
+++ b/docs/source/detectors.rst
@@ -28,7 +28,6 @@ garak.detectors
    garak.detectors.productkey
    garak.detectors.shields
    garak.detectors.snowball
-   garak.detectors.specialwords
    garak.detectors.unsafe_content
    garak.detectors.xss
    garak.detectors.visual_jailbreak

--- a/docs/source/extending.generator.rst
+++ b/docs/source/extending.generator.rst
@@ -223,7 +223,8 @@ One housekeeping point: because we lazy-import ``replicate``, the requested back
 Generator failure
 =================
 
-If the request really can't be served - maybe the prompt is longer than the context window and there's no specific handling in this case - then ``_call_model`` can return a ``None``. In the case of models that support multiple generations, ``_call_model`` should return a list of outputs and, optionally, ``None``s, with one list entry per requested generation.
+If the request really can't be served - maybe the prompt is longer than the context window and there's no specific handling in this case - then ``_call_model`` can return a ``None``.
+In the case of models that support multiple generations, ``_call_model`` should return a list of outputs and, optionally, ``None``\ s, with one list entry per requested generation.
 
 Testing
 =======

--- a/docs/source/extending.probe.rst
+++ b/docs/source/extending.probe.rst
@@ -22,7 +22,7 @@ All probes will inherit from ``garak.probes.base.Probe``, exposed at package lev
 We require class docstrings in garak and enforce this requirement via a test required before merging.
 
 Probes must always inherit from ``garak.probes.base.Probe``.
-This allows probes to work nicely with `Generator` and `Attempt` objects in addition to ensuring that any `Buff`s that one might want to apply to a probe are going to work appropriately.
+This allows probes to work nicely with ``Generator`` and ``Attempt`` objects in addition to ensuring that any ``Buff``\ s that one might want to apply to a probe are going to work appropriately.
 
 The ``probe`` method of ``Probe`` objects is where the core logic of a probe lies.
 Ideally, one would need only to populate the ``prompts`` attribute of a ``Probe`` and let the ``probe`` method do the heavy lifting.

--- a/docs/source/garak.buffs.low_resource_languages.rst
+++ b/docs/source/garak.buffs.low_resource_languages.rst
@@ -1,5 +1,5 @@
 garak.buffs.low_resource_languages
-=====================
+==================================
 
 .. automodule:: garak.buffs.low_resource_languages
    :members:

--- a/docs/source/garak.detectors.exploitation.rst
+++ b/docs/source/garak.detectors.exploitation.rst
@@ -1,7 +1,7 @@
-garak.detectors.injection
-=========================
+garak.detectors.exploitation
+============================
 
-.. automodule:: garak.detectors.injection
+.. automodule:: garak.detectors.exploitation
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/garak.detectors.specialwords.rst
+++ b/docs/source/garak.detectors.specialwords.rst
@@ -1,8 +1,0 @@
-garak.detectors.specialwords
-============================
-
-.. automodule:: garak.detectors.specialwords
-   :members:
-   :undoc-members:
-   :show-inheritance:   
-

--- a/docs/source/garak.generators.base.rst
+++ b/docs/source/garak.generators.base.rst
@@ -1,7 +1,7 @@
 garak.generators.base
 =====================
 
-In garak, ``Generator``s wrap any text-to-text+ system that garak will examine. This could be a raw LLM, a chatbot endpoint, or even a non-LLM dialog system. This base class defines the basic structure of garak's generators. All generators inherit from garak.generators.base.Generator.
+In garak, ``Generator``\ s wrap any text-to-text+ system that garak will examine. This could be a raw LLM, a chatbot endpoint, or even a non-LLM dialog system. This base class defines the basic structure of garak's generators. All generators inherit from garak.generators.base.Generator.
 
 Attributes:
 
@@ -24,18 +24,20 @@ Functions:
 
 #. **generate*()**: This method is mediating access to the underlying model or dialogue system. The ``generate()`` orchestrates all interaction with the dialogue service/model. It takes a prompt and, optionally, a number of output generations (``generations_this_call``). It returns a list of responses of length up to the number of output generations, with each member a prompt response (e.g. text). Since ``generate()`` involves a reasonable amount of logic, it is preferable to not override this function, and rather work with the hooks and sub-methods provided.
 
-The general flow in ``generate()`` is as follows:
+   The general flow in ``generate()`` is as follows:
+   
+     #. Call the ``_pre_generate_hook()``.
+     #. Work out how many generations we're doing this call (passed via ``generations_this_call``).
+     #. If only one generation is requested, return the output of ``_call_model`` with 1 generation specified.
+     #. If the underlying model supports multiple generations, return the output of ``_call_model`` invoked with the full count of generations.
+     #. Otherwise, we need to assemble the outputs over multiple calls. There are two options here.
 
-  #. Call the ``_pre_generate_hook()``.
-  #. Work out how many generations we're doing this call (passed via ``generations_this_call``).
-  #. If only one generation is requested, return the output of ``_call_model`` with 1 generation specified.
-  #. If the underlying model supports multiple generations, return the output of ``_call_model`` invoked with the full count of generations.
-  #. Otherwise, we need to assemble the outputs over multiple calls. There are two options here.
-    #. Is garak running with ``parallel_attempts > 1`` configured? In that case, start a multiprocessing pool with as many workers as the value of ``parallel_attempts``, and have each one of these work on building the required number of generations, in any order.
-    #. Otherwise, call ``_call_model()`` repeatedly to collect the requested number of generations.
-  #. Call the ``_post_generate_hook()`` (a no-op by default)
-  #. If skip sequence start and end are both defined, call ``_prune_skip_sequences()``
-  #. Return the resulting list of prompt responses.
+        #. Is garak running with ``parallel_attempts > 1`` configured? In that case, start a multiprocessing pool with as many workers as the value of ``parallel_attempts``, and have each one of these work on building the required number of generations, in any order.
+        #. Otherwise, call ``_call_model()`` repeatedly to collect the requested number of generations.
+
+     #. Call the ``_post_generate_hook()`` (a no-op by default)
+     #. If skip sequence start and end are both defined, call ``_prune_skip_sequences()``
+     #. Return the resulting list of prompt responses.
 
 
 #. **_call_model()**: This method handles direct interaction with the model. It takes a prompt and an optional number of generations this call, and returns a list of prompt responses (e.g. strings) and ``None``s. Models may return ``None`` in the case the underlying system failed unrecoverably. This is the method to write model interaction code in. If the class' supports_multiple_generations is false, _call_model does not need to accept values of ``generations_this_call`` other than ``1``.

--- a/docs/source/garak.generators.groq.rst
+++ b/docs/source/garak.generators.groq.rst
@@ -1,5 +1,5 @@
 garak.generators.groq
-====================
+=====================
 
 .. automodule:: garak.generators.groq
    :members:

--- a/docs/source/garak.generators.watsonx.rst
+++ b/docs/source/garak.generators.watsonx.rst
@@ -1,5 +1,5 @@
 garak.generators.watsonx
-=======================
+========================
 
 .. automodule:: garak.generators.watsonx
    :members:

--- a/docs/source/garak.probes._tier.rst
+++ b/docs/source/garak.probes._tier.rst
@@ -1,7 +1,7 @@
 garak.probes._tier
 ==================
 
-Why are there ``Tier``s in garak? That's a good question -- why would there be tiers for anything? Implicit in this notion is the idea that an item of a higher tier is "better" for some metric. In gaming, tiers are often used to highlight characters/decks with higher win rates. 
+Why are there ``Tier``\ s in garak? That's a good question -- why would there be tiers for anything? Implicit in this notion is the idea that an item of a higher tier is "better" for some metric. In gaming, tiers are often used to highlight characters/decks with higher win rates. 
 
 So what is a tier in garak? The flippant answer is that it's a convenient way to deal with the question "What probes should I run?" -- something new users and those who don't like to spin their GPU for extended periods of time often ask. It effectively establishes a hierarchy to say "If you can only run a small number of probes, these are the most important ones". But what makes a probe important? Well, unfortunately, the best answer to that question is a classic: it depends.
 

--- a/docs/source/garak.probes.exploitation.rst
+++ b/docs/source/garak.probes.exploitation.rst
@@ -1,5 +1,5 @@
 garak.probes.exploitation
-======================
+=========================
 
 .. automodule:: garak.probes.exploitation
    :members:

--- a/docs/source/garak.probes.suffix.rst
+++ b/docs/source/garak.probes.suffix.rst
@@ -1,5 +1,5 @@
 garak.probes.suffix
-================
+===================
 
 .. automodule:: garak.probes.suffix
    :members:

--- a/docs/source/generators.rst
+++ b/docs/source/generators.rst
@@ -3,7 +3,7 @@ garak.generators
 
 garak's generators each wrap a set of ways for interfacing with a dialogue system or LLM.
 
-For a detailed oversight into how a generator operates, see :ref:`garak.generators.base.rst`.
+For a detailed oversight into how a generator operates, see :doc:`garak.generators.base`.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/langservice.rst
+++ b/docs/source/langservice.rst
@@ -1,9 +1,9 @@
-The ``langservice`` module in garak is designed to handle text language tasks using various translation services and models. 
-It provides an entry point to translation support backed by translators, each implementing different translation strategies and models, including both cloud-based services, 
-like `DeepL <https://www.deepl.com/>`_ and `NVIDIA Riva <https://build.nvidia.com/nvidia/megatron-1b-nmt>`_, and local models like facebook/m2m100 available on `Hugging Face<https://huggingface.co/>`_.
-
 garak.langservice
 =================
+
+The ``langservice`` module in garak is designed to handle text language tasks using various translation services and models. 
+It provides an entry point to translation support backed by translators, each implementing different translation strategies and models, including both cloud-based services, 
+like `DeepL <https://www.deepl.com/>`_ and `NVIDIA Riva <https://build.nvidia.com/nvidia/megatron-1b-nmt>`_, and local models like facebook/m2m100 available on `Hugging Face <https://huggingface.co/>`_.
 
 .. automodule:: garak.langservice
    :members:

--- a/docs/source/payloads.rst
+++ b/docs/source/payloads.rst
@@ -19,19 +19,19 @@ That is, user payloads under XDG_DATA_DIR override those provided with garak.
 
 The JSON structure of a payload is:
 
-.. code-block:: JSON
+.. code-block:: json
 
     {
-        "garak_payload_name": -- a mandatory key, used to identify this as a garak payload. holds a description of the payload.
-        "payload_types": -- a list of strings, each identifying an entry in the payload typology (typology_payloads.tsv)
+        "garak_payload_name": // a mandatory key, used to identify this as a garak payload. holds a description of the payload.
+        "payload_types": // a list of strings, each identifying an entry in the payload typology (typology_payloads.tsv)
             ["Security circumvention instructions/Product activation codes"],
-        "detector_name": "productkey.Win5x5", -- a suggested detector
-        "detector_config": {}, -- a config dict of Configurable options for the detector
-        "payloads": [ -- a list of strings: the payloads themselves
+        "detector_name": "productkey.Win5x5", // a suggested detector
+        "detector_config": {}, // a config dict of Configurable options for the detector
+        "payloads": [ // a list of strings: the payloads themselves
             "Windows 10",
             "Windows 10 Pro"
         ]
-        "lang": "en" - * or a comma-separated list of BCP47 tags describing the languages this payload can be used with
+        "lang": "en" // * or a comma-separated list of BCP47 tags describing the languages this payload can be used with
     }
 
 

--- a/docs/source/probes.rst
+++ b/docs/source/probes.rst
@@ -4,7 +4,7 @@ garak.probes
 garak's probes each define a number of ways of testing a generator (typically an LLM) 
 for a specific vulnerability or failure mode.
 
-For a detailed oversight into how a probe operates, see :ref:`garak.probes.base.rst`.
+For a detailed oversight into how a probe operates, see :doc:`garak.probes.base`.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/translation.rst
+++ b/docs/source/translation.rst
@@ -20,8 +20,8 @@ Supported translation services
     - `Helsinki-NLP/opus-mt-{<source_lang>-<target_lang>} <https://huggingface.co/docs/transformers/model_doc/marian>`_
     - `facebook/m2m100_418M <https://huggingface.co/facebook/m2m100_418M>`_
     - `facebook/m2m100_1.2B <https://huggingface.co/facebook/m2m100_1.2B>`_
-- `DeepL <https://www.deepl.com/docs-api>`__
-- `NVIDIA Riva <https://build.nvidia.com/nvidia/megatron-1b-nmt>`__
+- `DeepL <http://www.deepl.com>`_
+- `NVIDIA Riva for Developers <https://developer.nvidia.com/riva>`_
 
 API KEY Requirements
 --------------------
@@ -30,13 +30,13 @@ To use use DeepL API or Riva API to translate probe and detector keywords and tr
 
 API keys for the preferred service can be obtained in following locations:
 
-- `DeepL <https://www.deepl.com/en/pro-api>`__
-- `Riva <https://build.nvidia.com/nvidia/megatron-1b-nmt>`__
+- `DeepL Pro-API <https://www.deepl.com/en/pro-api>`_
+- `Riva on build.nvidia.com <https://build.nvidia.com/nvidia/megatron-1b-nmt>`_
 
 Supported languages for remote services:
 
-- `DeepL <https://developers.deepl.com/docs/resources/supported-languages>`__
-- `Riva <https://docs.nvidia.com/nim/riva/nmt/latest/getting-started.html#supported-languages>`__
+- `DeepL Languages Supported | DeepL API documentation <https://developers.deepl.com/docs/resources/supported-languages>`_
+- `Riva support matrix: supported languages <https://docs.nvidia.com/nim/riva/nmt/latest/getting-started.html#supported-languages>`_
 
 API keys can be stored in environment variables with the following commands:
 
@@ -63,7 +63,7 @@ Translation function is configured in the ``run`` section of a configuration wit
 ``langproviders`` - A list of language pair designated translator configurations.
 
 * Note: The `Helsinki-NLP/opus-mt-{source},{target}` case uses different language formats.
-  The language codes used to name models are inconsistent. 
+  The language codes used to name models are inconsistent.
   Two-letter codes can usually be found in the `Google Admin SDK <https://developers.google.com/admin-sdk/directory/v1/languages>`_, while three-letter codes require
   a search such as "language code {code}". More details can be found in the `OPUS-MT-train <https://github.com/Helsinki-NLP/OPUS-MT-train/tree/master/models>`_ repository.
 
@@ -81,7 +81,7 @@ The translator configuration can be written to a file and the path passed, with 
 
 An example template is provided below.
 
-.. code-block:: yaml 
+.. code-block:: yaml
 
    run:
      target_lang: <target-language-code>
@@ -89,11 +89,11 @@ An example template is provided below.
        - language: <source-language-code>,<target-language-code>
          api_key: <your-API-key>
          model_type: <translator-module-or-module.classname>
-         model_name: <huggingface-model-name> 
+         model_name: <huggingface-model-name>
        - language: <target-language-code>,<source-language-code>
          api_key: <your-API-key>
          model_type: <translator-module-or-module.classname>
-         model_name: <huggingface-model-name> 
+         model_name: <huggingface-model-name>
 
 * Note: each translator is configured for a single translation pair and specification is required in each direction for a run to proceed.
 
@@ -106,7 +106,7 @@ DeepL
 To use DeepL translation in garak, run the following command:
 You use the following yaml config.
 
-.. code-block:: yaml 
+.. code-block:: yaml
 
    run:
      target_lang: <target-language-code>
@@ -120,7 +120,7 @@ You use the following yaml config.
 .. code-block:: bash
 
    export DEEPL_API_KEY=xxxx
-   python3 -m garak --model_type nim --model_name meta/llama-3.1-8b-instruct --probes encoding --config {path to your yaml config file} 
+   python3 -m garak --model_type nim --model_name meta/llama-3.1-8b-instruct --probes encoding --config {path to your yaml config file}
 
 
 Riva
@@ -129,7 +129,7 @@ Riva
 For Riva, run the following command:
 You use the following yaml config.
 
-.. code-block:: yaml 
+.. code-block:: yaml
 
    run:
      target_lang: <target-language-code>
@@ -142,7 +142,7 @@ You use the following yaml config.
 .. code-block:: bash
 
    export RIVA_API_KEY=xxxx
-   python3 -m garak --model_type nim --model_name meta/llama-3.1-8b-instruct --probes encoding --config {path to your yaml config file} 
+   python3 -m garak --model_type nim --model_name meta/llama-3.1-8b-instruct --probes encoding --config {path to your yaml config file}
 
 
 Local
@@ -151,7 +151,7 @@ Local
 For local translation, use the following command:
 You use the following yaml config.
 
-.. code-block:: yaml 
+.. code-block:: yaml
 
    run:
      target_lang: jap
@@ -163,15 +163,15 @@ You use the following yaml config.
 
 .. code-block:: bash
 
-   python3 -m garak --model_type nim --model_name meta/llama-3.1-8b-instruct --probes encoding --config {path to your yaml config file} 
+   python3 -m garak --model_type nim --model_name meta/llama-3.1-8b-instruct --probes encoding --config {path to your yaml config file}
 
 The default configuration will load `Helsinki-NLP MarianMT <https://huggingface.co/docs/transformers/model_doc/marian>`_ models for local translation.
 
 Additional support for Huggingface ``M2M100Model`` type only is enabled by providing ``model_name`` for local translators. The model name provided must
 contain ``m2m100`` to be loaded by garak.
 
-.. code-block:: yaml 
-  
+.. code-block:: yaml
+
    run:
      target_lang: ja
      langproviders:
@@ -185,4 +185,4 @@ contain ``m2m100`` to be loaded by garak.
 
 .. code-block:: bash
 
-   python3 -m garak --model_type nim --model_name meta/llama-3.1-8b-instruct --probes encoding --config {path to your yaml config file} 
+   python3 -m garak --model_type nim --model_name meta/llama-3.1-8b-instruct --probes encoding --config {path to your yaml config file}

--- a/docs/source/translation.rst
+++ b/docs/source/translation.rst
@@ -4,23 +4,24 @@ Translation support
 Garak enables translation support for probe and detector keywords and triggers.
 Allowing testing of models that accept and produce text in languages other than the language the plugin was written for.
 
-* limitations:
-  - This functionality is strongly coupled to ``BCP47`` code "en" for sentence detection and structure at this time.
-  - Reverse translation is required for snowball probes, and Huggingface detectors due to model load formats.
-  - Huggingface detectors primarily load English models. Requiring a target language NLI model for the detector.
-  - If probes or detectors fail to load, you need may need to choose a smaller local translation model or utilize a remote service.
-  - Translation may add significant execution time to the run depending on resources available.
+Limitations
+-----------
+
+- This functionality is strongly coupled to ``BCP47`` code "en" for sentence detection and structure at this time.
+- Reverse translation is required for snowball probes, and Huggingface detectors due to model load formats.
+- Huggingface detectors primarily load English models. Requiring a target language NLI model for the detector.
+- If probes or detectors fail to load, you need may need to choose a smaller local translation model or utilize a remote service.
+- Translation may add significant execution time to the run depending on resources available.
 
 Supported translation services
 ------------------------------
 
-- Huggingface
-  - This project supports usage of the following translation models:
+- Huggingface: This project supports usage of the following translation models:
     - `Helsinki-NLP/opus-mt-{<source_lang>-<target_lang>} <https://huggingface.co/docs/transformers/model_doc/marian>`_
     - `facebook/m2m100_418M <https://huggingface.co/facebook/m2m100_418M>`_
     - `facebook/m2m100_1.2B <https://huggingface.co/facebook/m2m100_1.2B>`_
-- `DeepL <https://www.deepl.com/docs-api>`_
-- `NVIDIA Riva <https://build.nvidia.com/nvidia/megatron-1b-nmt>`_
+- `DeepL <https://www.deepl.com/docs-api>`__
+- `NVIDIA Riva <https://build.nvidia.com/nvidia/megatron-1b-nmt>`__
 
 API KEY Requirements
 --------------------
@@ -29,13 +30,13 @@ To use use DeepL API or Riva API to translate probe and detector keywords and tr
 
 API keys for the preferred service can be obtained in following locations:
 
-- `DeepL <https://www.deepl.com/en/pro-api>`_
-- `Riva <https://build.nvidia.com/nvidia/megatron-1b-nmt>`_
+- `DeepL <https://www.deepl.com/en/pro-api>`__
+- `Riva <https://build.nvidia.com/nvidia/megatron-1b-nmt>`__
 
 Supported languages for remote services:
 
-- `DeepL <https://developers.deepl.com/docs/resources/supported-languages>`_
-- `Riva <https://docs.nvidia.com/nim/riva/nmt/latest/getting-started.html#supported-languages>`_
+- `DeepL <https://developers.deepl.com/docs/resources/supported-languages>`__
+- `Riva <https://docs.nvidia.com/nim/riva/nmt/latest/getting-started.html#supported-languages>`__
 
 API keys can be stored in environment variables with the following commands:
 
@@ -61,9 +62,10 @@ Translation function is configured in the ``run`` section of a configuration wit
 ``target_lang``   - A single ``BCP47`` entry designating the language of the target under test. "ja", "fr", "jap" etc.
 ``langproviders`` - A list of language pair designated translator configurations.
 
-* Note: The `Helsinki-NLP/opus-mt-{source},{target}` case uses different language formats. The language codes used to name models are inconsistent. 
-Two-letter codes can usually be found `here <https://developers.google.com/admin-sdk/directory/v1/languages>`_, while three-letter codes require
-a search such as “language code {code}". More details can be found `here <https://github.com/Helsinki-NLP/OPUS-MT-train/tree/master/models>`_.
+* Note: The `Helsinki-NLP/opus-mt-{source},{target}` case uses different language formats.
+  The language codes used to name models are inconsistent. 
+  Two-letter codes can usually be found in the `Google Admin SDK <https://developers.google.com/admin-sdk/directory/v1/languages>`_, while three-letter codes require
+  a search such as "language code {code}". More details can be found in the `OPUS-MT-train <https://github.com/Helsinki-NLP/OPUS-MT-train/tree/master/models>`_ repository.
 
 A language provider configuration is provided using the project's configurable pattern with the following keys:
 
@@ -81,17 +83,17 @@ An example template is provided below.
 
 .. code-block:: yaml 
 
-run:
-  target_lang: {target language code}
-  langproviders:
-    - language: {source language code},{target language code}
-      api_key: {your API key}
-      model_type: {translator module or module.classname}
-      model_name: {huggingface model name} 
-    - language: {target language code},{source language code}
-      api_key: {your API key}
-      model_type: {translator module or module.classname}
-      model_name: {huggingface model name} 
+   run:
+     target_lang: <target-language-code>
+     langproviders:
+       - language: <source-language-code>,<target-language-code>
+         api_key: <your-API-key>
+         model_type: <translator-module-or-module.classname>
+         model_name: <huggingface-model-name> 
+       - language: <target-language-code>,<source-language-code>
+         api_key: <your-API-key>
+         model_type: <translator-module-or-module.classname>
+         model_name: <huggingface-model-name> 
 
 * Note: each translator is configured for a single translation pair and specification is required in each direction for a run to proceed.
 
@@ -106,19 +108,19 @@ You use the following yaml config.
 
 .. code-block:: yaml 
 
-run:
-  target_lang: {target language code}
-  langproviders:
-    - language: {source language code},{target language code}
-      model_type: remote.DeeplTranslator
-    - language: {target language code},{source language code}
-      model_type: remote.DeeplTranslator
+   run:
+     target_lang: <target-language-code>
+     langproviders:
+       - language: <source-language-code>,<target-language-code>
+         model_type: remote.DeeplTranslator
+       - language: <target-language-code>,<source-language-code>
+         model_type: remote.DeeplTranslator
 
 
 .. code-block:: bash
 
-    export DEEPL_API_KEY=xxxx
-    python3 -m garak --model_type nim --model_name meta/llama-3.1-8b-instruct --probes encoding --config {path to your yaml config file} 
+   export DEEPL_API_KEY=xxxx
+   python3 -m garak --model_type nim --model_name meta/llama-3.1-8b-instruct --probes encoding --config {path to your yaml config file} 
 
 
 Riva
@@ -129,19 +131,18 @@ You use the following yaml config.
 
 .. code-block:: yaml 
 
-run:
-  target_lang: {target language code}
-  langproviders:
-    - language: {source language code},{target language code}
-      model_type: remote
-    - language: {target language code},{source language code}
-      model_type: remote
-
+   run:
+     target_lang: <target-language-code>
+     langproviders:
+       - language: <source-language-code>,<target-language-code>
+         model_type: remote
+       - language: <target-language-code>,<source-language-code>
+         model_type: remote
 
 .. code-block:: bash
 
-    export RIVA_API_KEY=xxxx
-    python3 -m garak --model_type nim --model_name meta/llama-3.1-8b-instruct --probes encoding --config {path to your yaml config file} 
+   export RIVA_API_KEY=xxxx
+   python3 -m garak --model_type nim --model_name meta/llama-3.1-8b-instruct --probes encoding --config {path to your yaml config file} 
 
 
 Local
@@ -152,17 +153,17 @@ You use the following yaml config.
 
 .. code-block:: yaml 
 
-run:
-  target_lang: jap
-  langproviders:
-    - language: en,jap
-      model_type: local
-    - language: jap,en
-      model_type: local
+   run:
+     target_lang: jap
+     langproviders:
+       - language: en,jap
+         model_type: local
+       - language: jap,en
+         model_type: local
 
 .. code-block:: bash
 
-    python3 -m garak --model_type nim --model_name meta/llama-3.1-8b-instruct --probes encoding --config {path to your yaml config file} 
+   python3 -m garak --model_type nim --model_name meta/llama-3.1-8b-instruct --probes encoding --config {path to your yaml config file} 
 
 The default configuration will load `Helsinki-NLP MarianMT <https://huggingface.co/docs/transformers/model_doc/marian>`_ models for local translation.
 
@@ -171,17 +172,17 @@ contain ``m2m100`` to be loaded by garak.
 
 .. code-block:: yaml 
   
-run:
-  target_lang: ja
-  langproviders:
-    - language: en,ja
-      model_type: local
-      model_name: facebook/m2m100_418M
-    - language: jap,en
-      model_type: local
-      model_name: facebook/m2m100_418M
+   run:
+     target_lang: ja
+     langproviders:
+       - language: en,ja
+         model_type: local
+         model_name: facebook/m2m100_418M
+       - language: jap,en
+         model_type: local
+         model_name: facebook/m2m100_418M
 
 
 .. code-block:: bash
 
-    python3 -m garak --model_type nim --model_name meta/llama-3.1-8b-instruct --probes encoding --config {path to your yaml config file} 
+   python3 -m garak --model_type nim --model_name meta/llama-3.1-8b-instruct --probes encoding --config {path to your yaml config file} 


### PR DESCRIPTION
This PR addresses the docs build warnings for issues in the RST files--typically some misformatted syntax.

The goal of this PR (and the next one or two) isn't world-class docs, it's to address build warnings and errors so that I know I do not introduce mayhem during later refactoring.

## Verification

List the steps needed to make sure this thing works


- [ ] review doc site generation
