### PR TITLE
Use numpy v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ dependencies = [
   "torch>=2.6.0",
   "sentencepiece>=0.1.99",
   "markdown>=3.4.3",
-  "numpy>=1.26.4,<2.0",
+  "numpy>=2.0.0",
   "zalgolib>=0.2.2",
   "ecoji>=0.1.1",
   "deepl==1.17.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ cmd2==2.4.3
 torch>=2.6.0
 sentencepiece>=0.1.99
 markdown>=3.4.3
-numpy>=1.26.4,<2.0
+numpy>=2.0.0
 zalgolib>=0.2.2
 ecoji>=0.1.1
 deepl==1.17.0


### PR DESCRIPTION
Since #1283 it appears garak can update to numpy v2
If there's anything else that needs updating LMK
If you'd prefer to just allow v1 and v2 LMK
