### PR TITLE
Update how license is defined in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ authors = [
   { name = "Divya Chitimalla" },
   { name = "Katherine Luna" },
 ]
-license = { file = "LICENSE" }
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 description = "LLM vulnerability scanner"
 readme = "README.md"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
-    "License :: OSI Approved :: Apache Software License",
 ]
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
Update how license(s) are defined in pyproject.toml

Driver for change:

> By 2026-Feb-18, you need to update your project and remove deprecated calls
> or your builds will no longer be supported.
>
> Please consider removing the following classifiers in favor of a SPDX license expression:
> License :: OSI Approved :: Apache Software License
>
> See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.

