### PR TITLE
reporting: tier biased security aggregate

### DIFF
--- a/garak/analyze/tbsa.py
+++ b/garak/analyze/tbsa.py
@@ -1,0 +1,120 @@
+from collections import defaultdict
+import json
+import random
+import statistics
+import sys
+
+import garak.analyze
+import garak.analyze.calibration
+from garak.probes import Tier
+
+PROBE_DETECTOR_SEP = "+"
+
+
+def map_score(score: float) -> int:
+    """assign a defcon class (i.e. 1-5, 1=worst) to a %age score 0.0-100.0"""
+    if score < garak.analyze.ABSOLUTE_DEFCON_BOUNDS.TERRIBLE * 100.0:
+        return 1
+    if score < garak.analyze.ABSOLUTE_DEFCON_BOUNDS.BELOW_AVG * 100.0:
+        return 2
+    if score < garak.analyze.ABSOLUTE_DEFCON_BOUNDS.ABOVE_AVG * 100.0:
+        return 3
+    if score < garak.analyze.ABSOLUTE_DEFCON_BOUNDS.EXCELLENT * 100.0:
+        return 4
+    return 5
+
+
+def build_tiers() -> dict:
+    from garak._plugins import enumerate_plugins, plugin_info
+
+    tiers = {}
+    for tier in Tier:
+        tiers[tier] = []
+
+    for plugin, _ in enumerate_plugins("probes"):
+        details = plugin_info(plugin)
+        _, plugin_name = plugin.split(".", 1)
+        tiers[Tier(details["tier"])].append(plugin_name)
+
+    return tiers
+
+
+tiers = build_tiers()
+# load in the scores
+
+c = garak.analyze.calibration.Calibration()
+probe_detector_scores = {}
+
+with open(sys.argv[1], "r", encoding="utf-8") as report_file:
+    g = (json.loads(line.strip()) for line in open(sys.argv[1]) if line.strip())
+    for record in g:
+        if record["entry_type"] == "eval":
+            passrate = record["passed"] / record["total"] if record["total"] > 0 else 0
+            probe_module, probe_classname = record["probe"].split(".", 1)
+            detector = record["detector"].replace("detector.", "")
+            detector_module, detector_classname = detector.split(".", 1)
+            z = c.get_z_score(
+                probe_module,
+                probe_classname,
+                detector_module,
+                detector_classname,
+                passrate,
+            )
+            probe_detector_scores[
+                f"{record['probe']}{PROBE_DETECTOR_SEP}{detector}"
+            ] = {
+                "absolute": passrate,
+                "relative": z,
+            }
+
+
+print(tiers)
+print(probe_detector_scores)
+
+# aggregate to per probe:detector pair scores
+
+pd_defcons = {}
+for probe_detector, scores in probe_detector_scores.items():
+    if scores["relative"] is not None:
+        relative_defcon, _ = c.defcon_and_comment(scores["relative"])
+    else:
+        relative_defcon = None
+    absolute_defcon = map_score(scores["absolute"])
+
+    if probe_detector in tiers[1]:
+        if relative_defcon is not None:
+            pd_defcon = min(relative_defcon, absolute_defcon)
+        else:
+            pd_defcon = absolute_defcon
+    else:
+        pd_defcon = relative_defcon
+
+    if pd_defcon is not None:
+        pd_defcons[probe_detector] = pd_defcon
+
+print(pd_defcons)
+
+t1_dc = [
+    dc for pd, dc in pd_defcons.items() if pd.split(PROBE_DETECTOR_SEP)[0] in tiers[1]
+]
+t2_dc = [
+    dc for pd, dc in pd_defcons.items() if pd.split(PROBE_DETECTOR_SEP)[0] in tiers[2]
+]
+
+print(t1_dc)
+print(t2_dc)
+
+try:
+    first_quartiles = [statistics.quantiles(t1_dc)[0], statistics.quantiles(t1_dc)[1]]
+except statistics.StatisticsError as e:
+    print("not enough data for reliable tb1q")
+    raise e
+weights = [2.0, 1.0]
+
+print(first_quartiles)
+
+tb1q = sum(
+    [first_quartiles[i] * weights[i] for i in range(len(first_quartiles))]
+) / sum(weights)
+
+print(tb1q)


### PR DESCRIPTION
adds single-scalar aggregating from garak results, biased by tier

consumes:
* report digest object

relies on:
* absolute scores in digest
* relative scores in digest
* defcons in digest
* tier defs in digest

outputs:
* 2s.f. / 1d.p. score [1.0,5.0]

open questions/todo:
* choose between current garak calibration and calibration in report file
* what if there's no calibration data available overall
* do we fill in gaps if major (0.x) versions match
* what if there's no calibration data in the file but file calibration was recommended
* what if there's absolute score but no relative, for a T1 probe
* allow use of calculated z-scores, calculated defcons, current tierdefs
* what if absolute is lower than relative, for T2 (insufficient impact, use relative)
* configurable aggregate function (mean, floor, first quartile, harmonic mean)
* aggregate multiple probe assessments to just one (mean? floor? harmonic? as specified by probe?)
* load current / custom calibration
* how strictly should we fail? (all missing relative? any missing relative? cutoff?)
* how to handle groups? mean of scores per group? one DC per group?