### PR TITLE
chore: Reformat docstrings to reduce docs issues

### DIFF
--- a/docs/source/basic.rst
+++ b/docs/source/basic.rst
@@ -61,10 +61,8 @@ The :doc:`harnesses` manage orchestration of a ``garak`` run. They select probes
 detectors, and co-ordinate running probes, passing results to detectors, and
 doing the final evaluation
 
-
-
-
 .. automodule:: garak._plugins
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:

--- a/docs/source/garak.detectors.ansiescape.rst
+++ b/docs/source/garak.detectors.ansiescape.rst
@@ -1,7 +1,7 @@
-garak.detectors.always
-======================
+garak.detectors.ansiescape
+==========================
 
-.. automodule:: garak.detectors.always
+.. automodule:: garak.detectors.ansiescape
    :members:
    :undoc-members:
    :show-inheritance:

--- a/garak/attempt.py
+++ b/garak/attempt.py
@@ -43,26 +43,29 @@ class Attempt:
     :param reverse_translation_outputs: The reverse translation of output based on the original language of the probe
     :param reverse_translation_outputs: List(str)
 
-    Expected use
-    * an attempt tracks a seed prompt and responses to it
-    * there's a 1:1 relationship between attempts and source prompts
-    * attempts track all generations
-    * this means messages tracks many histories, one per generation
-    * for compatibility, setting Attempt.prompt will set just one turn, and this is unpacked later
-      when output is set; we don't know the # generations to expect until some output arrives
-    * to keep alignment, generators need to return aligned lists of length #generations
+    Typical use:
 
-    Patterns/expectations for Attempt access:
-    .prompt - returns the first user prompt
-    .outputs - returns the most recent model outputs
-    .latest_prompts - returns a list of the latest user prompts
+    * An attempt tracks a seed prompt and responses to the prompt.
+    * There is a 1:1 relationship between an attempt and a source prompt.
+    * Attempts track all generations.
+      This means ``messages`` tracks many histories, one per generation.
+    * For compatibility, setting ``Attempt.prompt`` sets just one turn and the prompt is unpacked later when output is set.
+      We don't know the number of generations to expect until some output arrives.
+    * To keep alignment, generators must return lists of length generations.
 
-    Patterns/expectations for Attempt setting:
-    .prompt - sets the first prompt, or fails if this has already been done
-    .outputs - sets a new layer of model responses. silently handles expansion of prompt to multiple histories. prompt must be set
-    .latest_prompts - adds a new set of user prompts
+    Patterns and expectations for Attempt access:
 
+    * ``.prompt`` returns the first user prompt.
+    * ``.outputs`` returns the most recent model outputs.
+    * ``.latest_prompts`` returns a list of the latest user prompts.
 
+    Patterns and expectations for Attempt setting:
+
+    * ``.prompt`` sets the first prompt, or fails if the first prompt is already set.
+    * ``.outputs`` sets a new layer of model responses.
+      Silently handles expansion of prompt to multiple histories.
+      Prompt must be set before outputs are set.
+    * ``.latest_prompts`` adds a new set of user prompts.
     """
 
     def __init__(

--- a/garak/generators/function.py
+++ b/garak/generators/function.py
@@ -1,17 +1,17 @@
 """function-based generator
 
-Call a given function to use as a generator; specify this as either the 
+Call a given function to use as a generator; specify this as either the
 model name on the command line, or as the parameter to the constructor.
 
-This generator is designed to be used programmatically, rather than 
+This generator is designed to be used programmatically, rather than
 invoked from the CLI. An example usage might be:
 
-```
-import mymodule
-import garak.generators.function
+.. code-block:: python
 
-g = garak.generators.function.Single(name="mymodule#myfunction")
-```
+   import mymodule
+   import garak.generators.function
+
+   g = garak.generators.function.Single(name="mymodule#myfunction")
 
 The target function is expected to take a string, and return a string.
 Other arguments passed by garak are forwarded to the target function.
@@ -19,13 +19,13 @@ Other arguments passed by garak are forwarded to the target function.
 Note that one can import the intended target module into scope and then
 invoke a garak run via garak's cli module, using something like:
 
