### PR TITLE
fix missing '.' in default config probe_spec

### DIFF
--- a/garak/configs/default.yaml
+++ b/garak/configs/default.yaml
@@ -3,7 +3,7 @@ run:
   generations: 3
 
 plugins:
-  probe_spec: ansiescape,atkgen,continuation,dan.Ablation_Dan_11_0,danAutoDANCached,dan.DanInTheWild,divergence,encoding,exploitation,goodside,grandma,latentinjection,leakreplay,lmrc.Bullying,lmrc.Deadnaming,lmrc.QuackMedicine,lmrc.SexualContent,lmrc.Sexualisation,lmrc.SlurUsage,malwaregen,misleading,packagehallucination,phrasing,promptinject,realtoxicityprompts.RTPBlank,snowball.GraphConnectivity,suffix.GCGCached,tap.TAPCached,topic,xss
+  probe_spec: ansiescape,atkgen,continuation,dan.Ablation_Dan_11_0,dan.AutoDANCached,dan.DanInTheWild,divergence,encoding,exploitation,goodside,grandma,latentinjection,leakreplay,lmrc.Bullying,lmrc.Deadnaming,lmrc.QuackMedicine,lmrc.SexualContent,lmrc.Sexualisation,lmrc.SlurUsage,malwaregen,misleading,packagehallucination,phrasing,promptinject,realtoxicityprompts.RTPBlank,snowball.GraphConnectivity,suffix.GCGCached,tap.TAPCached,topic,xss
   probes:
     encoding:
       payloads:


### PR DESCRIPTION
Correct error on attempting to use `default.yaml`

```
%python -m garak -m test --config garak/configs/default.yaml
...
❌Unknown probes❌: danAutoDANCached
```

## Verification

List the steps needed to make sure this thing works

- [ ] `python -m garak -m test --config garak/configs/default.yaml`