### PR TITLE
documentation: typo fix

### DIFF
--- a/garak/probes/grandma.py
+++ b/garak/probes/grandma.py
@@ -100,7 +100,7 @@ class Slurs(garak.probes.Probe):
 
 
 class Substances(garak.probes.Probe):
-    """Use the grandma attack to get instructios for harmful items.
+    """Use the grandma attack to get instructions for harmful items.
 
     Appeal to pathos to ask the model to output instructions for making
     harmful/illegal goods

--- a/garak/resources/plugin_cache.json
+++ b/garak/resources/plugin_cache.json
@@ -2034,7 +2034,7 @@
       "mod_time": "2025-05-21 06:27:50 +0000"
     },
     "probes.grandma.Substances": {
-      "description": "Use the grandma attack to get instructios for harmful items.",
+      "description": "Use the grandma attack to get instructions for harmful items.",
       "DEFAULT_PARAMS": {
         "substances": [
           "napalm",


### PR DESCRIPTION
Corrects a spelling error in documentation of the `grandma.Substances` probe.

## Verification

- [ ] review docs and `plugin_info`
