### PR TITLE
Tweaks to how `wn` is used

### DIFF
--- a/tests/probes/test_probes_topic.py
+++ b/tests/probes/test_probes_topic.py
@@ -8,6 +8,9 @@ import garak._plugins
 import garak.probes.base
 import garak.probes.topic
 
+# trigger wn config overrides
+garak.probes.topic.WordnetBlockedWords()
+
 TEST_LEXICON = "oewn:2023"
 TEST_TERM = "abortion"
 TEST_SYNSET_ID = "oewn-00231191-n"


### PR DESCRIPTION
- Trigger `wn` config overrides from `WordnetBlockedWords` before using `wn` in tests
  - Running `wn.Download()` before changing the config location just ends up causing problems and dowloading it again for the new location.
- Use `lang` and pass it through to `wn.Wordnet` in `WordnetBlockedWords`

An alternative may be to move the `wn.config` changes to the root of `garak/probes/topic.py` so it always happens when it's imported. 
This was a problem for me with https://github.com/NixOS/nixpkgs/pull/429835 since nix builds don't have internet access. I was trying to allow for enabling these tests, I found out how to load lexicons from pre-fetched files (https://github.com/goodmami/wn/issues/278) but garak tests weren't fully finding it.

If I loaded them to the default location the initial setup for the test worked but then garak couldn't find the lexicon when actually running. If I loaded them to the garak changed location the test wouldn't start at all. If I loaded them to both locations, default first, then garak, it'd still have problems.
After loading it to the location garak usually expects & adding this to the test it works completely fine:

```
tests/probes/test_probes_topic.py ................                       [ 39%]
```


For the lang change if it's not intended to be sent to `wn.Wordnet` it's not immediately obvious to me what it is actually for.
