### PR TITLE
download models used in translation tests early

### DIFF
--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -65,6 +65,16 @@ jobs:
             .cache/huggingface
           key: garak-test-resources-shared
 
+      - name: More cached models
+        run: |
+          export HF_HUB_DISABLE_XET=1
+          # download translation support models too large for standard cache
+          huggingface-cli download facebook/m2m100_418M --quiet
+          huggingface-cli download Helsinki-NLP/opus-mt-en-fr --quiet
+          huggingface-cli download Helsinki-NLP/opus-mt-fr-en --quiet
+          huggingface-cli download Helsinki-NLP/opus-mt-en-jap --quiet
+          huggingface-cli download Helsinki-NLP/opus-mt-jap-en --quiet
+
       - name: Test with pytest
         run: |
           cd garak


### PR DESCRIPTION
MacOS runners often exhibit errors when downloading some huggingface models due to kernel network buffering issues similar to [this reference](https://stackoverflow.com/questions/21973661/os-x-udp-send-error-55-no-buffer-space-available).

To reduce these errors, suppress the huggingface Xet protocol and prep the cache with early downloads.

In theory this could just set the environment variable before executing any tests, this change intentionally limits the scope of environment changes to a separate process before tests execute.

## Verification

- [ ] MacOS testing automation passes
