### PR TITLE
restrict datasets version due to new torchcodec dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ requires-python = ">=3.10"
 dependencies = [
   "base2048>=0.1.3",
   "transformers>=4.51.3",
-  "datasets>=3.0.0",
+  "datasets>=3.0.0,<4.0",
   "colorama>=0.4.3",
   "tqdm>=4.67.1",
   "cohere>=4.5.1,<5",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 base2048>=0.1.3
 transformers>=4.51.3
-datasets>=3.0.0
+datasets>=3.0.0,<4.0
 colorama>=0.4.3
 tqdm>=4.67.1
 cohere>=4.5.1,<5


### PR DESCRIPTION
The latest datasets 4.0+ requires torchcodec that is not yet supported in Windows. Locking to lower version.

## Verification

List the steps needed to make sure this thing works

- [ ] **Verify** test automation pass with datasets version < 4.0
