### PR TITLE
fixing probable typo in cliref.rst

### DIFF
--- a/docs/source/cliref.rst
+++ b/docs/source/cliref.rst
@@ -110,7 +110,7 @@ CLI reference for garak
     --interactive, -I     Enter interactive probing mode
     --generate_autodan    generate AutoDAN prompts; requires --prompt_options
                           with JSON containing a prompt and target
-    --interactive.py      Launch garak in interactive.py mode
+    --interactive         Launch garak in interactive Python mode
     --fix                 Update provided configuration with fixer migrations;
                           requires one of --config / --*_option_file, /
                           --*_options


### PR DESCRIPTION
Hi everyone, this is just a detail fix..but it might make someone who's just starting confused.

I was using Garak's help and noticed a probable typo in the `interactive mode flag`.

In the the `docs/source/cliref.rst` file, we currently have: 
`--interactive.py Launch garak in interactive.py mode`

Considering there is no `--interactive.py` flag, I've changed it to:
`--interactive Launch garak in interactive Python mode`

Let me know if it makes sense :v:

