### PR TITLE
Replace deprecated `np.infty` with `np.inf`.

### DIFF
--- a/garak/resources/gcg/attack_manager.py
+++ b/garak/resources/gcg/attack_manager.py
@@ -799,7 +799,7 @@ class MultiPromptAttack(object):
         control_weight=None,
         anneal=True,
         anneal_from=0,
-        prev_loss=np.infty,
+        prev_loss=np.inf,
         stop_on_success=True,
         test_steps=50,
         log_first=False,
@@ -1198,7 +1198,7 @@ class ProgressiveMultiPromptAttack(object):
         num_workers = 1 if self.progressive_models else len(self.workers)
         step = 0
         stop_inner_on_success = self.progressive_goals
-        loss = np.infty
+        loss = np.inf
         success = False
 
         while step < n_steps:
@@ -1239,11 +1239,11 @@ class ProgressiveMultiPromptAttack(object):
 
             if num_goals < len(self.goals):
                 num_goals += 1
-                loss = np.infty
+                loss = np.inf
             elif num_goals == len(self.goals):
                 if num_workers < len(self.workers):
                     num_workers += 1
-                    loss = np.infty
+                    loss = np.inf
                 elif num_workers == len(self.workers) and stop_on_success:
                     model_tests = attack.test_all()
                     attack.log(
@@ -1260,7 +1260,7 @@ class ProgressiveMultiPromptAttack(object):
                     if isinstance(control_weight, (int, float)) and incr_control:
                         if control_weight <= 0.09:
                             control_weight += 0.01
-                            loss = np.infty
+                            loss = np.inf
                             if verbose:
                                 logger.debug(
                                     f"Control weight increased to {control_weight:.5}"
@@ -1477,7 +1477,7 @@ class IndividualPromptAttack(object):
                 control_weight=control_weight,
                 anneal=anneal,
                 anneal_from=0,
-                prev_loss=np.infty,
+                prev_loss=np.inf,
                 stop_on_success=stop_inner_on_success,
                 test_steps=test_steps,
                 log_first=True,

--- a/garak/resources/gcg/gcg_attack.py
+++ b/garak/resources/gcg/gcg_attack.py
@@ -116,7 +116,7 @@ class GCGPromptManager(PromptManager):
 
     def sample_control(self, grad, batch_size, topk=256, temp=1, allow_non_ascii=True):
         if not allow_non_ascii:
-            grad[:, self._nonascii_toks.to(grad.device)] = np.infty
+            grad[:, self._nonascii_toks.to(grad.device)] = np.inf
         top_indices = (-grad).topk(topk, dim=1).indices
         control_toks = self.control_toks.to(grad.device)
         original_control_toks = control_toks.repeat(batch_size, 1)


### PR DESCRIPTION
Replace deprecated `np.infty` with `np.inf`. Resolved #1250 