### PR TITLE
reporting: add basic docs to scripts in analyze pkg

### DIFF
--- a/garak/analyze/analyze_log.py
+++ b/garak/analyze/analyze_log.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python3
 
+"""
+analyze a garak report.jsonl log file
+
+print out summary stats, and which prompts led to failures
+
+usage:
+
+./analyze_log.py <report.jsonl filename>
+
+"""
 import sys
 import json
 

--- a/garak/analyze/count_tokens.py
+++ b/garak/analyze/count_tokens.py
@@ -3,6 +3,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+"""
+count the number of characters sent and received based on prompts, outputs, and generations
+
+should probably be upgraded to estimate token counts, too
+
+usage
+
+./count_tokens.py <report.jsonl filename>
+"""
+
 import json
 import sys
 

--- a/garak/analyze/get_tree.py
+++ b/garak/analyze/get_tree.py
@@ -1,7 +1,15 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # SPDX-FileCopyrightText: Portions Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+"""
+if a TreeSearchProbe probe was used, display the tree of items explored 
+
+usage:
+
+./get_tree.py <report.jsonl filename>
+"""
 
 from collections import defaultdict
 import json

--- a/garak/analyze/misp.py
+++ b/garak/analyze/misp.py
@@ -1,8 +1,19 @@
 #!/usr/bin/env python3
 
-# report probes per tag
-# look for untagged probes
-# look for tags without description entries
+"""
+report on & validate categories maintained within garak
+
+these are stored in MISP format
+report probes per tag
+look for untagged probes
+look for tags without description entries
+
+this might make sense to move to tests, though we are OK to pass on an unused category
+
+usage:
+
+./misp.py 
+"""
 
 from collections import defaultdict
 import importlib

--- a/garak/analyze/perf_stats.py
+++ b/garak/analyze/perf_stats.py
@@ -1,8 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# calculate calibration data given a list of report.jsonl files
 # input: list of report jsonl
 # process:
 #  for each combination of probe & detector:
@@ -13,7 +14,6 @@ from collections import defaultdict
 import datetime
 from glob import glob
 import json
-import os
 
 import numpy as np
 import scipy

--- a/garak/analyze/qual_review.py
+++ b/garak/analyze/qual_review.py
@@ -1,10 +1,12 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
 # SPDX-FileCopyrightText: Portions Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# generate a qualitative review of a garak report
 # highlight failing probes
 # give ten +ve and ten -ve examples from failing probes
-# takes report.jsonl, optional bag.json as input
+# takes report.jsonl, optional bag.json (e.g. data/calibration/calibration.json) as input
 
 from collections import defaultdict
 import json

--- a/garak/analyze/report_avid.py
+++ b/garak/analyze/report_avid.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-"""Prints a report given a garak report in jsonl"""
+"""Prints an AVID report given a garak report in jsonl"""
 
 import importlib
 import sys

--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
-"""Generate reports from garak report JSONL"""
+"""Generate reports from garak report JSONL
+
+see argparse config below for usage"""
 
 from collections import defaultdict
 import datetime


### PR DESCRIPTION
add description of script purpose and of CLI params to everything command-line executable in `garak.analyze`

prep for #1368