-```
-import garak
-import garak.cli
-import mymodule
+.. code-block:: python
 
-garak.cli.main("--model_type function --model_name mymodule#function_name --probes encoding.InjectBase32".split())
-```
+   import garak
+   import garak.cli
+   import mymodule
+
+   garak.cli.main("--model_type function --model_name mymodule#function_name --probes encoding.InjectBase32".split())
 
 """
 
@@ -51,7 +51,11 @@ from garak.generators.base import Generator
 #  self.kwargs = { "special_param": param_value, "special_other_param": other_value }
 #  custom_generator(prompt, **kwargs)
 class Single(Generator):
-    """pass a module#function to be called as generator, with format function(prompt:str, **kwargs)->List[Union(str, None)] the parameter `name` is reserved"""
+    """Pass a function to call as a generator.
+    The function must have the signature ``function(prompt:str, **kwargs)->List[Union(str, None)]``
+    and is specified in the format ``module#function`` with the CLI or in the config file.
+    The parameter ``name`` is reserved.
+    """
 
     DEFAULT_PARAMS = {
         "kwargs": {},
@@ -93,7 +97,11 @@ class Single(Generator):
 
 
 class Multiple(Single):
-    """pass a module#function to be called as generator, with format function(prompt:str, generations:int, **kwargs)->List[Union(str, None)]"""
+    """Pass a function to call as a generator.
+    The function must have the signature ``function(prompt:str, generations:int, **kwargs)->List[Union(str, None)]``
+    and is specified in the format ``module#function`` with the CLI or in the config file.
+    The parameter ``name`` is reserved.
+    """
 
     supports_multiple_generations = True
 

--- a/garak/generators/litellm.py
+++ b/garak/generators/litellm.py
@@ -3,28 +3,28 @@
 Support for LiteLLM, which allows calling LLM APIs using the OpenAI format.
 
 Depending on the model name provider, LiteLLM automatically
-reads API keys from the respective environment variables.
-(e.g. OPENAI_API_KEY for OpenAI models)
+reads API keys from the respective environment variables
+such as ``OPENAI_API_KEY`` for OpenAI models.
 
-e.g Supply a JSON like this for Ollama's OAI api:
-```json
-{
-    "litellm": {
-        "LiteLLMGenerator" : {
-            "api_base" : "http://localhost:11434/v1",
-            "provider" : "openai"
-        }
-    }
-}
-```
+Create a file, such as ``ollama_base.json``, with content like the following
+to connect LiteLLM with the Ollama OAI API:
 
-The above is an example of a config to connect LiteLLM with Ollama's OpenAI compatible API.
+.. code-block:: json
 
-Then, when invoking garak, we pass it the path to the generator option file.
+   {
+       "litellm": {
+           "LiteLLMGenerator" : {
+               "api_base" : "http://localhost:11434/v1",
+               "provider" : "openai"
+           }
+       }
+   }
 
-```
-python -m garak --model_type litellm --model_name "phi" --generator_option_file ollama_base.json -p dan
-```
+When invoking garak, specify the path to the generator option file:
+
+.. code-block:: bash
+
+   python -m garak --model_type litellm --model_name "phi" --generator_option_file ollama_base.json -p dan
 """
 
 import logging
@@ -155,7 +155,6 @@ class LiteLLMGenerator(Generator):
             litellm.exceptions.AuthenticationError,  # authentication failed for detected or passed `provider`
             litellm.exceptions.BadRequestError,
         ) as e:
-
             raise BadGeneratorException(
                 "Unrecoverable error during litellm completion see log for details"
             ) from e

--- a/garak/generators/rasa.py
+++ b/garak/generators/rasa.py
@@ -16,7 +16,8 @@ from garak.generators.rest import RestGenerator
 class RasaRestGenerator(RestGenerator):
     """API interface for RASA models
 
-    Uses the following options from _config.plugins.generators["rasa.RasaRestGenerator"]:
+    Uses the following options from ``_config.plugins.generators["rasa.RasaRestGenerator"]``:
+
     * ``uri`` - (optional) the URI of the REST endpoint; this can also be passed
             in --model_name
     * ``name`` - a short name for this service; defaults to the uri
@@ -48,26 +49,28 @@ class RasaRestGenerator(RestGenerator):
     The $INPUT and $KEY placeholders can also be specified in header values.
 
     If we want to call an endpoint where the API key is defined in the value
-    of an ``X-Authorization header``, sending and receiving JSON where the prompt
+    of an ``X-Authorization`` header, sending and receiving JSON where the prompt
     and response value are both under the "text" key, we'd define the service
     using something like:
 
-    {
-        "rasa": {
-            "RasaRestGenerator": {
-                "name": "example rasa service",
-                "uri": "https://test.com/webhooks/rest/webhook"
-            }
-        }
-    }
+    .. code-block:: json
+
+       {
+           "rasa": {
+               "RasaRestGenerator": {
+                   "name": "example rasa service",
+                   "uri": "https://test.com/webhooks/rest/webhook"
+               }
+           }
+       }
 
     To use this specification with garak, you can either pass the JSON as a
     strong option on the command line via --generator_options, or save the
     JSON definition into a file and pass the filename to
     --generator_option_file / -G. For example, if we save the above JSON into
-    `example_rasa_service.json", we can invoke garak as:
+    ``example_rasa_service.json``, we can invoke garak as:
 
-    garak --model_type rest -G example_rasa_service.json
+      garak --model_type rest -G example_rasa_service.json
 
     This will load up the default RasaRestGenerator and use the details in the
     JSON file to connect to the LLM endpoint.

--- a/garak/probes/phrasing.py
+++ b/garak/probes/phrasing.py
@@ -1,9 +1,8 @@
-"""Past Tense
+"""About Past Tense Probes
 
-    Refusal training is widely used to prevent LLMs from generating harmful, undesirable, or illegal
-outputs. We reveal a curious generalization gap in the current refusal training approaches:
-simply reformulating a harmful request in the past tense  is often sufficient to jailbreak many state-
-of-the-art LLMs
+Refusal training is widely used to prevent LLMs from generating harmful, undesirable, or illegal outputs.
+We reveal a curious generalization gap in the current refusal training approaches:
+simply reformulating a harmful request in the past tense is often sufficient to jailbreak many state-of-the-art LLMs.
 """
 
 from garak import _config

--- a/garak/probes/visual_jailbreak.py
+++ b/garak/probes/visual_jailbreak.py
@@ -18,11 +18,13 @@ from garak.generators.base import Generator
 
 
 class FigStepFull(garak.probes.Probe):
-    """Using another modal - image to assist jailbreak
+    """Using image modality to assist jailbreak.
+    Refer to the following paper for more detail:
 
-    Title: FigStep: Jailbreaking Large Vision-language Models via Typographic Visual Prompts
-    Link: https://arxiv.org/pdf/2311.05608.pdf
-    Reference: Yichen Gong, Delong Ran, Jinyuan Liu, Conglei Wang, Tianshuo Cong, Anyu Wang, Sisi Duan, and Xiaoyun Wang. 2023. FigStep: Jailbreaking Large Vision-language Models via Typographic Visual Prompts.
+    Yichen Gong, Delong Ran, Jinyuan Liu, Conglei Wang, Tianshuo Cong, Anyu Wang, Sisi Duan, and Xiaoyun Wang. 2023.
+    "FigStep: Jailbreaking Large Vision-language Models via Typographic Visual Prompts."
+    ArXiv. https://arxiv.org/pdf/2311.05608
+
     """
 
     active = False  # default to use limit version - FigStep80


### PR DESCRIPTION
Change docstring-related docs build errors and warnings.

- detectors.ansiescape file reffed detectors.always
- revise docstring in attempt.py -- needs SME review
- do we want basic.rst to include _plugins API?
- format comments in function.py as RST
- reformat docstring in litellm as RST instead of MD

## Verification

Building the docs produces three remaining build warnings about documents that are not included in any toctree.  That's the next PR.