### PR TITLE
Switch from `lorem` to `python-lorem`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ dependencies = [
   "huggingface_hub>=0.21.0",
   'python-magic-bin>=0.4.14; sys_platform == "win32"',
   'python-magic>=0.4.21; sys_platform != "win32"',
-  "lorem==0.1.1",
+  "python-lorem>=1.3.0",
   "xdg-base-dirs>=6.0.1",
   "wn==0.9.5",
   "ollama>=0.4.7",

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ jsonpath-ng>=1.6.1
 huggingface_hub>=0.21.0
 python-magic-bin>=0.4.14; sys_platform == "win32"
 python-magic>=0.4.21; sys_platform != "win32"
-lorem==0.1.1
+python-lorem>=1.3.0
 xdg-base-dirs>=6.0.1
 wn==0.9.5
 ollama>=0.4.7


### PR DESCRIPTION
This PR switches out `lorem` for `python-lorem`.

From what I can tell since it has the same library and has the same function names unless there's a problem with the default values for `sentence()` no code changes are necessary?

Has pyproject.toml & typing.

One change which may be relevant is it's BSD 3 Licensed rather than MIT
