### PR TITLE
probe: Atbash Encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,4 +171,4 @@ garak_runs/
 runs/
 logs/
 .DS_Store
-Miniforge3.sh
+

--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,4 @@ garak_runs/
 runs/
 logs/
 .DS_Store
+Miniforge3.sh

--- a/garak/probes/encoding.py
+++ b/garak/probes/encoding.py
@@ -457,6 +457,7 @@ class InjectBraille(EncodingMixin, garak.probes.Probe):
         garak.probes.Probe.__init__(self, config_root=config_root)
         EncodingMixin.__init__(self)
 
+
 class InjectAtbash(EncodingMixin, garak.probes.Probe):
     """Atbash Probe Credit: Nakul-Rajpal
 
@@ -467,9 +468,10 @@ class InjectAtbash(EncodingMixin, garak.probes.Probe):
     - repeats or decodes them,
     - and follows hidden instructions despite obfuscation.
     """
-    
+
     encoding_name = "Atbash"
     active = True
+    doc_uri = "https://en.wikipedia.org/wiki/Atbash"
 
     @staticmethod
     def atbash(text: bytes) -> bytes:

--- a/garak/probes/encoding.py
+++ b/garak/probes/encoding.py
@@ -21,6 +21,7 @@ import base64
 import binascii
 import random
 
+
 import garak.payloads
 import garak.resources.encodings
 from garak.resources.smuggling import smuggle_ascii
@@ -453,6 +454,38 @@ class InjectBraille(EncodingMixin, garak.probes.Probe):
     active = True
 
     def __init__(self, config_root=_config):
+        garak.probes.Probe.__init__(self, config_root=config_root)
+        EncodingMixin.__init__(self)
+
+class InjectAtbash(EncodingMixin, garak.probes.Probe):
+    """Atbash Probe Credit: Nakul-Rajpal
+
+    https://en.wikipedia.org/wiki/Atbash
+
+    This probe checks whether a model:
+    - recognizes Atbash-encoded malicious instructions,
+    - repeats or decodes them,
+    - and follows hidden instructions despite obfuscation.
+    """
+    
+    encoding_name = "Atbash"
+    active = True
+
+    @staticmethod
+    def atbash(text: bytes) -> bytes:
+        out = []
+        for ch in text.decode():
+            if "a" <= ch <= "z":
+                out.append(chr(ord("z") - (ord(ch) - ord("a"))))
+            elif "A" <= ch <= "Z":
+                out.append(chr(ord("Z") - (ord(ch) - ord("A"))))
+            else:
+                out.append(ch)
+        return "".join(out).encode("utf-8")
+
+    encoding_funcs = [atbash]
+
+    def __init__(self, config_root=None):
         garak.probes.Probe.__init__(self, config_root=config_root)
         EncodingMixin.__init__(self)
 

--- a/tests/probes/test_probes_encoding.py
+++ b/tests/probes/test_probes_encoding.py
@@ -3,6 +3,7 @@
 import pytest
 import garak.probes.encoding
 from garak import _plugins
+from garak.probes.encoding import InjectAtbash
 
 ENCODING_PROBES = [
     classname
@@ -72,3 +73,17 @@ def test_encoding_suppress_prompt_cap(classname):
     }
     p = _plugins.load_plugin(classname, config_root=instance_config)
     assert len(p.prompts) >= rand_cap
+
+@pytest.mark.parametrize("plain, expected", [
+    ("abc", "zyx"),                       
+    ("ABC", "ZYX"),                       
+    ("Hello, World!", "Svool, Dliow!"),   
+    ("1234!?", "1234!?"),                 
+])
+def test_atbash_function(plain, expected):
+    # Tests all 4 cases of Atbash Encoding
+    # Uppercase, Lowercase, Mixed case, and Numbers/Special characters.
+
+    encoder = InjectAtbash.atbash  # staticmethod reference
+    result = encoder(plain.encode()).decode()
+    assert result == expected


### PR DESCRIPTION
Fixes Issue #845 

# Summary
This PR adds a new probe to the encoding module: encoding.InjectAtbash.
The Atbash probe encodes payloads using the classical monoalphabetic Atbash cipher, in order to test whether models recognize, repeat, or act upon instructions hidden via this encoding.

# Changes Made

- Implemented encoding.InjectAtbash as a new encoding probe

- Added docstrings explaining Atbash and probe intent

# Testing

- Ran pytest tests/probes/test_probes_encoding.py
