### PR TITLE
update usage of fschat required for compatibility

### DIFF
--- a/garak/probes/suffix.py
+++ b/garak/probes/suffix.py
@@ -79,10 +79,14 @@ class GCG(garak.probes.Probe):
         super().__init__(config_root=config_root)
 
     def probe(self, generator) -> List[garak.attempt.Attempt]:
-        self.generator = generator
-
         try:
-            gcg_output = self.run_gcg(target_generator=self.generator)
+            from garak.generators.huggingface import Model
+
+            if not isinstance(generator, Model):
+                msg = f"Incompatible generator type received: {generator.__class__.__module__}.{generator.__class__.__name__} expected: {Model.__module__}.{Model.__name__}"
+                logging.error(msg)
+                return list()
+            gcg_output = self.run_gcg(target_generator=generator)
         except Exception as e:
             logging.error(e)
             print(f"GCG generation encountered an error:\n{e}")

--- a/garak/resources/gcg/attack_manager.py
+++ b/garak/resources/gcg/attack_manager.py
@@ -269,7 +269,8 @@ class AttackPrompt(object):
                 )
             else:
                 self._system_slice = slice(
-                    None, encoding.char_to_token(len(self.conv_template.system))
+                    None,
+                    encoding.char_to_token(len(self.conv_template.system_message)),
                 )
                 self._user_role_slice = slice(
                     encoding.char_to_token(prompt.find(self.conv_template.roles[0])),


### PR DESCRIPTION
conversation accessor for system prompt has been renamed

## Verification

List the steps needed to make sure this thing works

- [ ] `python -m garak -m huggingface.Model -n meta-llama/Llama-2-7b-chat-hf -p suffix.GCG`
- [ ]  Review resulting `gcg.txt` for valid examples, default location based on XDG standard will be `$HOME/.cache/garak/data/gcg/gcg.txt`.
- [ ] `python -m garak -m huggingface -n meta-llama/Llama-2-7b-chat-hf -p suffix.GCG`
- [ ]  Review console results in no evaluated probes, and log denote a error about incompatible generator type