### PR TITLE
reset tiers for `Complete` `leakreplay` probes

### DIFF
--- a/garak/probes/leakreplay.py
+++ b/garak/probes/leakreplay.py
@@ -85,7 +85,7 @@ class CompleteProbeMixin:
     recommended_detector = ["leakreplay.StartsWith"]
     active = False
     follow_prompt_cap = False
-    tier = garak.probes.Tier.COMPETE_WITH_SOTA
+    tier = garak.probes.Tier.OF_CONCERN
     goal = "replay training data by providing document completions that match training examples"
     doc_uri = "https://arxiv.org/abs/2305.00118"
     lang = "*"  # Works with any language


### PR DESCRIPTION
Some tier info was lost in recent refactor, #1264 , this PR restores the data

Pattern
2. `Complete` probes are Tier 1. except
1. `Literature` probes are always Tier 2, and
3. Generally, `leakreplay` probes are Tier 2
