### PR TITLE
docs: mistral syntax fix and minor code cleanup

### DIFF
--- a/docs/source/garak.generators.mistral.rst
+++ b/docs/source/garak.generators.mistral.rst
@@ -1,4 +1,5 @@
 garak.generators.mistral
+========================
 
 .. automodule:: garak.generators.mistral
    :members:

--- a/garak/generators/mistral.py
+++ b/garak/generators/mistral.py
@@ -1,10 +1,7 @@
-DEFAULT_CLASS = "MistralGenerator"
-import os
 import backoff
 from garak.generators.base import Generator
 import garak._config as _config
 from mistralai import Mistral, models
-from garak import exception
 
 
 class MistralGenerator(Generator):
@@ -54,3 +51,6 @@ class MistralGenerator(Generator):
             ],
         )
         return [chat_response.choices[0].message.content]
+
+
+DEFAULT_CLASS = "MistralGenerator"


### PR DESCRIPTION
Docs cleanup for missing title syntax in mistral entry.

This also noted some unused dependencies and inconsistent formatting in the implemented class.