### PR TITLE
#1368 PR

### DIFF
--- a/garak/__init__.py
+++ b/garak/__init__.py
@@ -12,8 +12,8 @@ GARAK_LOG_FILE_VAR = "GARAK_LOG_FILE"
 # allow for a file path configuration from the ENV and set for child processes
 _log_filename = os.getenv(GARAK_LOG_FILE_VAR, default=None)
 if _log_filename is None:
-	_log_filename = _config.transient.data_dir / "garak.log"
-	os.environ[GARAK_LOG_FILE_VAR] = str(_log_filename)
+    _log_filename = _config.transient.data_dir / "garak.log"
+    os.environ[GARAK_LOG_FILE_VAR] = str(_log_filename)
 
 _config.transient.log_filename = _log_filename
 

--- a/garak/__init__.py
+++ b/garak/__init__.py
@@ -4,7 +4,6 @@ __version__ = "0.13.1.pre1"
 __app__ = "garak"
 __description__ = "LLM vulnerability scanner"
 
-import logging
 import os
 from garak import _config
 
@@ -13,13 +12,10 @@ GARAK_LOG_FILE_VAR = "GARAK_LOG_FILE"
 # allow for a file path configuration from the ENV and set for child processes
 _log_filename = os.getenv(GARAK_LOG_FILE_VAR, default=None)
 if _log_filename is None:
-    _log_filename = _config.transient.data_dir / "garak.log"
-    os.environ[GARAK_LOG_FILE_VAR] = str(_log_filename)
+	_log_filename = _config.transient.data_dir / "garak.log"
+	os.environ[GARAK_LOG_FILE_VAR] = str(_log_filename)
 
 _config.transient.log_filename = _log_filename
 
-logging.basicConfig(
-    filename=_log_filename,
-    level=logging.DEBUG,
-    format="%(asctime)s  %(levelname)s  %(message)s",
-)
+# Note: Logging configuration is performed in garak.command.start_logging()
+# to enable a process-safe Queue-based logging architecture.

--- a/garak/analyze/__init__.py
+++ b/garak/analyze/__init__.py
@@ -18,15 +18,15 @@ class RELATIVE_DEFCON_BOUNDS(float, Enum):  # for Z-scores
     EXCELLENT = 1.0
 
 
-RELATIVE_COMMENT = {      # assuming normal distr
-    1: "critical risk",   # bottom 16%
+RELATIVE_COMMENT = {  # assuming normal distr
+    1: "critical risk",  # bottom 16%
     2: "very high risk",  # -5% to -25% below mean
-    3: "elevated risk",   # ±5% of mean
-    4: "medium risk",     # +5% to +38% above mean
-    5: "low risk",    # top 16%
+    3: "elevated risk",  # ±5% of mean
+    4: "medium risk",  # +5% to +38% above mean
+    5: "low risk",  # top 16%
 }
 
-ABSOLUTE_COMMENT = {      # see ABSOLUTE_DEFCON_BOUNDS
+ABSOLUTE_COMMENT = {  # see ABSOLUTE_DEFCON_BOUNDS
     1: "immediate risk (complete failure)",
     2: "critical risk",
     3: "elevated risk",

--- a/garak/analyze/aggregate_reports.py
+++ b/garak/analyze/aggregate_reports.py
@@ -57,9 +57,7 @@ def main(argv=None) -> None:
         allow_abbrev=False,
     )
     p.add_argument("-o", "--output_path", help="Output filename", required=True)
-    p.add_argument(
-        "infiles", nargs="+", help="garak jsonl reports to be aggregated"
-    )
+    p.add_argument("infiles", nargs="+", help="garak jsonl reports to be aggregated")
     a = p.parse_args(argv)
 
     # get the list of files

--- a/garak/analyze/analyze_log.py
+++ b/garak/analyze/analyze_log.py
@@ -2,81 +2,121 @@
 
 import sys
 import json
+import argparse
 
-started_attempt_uuids = set([])
-completed_attempt_uuids = set([])
+from garak import __description__
+from garak import _config
 
-completed_attempts = {}
 
-current_probe_classname = None
+def analyze_log(report_path: str) -> None:
+    started_attempt_uuids = set([])
+    completed_attempt_uuids = set([])
 
-with open(sys.argv[1], "r", encoding="utf-8") as reportfile:
-    for i, line in enumerate(reportfile):
-        line = line.strip()
-        if not line:
-            continue
+    current_probe_classname = None
 
-        record = json.loads(line)
-
-        if not isinstance(record, dict):
-            continue
-
-        if "entry_type" not in record.keys():
-            continue
-
-        if record["entry_type"] in ("config", "init"):
-            print("##", line)
-            continue
-
-        elif record["entry_type"] == "attempt":
-            if record["status"] == 1:  # started
-                started_attempt_uuids.add(record["uuid"])
+    with open(report_path, "r", encoding="utf-8") as reportfile:
+        for _, line in enumerate(reportfile):
+            line = line.strip()
+            if not line:
                 continue
 
-            if record["status"] == 2:
-                completed_attempt_uuids.add(record["uuid"])
+            record = json.loads(line)
 
-            if record["probe_classname"] != current_probe_classname:
-                print("## PROBE:", record["probe_classname"])
-                current_probe_classname = record["probe_classname"]
+            if not isinstance(record, dict):
+                continue
 
-            # for each detector:
-            for detector_name, detector_scores in record["detector_results"].items():
-                normalised_scores = [1 if i >= 0.5 else 0 for i in detector_scores]
-                # are there any hits?
-                if sum(normalised_scores):
-                    # if so print prompt & hit rate
-                    # i guess make this sortable so give probe, detector, hit rate, prompt
-                    hit_rate = sum(normalised_scores) / len(normalised_scores)
-                    print(
-                        "\t".join(
+            if "entry_type" not in record.keys():
+                continue
+
+            if record["entry_type"] in ("config", "init"):
+                print("##", line)
+                continue
+
+            elif record["entry_type"] == "attempt":
+                if record["status"] == 1:  # started
+                    started_attempt_uuids.add(record["uuid"])
+                    continue
+
+                if record["status"] == 2:
+                    completed_attempt_uuids.add(record["uuid"])
+
+                if record["probe_classname"] != current_probe_classname:
+                    print("## PROBE:", record["probe_classname"])
+                    current_probe_classname = record["probe_classname"]
+
+                # for each detector:
+                for detector_name, detector_scores in record["detector_results"].items():
+                    normalised_scores = [1 if i >= 0.5 else 0 for i in detector_scores]
+                    # are there any hits?
+                    if sum(normalised_scores):
+                        # if so print prompt & hit rate
+                        # i guess make this sortable so give probe, detector, hit rate, prompt
+                        hit_rate = sum(normalised_scores) / len(normalised_scores)
+                        print(
+                            "\t".join(
+                                [
+                                    current_probe_classname,
+                                    detector_name,
+                                    f"{hit_rate:0.2%}",
+                                    repr(record["prompt"]),
+                                ]
+                            )
+                        )
+            elif record["entry_type"] == "eval":
+                print(
+                    "\t".join(
+                        map(
+                            str,
                             [
-                                current_probe_classname,
-                                detector_name,
-                                f"{hit_rate:0.2%}",
-                                repr(record["prompt"]),
-                            ]
+                                record["probe"],
+                                record["detector"],
+                                "%0.4f" % (record["passed"] / record["total"]),
+                                record["total"],
+                            ],
                         )
                     )
-        elif record["entry_type"] == "eval":
-            print(
-                "\t".join(
-                    map(
-                        str,
-                        [
-                            record["probe"],
-                            record["detector"],
-                            "%0.4f" % (record["passed"] / record["total"]),
-                            record["total"],
-                        ],
-                    )
                 )
-            )
 
-if not started_attempt_uuids:
-    print("## no attempts in log")
-else:
-    completion_rate = len(completed_attempt_uuids) / len(started_attempt_uuids)
-    print("##", len(started_attempt_uuids), "attempts started")
-    print("##", len(completed_attempt_uuids), "attempts completed")
-    print(f"## attempt completion rate {completion_rate:.0%}")
+    if not started_attempt_uuids:
+        print("## no attempts in log")
+    else:
+        completion_rate = len(completed_attempt_uuids) / len(started_attempt_uuids)
+        print("##", len(started_attempt_uuids), "attempts started")
+        print("##", len(completed_attempt_uuids), "attempts completed")
+        print(f"## attempt completion rate {completion_rate:.0%}")
+
+
+def main(argv=None) -> None:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    _config.load_config()
+    print(
+        f"garak {__description__} v{_config.version} ( https://github.com/NVIDIA/garak )"
+    )
+
+    parser = argparse.ArgumentParser(
+        prog="python -m garak.analyze.analyze_log",
+        description="Analyze a garak JSONL report and emit summary lines",
+        epilog="See https://github.com/NVIDIA/garak",
+        allow_abbrev=False,
+    )
+    # Support both positional and -r/--report_path for backward compatibility
+    parser.add_argument("report_path", nargs="?", help="Path to the garak JSONL report")
+    parser.add_argument(
+        "-r",
+        "--report_path",
+        dest="report_path_opt",
+        help="Path to the garak JSONL report",
+    )
+    args = parser.parse_args(argv)
+    report_path = args.report_path_opt or args.report_path
+    if not report_path:
+        parser.error("a report path is required (positional or -r/--report_path)")
+
+    sys.stdout.reconfigure(encoding="utf-8")
+    analyze_log(report_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/garak/analyze/analyze_log.py
+++ b/garak/analyze/analyze_log.py
@@ -45,7 +45,9 @@ def analyze_log(report_path: str) -> None:
                     current_probe_classname = record["probe_classname"]
 
                 # for each detector:
-                for detector_name, detector_scores in record["detector_results"].items():
+                for detector_name, detector_scores in record[
+                    "detector_results"
+                ].items():
                     normalised_scores = [1 if i >= 0.5 else 0 for i in detector_scores]
                     # are there any hits?
                     if sum(normalised_scores):

--- a/garak/analyze/count_tokens.py
+++ b/garak/analyze/count_tokens.py
@@ -29,7 +29,23 @@ def count_tokens(report_path: str) -> None:
             if "status" in r and r["status"] == 2:
                 input_length += len(r["prompt"]) * generations
                 calls += generations
-                output_length += len("".join(r["outputs"]))
+                outputs = r.get("outputs", [])
+                if isinstance(outputs, list):
+                    def _to_text(o):
+                        if isinstance(o, str):
+                            return o
+                        if isinstance(o, dict):
+                            # common keys seen in generator outputs
+                            for k in ("text", "content", "response"):
+                                v = o.get(k)
+                                if isinstance(v, str):
+                                    return v
+                        return str(o)
+
+                    output_text = "".join(_to_text(o) for o in outputs)
+                else:
+                    output_text = str(outputs)
+                output_length += len(output_text)
 
     print(f"Calls: {calls}")
     print(f"Input chars: {input_length}")

--- a/garak/analyze/count_tokens.py
+++ b/garak/analyze/count_tokens.py
@@ -5,26 +5,71 @@
 
 import json
 import sys
+import argparse
 
-calls = 0
-input_length = 0
-output_length = 0
-generations = 10
+from garak import __description__
+from garak import _config
 
-reportfile = open(sys.argv[1], encoding="utf-8")
-for line in reportfile:
-    line = line.strip()
-    if not line:
-        continue
-    r = json.loads(line)
-    if "run.generations" in r:
-        generations = r["run.generations"]
-        continue
-    if "status" in r and r["status"] == 2:
-        input_length += len(r["prompt"]) * generations
-        calls += generations
-        output_length += len("".join(r["outputs"]))
 
-print(f"Calls: {calls}")
-print(f"Input chars: {input_length}")
-print(f"Output chars: {output_length}")
+def count_tokens(report_path: str) -> None:
+    calls = 0
+    input_length = 0
+    output_length = 0
+    generations = 10
+
+    with open(report_path, encoding="utf-8") as reportfile:
+        for line in reportfile:
+            line = line.strip()
+            if not line:
+                continue
+            r = json.loads(line)
+            if "run.generations" in r:
+                generations = r["run.generations"]
+                continue
+            if "status" in r and r["status"] == 2:
+                input_length += len(r["prompt"]) * generations
+                calls += generations
+                output_length += len("".join(r["outputs"]))
+
+    print(f"Calls: {calls}")
+    print(f"Input chars: {input_length}")
+    print(f"Output chars: {output_length}")
+
+
+def main(argv=None) -> None:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    _config.load_config()
+    print(
+        f"garak {__description__} v{_config.version} ( https://github.com/NVIDIA/garak )"
+    )
+
+    parser = argparse.ArgumentParser(
+        prog="python -m garak.analyze.count_tokens",
+        description="Count approximate token-like character totals from a garak JSONL report",
+        epilog="See https://github.com/NVIDIA/garak",
+        allow_abbrev=False,
+    )
+    parser.add_argument(
+        "-r",
+        "--report_path",
+        required=False,
+        help="Path to the garak JSONL report",
+    )
+    parser.add_argument(
+        "report_path_positional",
+        nargs="?",
+        help="Path to the garak JSONL report (positional)",
+    )
+    args = parser.parse_args(argv)
+    report_path = args.report_path or args.report_path_positional
+    if not report_path:
+        parser.error("a report path is required (positional or -r/--report_path)")
+
+    sys.stdout.reconfigure(encoding="utf-8")
+    count_tokens(report_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/garak/analyze/get_tree.py
+++ b/garak/analyze/get_tree.py
@@ -46,7 +46,8 @@ def get_tree(report_path: str) -> None:
         def print_tree(node_id, indent=0):
             forms = "" + ",".join(node_info[probe][node_id]["surface_forms"]) + ""
             print(
-                "  " * indent + f"{forms} ::> {node_info[probe][node_id]['node_score']}",
+                "  " * indent
+                + f"{forms} ::> {node_info[probe][node_id]['node_score']}",
             )
             children = node_children[node_id]
             if children:

--- a/garak/analyze/get_tree.py
+++ b/garak/analyze/get_tree.py
@@ -6,47 +6,91 @@
 from collections import defaultdict
 import json
 import sys
+import argparse
 
-probes = set([])
-node_info = defaultdict(dict)
-
-with open(sys.argv[1], "r") as reportfile:
-    for line in reportfile:
-        line = line.strip()
-        if not line:
-            continue
-        r = json.loads(line)
-        if r["entry_type"] == "tree_data":
-            probe = r["probe"]
-            probes.add(probe)
-            node_info[probe][r["node_id"]] = r
+from garak import __description__
+from garak import _config
 
 
-for probe in probes:
-    print(f"============== {probe} ==============")
+def get_tree(report_path: str) -> None:
+    probes = set([])
+    node_info = defaultdict(dict)
 
-    node_children = defaultdict(list)
-    for node in node_info[probe].values():
-        node_children[node["node_parent"]].append(node["node_id"])
+    with open(report_path, "r", encoding="utf-8") as reportfile:
+        for line in reportfile:
+            line = line.strip()
+            if not line:
+                continue
+            r = json.loads(line)
+            if r["entry_type"] == "tree_data":
+                probe = r["probe"]
+                probes.add(probe)
+                node_info[probe][r["node_id"]] = r
 
-    # roots: those with parents not in node_info, or none
-    roots = set([])
-    for node in node_info[probe].values():
-        if (
-            node["node_parent"] is None
-            or node["node_parent"] not in node_info[probe].keys()
-        ):
-            roots.add(node["node_id"])
+    for probe in probes:
+        print(f"============== {probe} ==============")
 
-    def print_tree(node_id, indent=0):
-        forms = "" + ",".join(node_info[probe][node_id]["surface_forms"]) + ""
-        print(
-            "  " * indent + f"{forms} ::> {node_info[probe][node_id]['node_score']}",
-        )
-        children = node_children[node_id]
-        if children:
-            for child in children:
-                print_tree(child, indent + 1)
+        node_children = defaultdict(list)
+        for node in node_info[probe].values():
+            node_children[node["node_parent"]].append(node["node_id"])
 
-    for root in sorted(list(roots)):
-        print_tree(root)
+        # roots: those with parents not in node_info, or none
+        roots = set([])
+        for node in node_info[probe].values():
+            if (
+                node["node_parent"] is None
+                or node["node_parent"] not in node_info[probe].keys()
+            ):
+                roots.add(node["node_id"])
+
+        def print_tree(node_id, indent=0):
+            forms = "" + ",".join(node_info[probe][node_id]["surface_forms"]) + ""
+            print(
+                "  " * indent + f"{forms} ::> {node_info[probe][node_id]['node_score']}",
+            )
+            children = node_children[node_id]
+            if children:
+                for child in children:
+                    print_tree(child, indent + 1)
+
+        for root in sorted(list(roots)):
+            print_tree(root)
+
+
+def main(argv=None) -> None:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    _config.load_config()
+    print(
+        f"garak {__description__} v{_config.version} ( https://github.com/NVIDIA/garak )"
+    )
+
+    parser = argparse.ArgumentParser(
+        prog="python -m garak.analyze.get_tree",
+        description="Print a tree view from 'tree_data' entries in a garak JSONL report",
+        epilog="See https://github.com/NVIDIA/garak",
+        allow_abbrev=False,
+    )
+    parser.add_argument(
+        "-r",
+        "--report_path",
+        required=False,
+        help="Path to the garak JSONL report",
+    )
+    parser.add_argument(
+        "report_path_positional",
+        nargs="?",
+        help="Path to the garak JSONL report (positional)",
+    )
+    args = parser.parse_args(argv)
+    report_path = args.report_path or args.report_path_positional
+    if not report_path:
+        parser.error("a report path is required (positional or -r/--report_path)")
+
+    sys.stdout.reconfigure(encoding="utf-8")
+    get_tree(report_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/garak/analyze/misp.py
+++ b/garak/analyze/misp.py
@@ -7,38 +7,74 @@
 from collections import defaultdict
 import importlib
 import os
+import sys
+import argparse
 
-from garak import _plugins
+from garak import __description__
+from garak import _config, _plugins
 from garak.data import path as data_path
 
-misp_resource_file = data_path / "misp_descriptions.tsv"
-misp_descriptions = {}
-if os.path.isfile(misp_resource_file):
-    with open(misp_resource_file, "r", encoding="utf-8") as f:
-        for line in f:
-            key, title, descr = line.strip().split("\t")
-            misp_descriptions[key] = (title, descr)
 
-probes_per_tag = defaultdict(list)
+def misp_report(include_untagged: bool = True) -> None:
+    misp_resource_file = data_path / "misp_descriptions.tsv"
+    misp_descriptions = {}
+    if os.path.isfile(misp_resource_file):
+        with open(misp_resource_file, "r", encoding="utf-8") as f:
+            for line in f:
+                key, title, descr = line.strip().split("\t")
+                misp_descriptions[key] = (title, descr)
 
-for plugin_name, active in _plugins.enumerate_plugins("probes"):
-    class_name = plugin_name.split(".")[-1]
-    module_name = plugin_name.replace(f".{class_name}", "")
-    m = importlib.import_module(f"garak.{module_name}")
-    c = getattr(m, class_name)
-    tags = c.tags
-    if tags == []:
-        print(f"{plugin_name}: no tags defined")
-    for tag in tags:
-        if tag not in misp_descriptions:
-            print(f"{plugin_name}: tag {tag} undefined in misp_descriptions.tsv")
-        probes_per_tag[tag].append(plugin_name)
+    probes_per_tag = defaultdict(list)
 
-for misp_tag in misp_descriptions.keys():
-    if len(probes_per_tag[misp_tag]) == 0:
-        print(f"{misp_tag}: zero probes testing this")
-    else:
-        if len(probes_per_tag[misp_tag]) == 1:
-            print(f"{misp_tag}: only one probe testing this")
-        probe_list = ", ".join(probes_per_tag[misp_tag]).replace(" probes.", " ")
-        print(f"> {misp_tag}: {probe_list}")
+    for plugin_name, active in _plugins.enumerate_plugins("probes"):
+        class_name = plugin_name.split(".")[-1]
+        module_name = plugin_name.replace(f".{class_name}", "")
+        m = importlib.import_module(f"garak.{module_name}")
+        c = getattr(m, class_name)
+        tags = c.tags
+        if tags == [] and include_untagged:
+            print(f"{plugin_name}: no tags defined")
+        for tag in tags:
+            if tag not in misp_descriptions:
+                print(f"{plugin_name}: tag {tag} undefined in misp_descriptions.tsv")
+            probes_per_tag[tag].append(plugin_name)
+
+    for misp_tag in misp_descriptions.keys():
+        if len(probes_per_tag[misp_tag]) == 0:
+            print(f"{misp_tag}: zero probes testing this")
+        else:
+            if len(probes_per_tag[misp_tag]) == 1:
+                print(f"{misp_tag}: only one probe testing this")
+            probe_list = ", ".join(probes_per_tag[misp_tag]).replace(" probes.", " ")
+            print(f"> {misp_tag}: {probe_list}")
+
+
+def main(argv=None) -> None:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    _config.load_config()
+    print(
+        f"garak {__description__} v{_config.version} ( https://github.com/NVIDIA/garak )"
+    )
+
+    parser = argparse.ArgumentParser(
+        prog="python -m garak.analyze.misp",
+        description="Report probes per MISP tag and tag coverage gaps",
+        epilog="See https://github.com/NVIDIA/garak",
+        allow_abbrev=False,
+    )
+    parser.add_argument(
+        "-u",
+        "--include_untagged",
+        action="store_true",
+        help="Also print probes without any tags",
+    )
+    args = parser.parse_args(argv)
+
+    sys.stdout.reconfigure(encoding="utf-8")
+    misp_report(include_untagged=args.include_untagged)
+
+
+if __name__ == "__main__":
+    main()

--- a/garak/analyze/perf_stats.py
+++ b/garak/analyze/perf_stats.py
@@ -39,7 +39,9 @@ def build_score_dict(filenames):
                     value = float(r["passed"]) / r["total"]
                     eval_scores[key].append(value)
                 else:
-                    print(f"invalid result check {filename} for {key}: total tests was 0")
+                    print(
+                        f"invalid result check {filename} for {key}: total tests was 0"
+                    )
 
     distribution_dict = {}
     for key in eval_scores:
@@ -88,7 +90,9 @@ def main(argv=None) -> None:
     sys.stdout.reconfigure(encoding="utf-8")
     report_list = args.report_paths or args.reports_positional
     if not report_list:
-        parser.error("one or more report paths are required (-r/--report_paths or positional)")
+        parser.error(
+            "one or more report paths are required (-r/--report_paths or positional)"
+        )
     distribution_dict = build_score_dict(report_list)
     print(json.dumps(distribution_dict, indent=2, sort_keys=True))
 

--- a/garak/analyze/qual_review.py
+++ b/garak/analyze/qual_review.py
@@ -10,9 +10,12 @@ from collections import defaultdict
 import json
 import random
 import sys
+import argparse
 
 import garak.analyze
 import garak.analyze.calibration
+from garak import __description__
+from garak import _config
 from garak.probes import Tier
 
 PROBE_DETECTOR_SEP = "+"
@@ -33,133 +36,171 @@ def build_tiers() -> dict:
     return tiers
 
 
-tiers = build_tiers()
-# load in the scores
+def qual_review(report_path: str) -> None:
+    tiers = build_tiers()
+    c = garak.analyze.calibration.Calibration()
+    probe_detector_scores = {}
+    pos_examples = defaultdict(list)
+    neg_examples = defaultdict(list)
 
-c = garak.analyze.calibration.Calibration()
-probe_detector_scores = {}
-pos_examples = defaultdict(list)
-neg_examples = defaultdict(list)
+    print("# garak Qualitative review")
+    print(
+        "Analysis of failing & passing probes/detectors, grouped by tier, including prompt & response samples for failing entries"
+    )
+    print("source filename: ", report_path)
 
-print("# garak Qualitative review")
-print(
-    "Analysis of failing & passing probes/detectors, grouped by tier, including prompt & response samples for failing entries"
-)
-print("source filename: ", sys.argv[1])
+    with open(report_path, "r", encoding="utf-8") as report_file:
+        g = (json.loads(line.strip()) for line in report_file if line.strip())
+        for record in g:
+            if record["entry_type"] == "eval":
+                passrate = (
+                    record["passed"] / record["total"] if record["total"] > 0 else 0
+                )
+                probe_module, probe_classname = record["probe"].split(".", 1)
+                detector = record["detector"].replace("detector.", "")
+                detector_module, detector_classname = detector.split(".", 1)
+                z = c.get_z_score(
+                    probe_module,
+                    probe_classname,
+                    detector_module,
+                    detector_classname,
+                    passrate,
+                )
+                probe_detector_scores[
+                    f"{record['probe']}{PROBE_DETECTOR_SEP}{detector}"
+                ] = {
+                    "passrate": passrate,
+                    "z": z,
+                }
+            elif record["entry_type"] == "attempt" and record["status"] == 2:
+                results = record["detector_results"]
+                for detector_name in results:
+                    for i, score in enumerate(results[detector_name]):
+                        try:
+                            fields = [record["prompt"], record["outputs"][i]]
+                            if "triggers" in record.get("notes", {}).keys():
+                                fields.append(record["notes"]["triggers"])
+                            if score > 0.5:
+                                pos_examples[
+                                    record["probe_classname"]
+                                    + PROBE_DETECTOR_SEP
+                                    + detector_name
+                                ].append(fields)
+                            else:
+                                neg_examples[
+                                    record["probe_classname"]
+                                    + PROBE_DETECTOR_SEP
+                                    + detector_name
+                                ].append(fields)
+                        except IndexError:
+                            continue
 
-with open(sys.argv[1], "r", encoding="utf-8") as report_file:
-    g = (json.loads(line.strip()) for line in open(sys.argv[1]) if line.strip())
-    for record in g:
-        if record["entry_type"] == "eval":
-            passrate = record["passed"] / record["total"] if record["total"] > 0 else 0
-            probe_module, probe_classname = record["probe"].split(".", 1)
-            detector = record["detector"].replace("detector.", "")
-            detector_module, detector_classname = detector.split(".", 1)
-            z = c.get_z_score(
-                probe_module,
-                probe_classname,
-                detector_module,
-                detector_classname,
-                passrate,
+    def _print_examples(probe_detector):
+        print("\n#### Examples of responses marked failing")
+        excerpt = pos_examples[probe_detector]
+        random.shuffle(excerpt)
+        for index, entry in enumerate(excerpt[0:10]):
+            print(f"##### Example {index+1}")
+            print()
+            print("  * **prompt**:\n```\n" + repr(entry[0]) + "\n```\n")
+            if len(entry) == 3:
+                print("  * **trigger**:\n```\n" + repr(entry[2]) + "\n```\n")
+            print("  * **response**:\n```\n" + repr(entry[1]) + "\n```\n")
+            print()
+        print("\n#### Examples of responses marked passing")
+        excerpt = neg_examples[probe_detector]
+        random.shuffle(excerpt)
+        for entry in excerpt[0:10]:
+            print()
+            print("  * **prompt**:\n```\n" + repr(entry[0]) + "\n```\n")
+            if len(entry) == 3:
+                print("  * **trigger**:\n```\n" + repr(entry[2]) + "\n```\n")
+            print("  * **response**:\n```\n" + repr(entry[1]) + "\n```\n")
+            print()
+
+    print("## Tier 1 probe results")
+    t1_probe_names = tiers[Tier.OF_CONCERN]
+    for probe_detector in probe_detector_scores.keys():
+        if probe_detector.split(PROBE_DETECTOR_SEP)[0] in t1_probe_names:
+            z, passrate = (
+                probe_detector_scores[probe_detector]["z"],
+                probe_detector_scores[probe_detector]["passrate"],
             )
-            probe_detector_scores[
-                f"{record['probe']}{PROBE_DETECTOR_SEP}{detector}"
-            ] = {
-                "passrate": passrate,
-                "z": z,
-            }
-        elif record["entry_type"] == "attempt" and record["status"] == 2:
-            results = record["detector_results"]
-            for detector_name in results:
-                for i, score in enumerate(results[detector_name]):
-                    try:
-                        fields = [record["prompt"], record["outputs"][i]]
-                        if "triggers" in record["notes"].keys():
-                            fields.append(record["notes"]["triggers"])
-                        if score > 0.5:
-                            pos_examples[
-                                record["probe_classname"]
-                                + PROBE_DETECTOR_SEP
-                                + detector_name
-                            ].append(fields)
-                        else:
-                            neg_examples[
-                                record["probe_classname"]
-                                + PROBE_DETECTOR_SEP
-                                + detector_name
-                            ].append(fields)
-                    except IndexError:
-                        continue
+            print("\n### Probe and detector: " + probe_detector)
+            print(f"\n\n * passrate: `{passrate:0.4f}`\n * z: `{z}`\n\n")
+            if passrate < garak.analyze.ABSOLUTE_DEFCON_BOUNDS.BELOW_AVG or (
+                z is not None and z < garak.analyze.RELATIVE_DEFCON_BOUNDS.BELOW_AVG
+            ):
+                print("Issues found:")
+                if passrate < garak.analyze.ABSOLUTE_DEFCON_BOUNDS.BELOW_AVG:
+                    print(f"* low pass rate `{passrate:0.4f}`")
+                if z is not None and z < garak.analyze.RELATIVE_DEFCON_BOUNDS.BELOW_AVG:
+                    print(f"* low z         `{z:-0.4f}`")
+                _print_examples(probe_detector)
+            else:
+                print("All performance within bounds")
 
-
-def _print_examples(probe_detector):
-    print("\n#### Examples of responses marked failing")
-    excerpt = pos_examples[probe_detector]
-    random.shuffle(excerpt)
-    for index, entry in enumerate(excerpt[0:10]):
-        print(f"##### Example {index+1}")
-        print()
-        print("  * **prompt**:\n```\n" + repr(entry[0]) + "\n```\n")
-        if len(entry) == 3:
-            print("  * **trigger**:\n```\n" + repr(entry[2]) + "\n```\n")
-        print("  * **response**:\n```\n" + repr(entry[1]) + "\n```\n")
-        print()
-    print("\n#### Examples of responses marked passing")
-    excerpt = neg_examples[probe_detector]
-    random.shuffle(excerpt)
-    for entry in excerpt[0:10]:
-        print()
-        print("  * **prompt**:\n```\n" + repr(entry[0]) + "\n```\n")
-        if len(entry) == 3:
-            print("  * **trigger**:\n```\n" + repr(entry[2]) + "\n```\n")
-        print("  * **response**:\n```\n" + repr(entry[1]) + "\n```\n")
-        print()
-
-
-print("## Tier 1 probe results")
-t1_probe_names = tiers[Tier.OF_CONCERN]
-for probe_detector in probe_detector_scores.keys():
-    if probe_detector.split(PROBE_DETECTOR_SEP)[0] in t1_probe_names:
-        z, passrate = (
-            probe_detector_scores[probe_detector]["z"],
-            probe_detector_scores[probe_detector]["passrate"],
-        )
-        print("\n### Probe and detector: " + probe_detector)
-        print(f"\n\n * passrate: `{passrate:0.4f}`\n * z: `{z}`\n\n")
-        if passrate < garak.analyze.ABSOLUTE_DEFCON_BOUNDS.BELOW_AVG or (
-            z is not None and z < garak.analyze.RELATIVE_DEFCON_BOUNDS.BELOW_AVG
-        ):
-            print("Issues found:")
-            if passrate < garak.analyze.ABSOLUTE_DEFCON_BOUNDS.BELOW_AVG:
-                print(f"* low pass rate `{passrate:0.4f}`")
+    print("## Tier 2 probe results")
+    t2_probe_names = tiers[Tier.COMPETE_WITH_SOTA]
+    for probe_detector in probe_detector_scores.keys():
+        if probe_detector.split(PROBE_DETECTOR_SEP)[0] in t2_probe_names:
+            z, passrate = (
+                probe_detector_scores[probe_detector]["z"],
+                probe_detector_scores[probe_detector]["passrate"],
+            )
+            print("\n### Probe and detector: " + probe_detector)
+            print(f"\n\n * passrate: `{passrate:0.4f}`\n * z: `{z}`\n\n")
             if z is not None and z < garak.analyze.RELATIVE_DEFCON_BOUNDS.BELOW_AVG:
-                print(f"* low z         `{z:-0.4f}`")
-            _print_examples(probe_detector)
-        else:
-            print("All performance within bounds")
+                print("Issues found:")
+                print(f"* low z   `{z:-0.4f}`")
+                _print_examples(probe_detector)
+            else:
+                print("All performance within bounds")
 
-print("## Tier 2 probe results")
-t2_probe_names = tiers[Tier.COMPETE_WITH_SOTA]
-for probe_detector in probe_detector_scores.keys():
-    if probe_detector.split(PROBE_DETECTOR_SEP)[0] in t2_probe_names:
-        z, passrate = (
-            probe_detector_scores[probe_detector]["z"],
-            probe_detector_scores[probe_detector]["passrate"],
-        )
-        print("\n### Probe and detector: " + probe_detector)
-        print(f"\n\n * passrate: `{passrate:0.4f}`\n * z: `{z}`\n\n")
-        if z is not None and z < garak.analyze.RELATIVE_DEFCON_BOUNDS.BELOW_AVG:
-            print("Issues found:")
-            print(f"* low z   `{z:-0.4f}`")
-            _print_examples(probe_detector)
-        else:
-            print("All performance within bounds")
+    print("\n## Probe/detector pairs not processed:")
+    t1_t2_probes = t1_probe_names + t2_probe_names
+    for entry in [
+        probe_detector
+        for probe_detector in probe_detector_scores.keys()
+        if probe_detector.split(PROBE_DETECTOR_SEP)[0] not in t1_t2_probes
+    ]:
+        print("*", entry)
 
-print("\n## Probe/detector pairs not processed:")
-t1_t2_probes = t1_probe_names + t2_probe_names
-for entry in [
-    probe_detector
-    for probe_detector in probe_detector_scores.keys()
-    if probe_detector.split(PROBE_DETECTOR_SEP)[0] not in t1_t2_probes
-]:
-    print("*", entry)
+
+def main(argv=None) -> None:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    _config.load_config()
+    print(
+        f"garak {__description__} v{_config.version} ( https://github.com/NVIDIA/garak )"
+    )
+
+    parser = argparse.ArgumentParser(
+        prog="python -m garak.analyze.qual_review",
+        description="Qualitative review of failing/passing probes and detectors with sample prompts/responses",
+        epilog="See https://github.com/NVIDIA/garak",
+        allow_abbrev=False,
+    )
+    parser.add_argument(
+        "-r",
+        "--report_path",
+        required=False,
+        help="Path to the garak JSONL report",
+    )
+    parser.add_argument(
+        "report_path_positional",
+        nargs="?",
+        help="Path to the garak JSONL report (positional)",
+    )
+    args = parser.parse_args(argv)
+    report_path = args.report_path or args.report_path_positional
+    if not report_path:
+        parser.error("a report path is required (positional or -r/--report_path)")
+
+    sys.stdout.reconfigure(encoding="utf-8")
+    qual_review(report_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/garak/analyze/report_avid.py
+++ b/garak/analyze/report_avid.py
@@ -11,109 +11,130 @@ import pandas as pd
 from datetime import date
 from avidtools.datamodels.report import Report
 from avidtools.datamodels.components import *
+from garak import __description__
 from garak import _config
 
-evals = []
-meta = None
 
-parser = argparse.ArgumentParser(
-    description="Conversion Tool from native garak jsonl to AVID reports"
-)
-# model type; model name; seed; generations; probe names; eval threshold
-parser.add_argument(
-    "--report",
-    "-r",
-    type=str,
-    help="location of garak report file",
-)
-_config.args = parser.parse_args(sys.argv[1:])
-_config.args.verbose = 0
+def convert_to_avid(report_location: str) -> str:
+    evals = []
+    meta = None
 
-# load up a .jsonl output file, take in eval and config rows
-report_location = _config.args.report
-print(f"📜 Converting garak reports {report_location}")
-with open(report_location, "r", encoding="utf-8") as reportfile:
-    for line in reportfile:
-        record = json.loads(line.strip())
-        if record["entry_type"] == "eval":
-            evals.append(record)
-        elif record["entry_type"] == "config":
-            meta = record
-if len(evals) == 0:
-    raise ValueError("No evaluations to report 🤷")
+    print(f"📜 Converting garak reports {report_location}")
+    with open(report_location, "r", encoding="utf-8") as reportfile:
+        for line in reportfile:
+            record = json.loads(line.strip())
+            if record["entry_type"] == "eval":
+                evals.append(record)
+            elif record["entry_type"] == "config":
+                meta = record
+    if len(evals) == 0:
+        raise ValueError("No evaluations to report 🤷")
 
-# preprocess
-for i in range(len(evals)):
-    module_name, plugin_class_name = evals[i]["probe"].split(".")
-    mod = importlib.import_module(f"garak.probes.{module_name}")
+    # preprocess
+    for i in range(len(evals)):
+        module_name, plugin_class_name = evals[i]["probe"].split(".")
+        mod = importlib.import_module(f"garak.probes.{module_name}")
 
-    evals[i]["probe"] = f"{module_name}.{plugin_class_name}"
-    plugin_instance = getattr(mod, plugin_class_name)()
-    evals[i]["probe_tags"] = plugin_instance.tags
+        evals[i]["probe"] = f"{module_name}.{plugin_class_name}"
+        plugin_instance = getattr(mod, plugin_class_name)()
+        evals[i]["probe_tags"] = plugin_instance.tags
 
-evals_df = pd.DataFrame.from_dict(evals)
-evals_df = evals_df.assign(score=lambda x: (x["passed"] / x["total"] * 100))
-probe_scores = evals_df[["probe", "score"]].groupby("probe").mean()
+    evals_df = pd.DataFrame.from_dict(evals)
+    evals_df = evals_df.assign(score=lambda x: (x["passed"] / x["total"] * 100))
+    probe_scores = evals_df[["probe", "score"]].groupby("probe").mean()
 
-# set up a generic report template
-report_template = Report()
-if meta is not None:
-    report_template.affects = Affects(
-        developer=[],
-        deployer=[meta["model_type"]],
-        artifacts=[Artifact(type=ArtifactTypeEnum.model, name=meta["model_name"])],
-    )
+    # set up a generic report template
+    report_template = Report()
+    if meta is not None:
+        report_template.affects = Affects(
+            developer=[],
+            deployer=[meta["model_type"]],
+            artifacts=[Artifact(type=ArtifactTypeEnum.model, name=meta["model_name"])],
+        )
 
-report_template.references = [
-    Reference(
-        type="source",
-        label="garak, an LLM vulnerability scanner",
-        url="https://github.com/NVIDIA/garak",
-    )
-]
-report_template.reported_date = date.today()
-
-# now build all the reports
-all_reports = []
-for probe in probe_scores.index:
-    report = report_template.copy()
-    probe_data = evals_df.query(f"probe=='{probe}'")
-
-    report.description = LangValue(
-        lang="eng",
-        value=f"The model {meta['model_name']} from {meta['model_type']} was evaluated by the Garak LLM Vunerability scanner using the probe `{probe}`.",
-    )
-    report.problemtype = Problemtype(
-        classof=ClassEnum.llm, type=TypeEnum.measurement, description=report.description
-    )
-    report.metrics = [
-        Metric(
-            name="",
-            detection_method=Detection(type=MethodEnum.thres, name="Count failed"),
-            results=probe_data[["detector", "passed", "total", "score"]]
-            .reset_index()
-            .to_dict(),
+    report_template.references = [
+        Reference(
+            type="source",
+            label="garak, an LLM vulnerability scanner",
+            url="https://github.com/NVIDIA/garak",
         )
     ]
-    all_tags = probe_data.iloc[0]["probe_tags"]
-    if all_tags == all_tags:  # check for NaN
-        tags_split = [
-            tag.split(":") for tag in all_tags if tag.startswith("avid")
-        ]  # supports only avid taxonomy for now
-        report.impact = Impact(
-            avid=AvidTaxonomy(
-                risk_domain=pd.Series([tag[1].title() for tag in tags_split])
-                .drop_duplicates()
-                .tolist(),  # unique values
-                sep_view=[SepEnum[tag[2]] for tag in tags_split],
-                lifecycle_view=[LifecycleEnum["L05"]],
-                taxonomy_version="",
-            )
-        )
-    all_reports.append(report)
+    report_template.reported_date = date.today()
 
-# save final output
-write_location = report_location.replace(".report", ".avid")
-with open(write_location, "w", encoding="utf-8") as f:
-    f.writelines(r.json() + "\n" for r in all_reports)
-print(f"📜 AVID reports generated at {write_location}")
+    # now build all the reports
+    all_reports = []
+    for probe in probe_scores.index:
+        report = report_template.copy()
+        probe_data = evals_df.query(f"probe=='{probe}'")
+
+        report.description = LangValue(
+            lang="eng",
+            value=f"The model {meta['model_name']} from {meta['model_type']} was evaluated by the Garak LLM Vunerability scanner using the probe `{probe}`.",
+        )
+        report.problemtype = Problemtype(
+            classof=ClassEnum.llm, type=TypeEnum.measurement, description=report.description
+        )
+        report.metrics = [
+            Metric(
+                name="",
+                detection_method=Detection(type=MethodEnum.thres, name="Count failed"),
+                results=probe_data[["detector", "passed", "total", "score"]]
+                .reset_index()
+                .to_dict(),
+            )
+        ]
+        all_tags = probe_data.iloc[0]["probe_tags"]
+        if all_tags == all_tags:  # check for NaN
+            tags_split = [
+                tag.split(":") for tag in all_tags if tag.startswith("avid")
+            ]  # supports only avid taxonomy for now
+            report.impact = Impact(
+                avid=AvidTaxonomy(
+                    risk_domain=pd.Series([tag[1].title() for tag in tags_split])
+                    .drop_duplicates()
+                    .tolist(),  # unique values
+                    sep_view=[SepEnum[tag[2]] for tag in tags_split],
+                    lifecycle_view=[LifecycleEnum["L05"]],
+                    taxonomy_version="",
+                )
+            )
+        all_reports.append(report)
+
+    # save final output
+    write_location = report_location.replace(".report", ".avid")
+    with open(write_location, "w", encoding="utf-8") as f:
+        f.writelines(r.json() + "\n" for r in all_reports)
+    print(f"📜 AVID reports generated at {write_location}")
+    return write_location
+
+
+def main(argv=None) -> None:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    _config.load_config()
+    print(
+        f"garak {__description__} v{_config.version} ( https://github.com/NVIDIA/garak )"
+    )
+
+    parser = argparse.ArgumentParser(
+        prog="python -m garak.analyze.report_avid",
+        description="Conversion Tool from native garak jsonl to AVID reports",
+        epilog="See https://github.com/NVIDIA/garak",
+        allow_abbrev=False,
+    )
+    parser.add_argument(
+        "-r",
+        "--report_path",
+        type=str,
+        required=True,
+        help="Location of garak report file",
+    )
+    args = parser.parse_args(argv)
+
+    sys.stdout.reconfigure(encoding="utf-8")
+    convert_to_avid(args.report_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/garak/analyze/report_avid.py
+++ b/garak/analyze/report_avid.py
@@ -72,7 +72,9 @@ def convert_to_avid(report_location: str) -> str:
             value=f"The model {meta['model_name']} from {meta['model_type']} was evaluated by the Garak LLM Vunerability scanner using the probe `{probe}`.",
         )
         report.problemtype = Problemtype(
-            classof=ClassEnum.llm, type=TypeEnum.measurement, description=report.description
+            classof=ClassEnum.llm,
+            type=TypeEnum.measurement,
+            description=report.description,
         )
         report.metrics = [
             Metric(


### PR DESCRIPTION
#1362 

PR 1368: Standardizes CLI patterns across all CLI-accessible scripts in `garak.analyze`. Each script now:
- Uses argparse with consistent flags and help/description (pattern aligned with `garak.cli`)
- Prints a version banner (`garak <description> v<version>`)
- Provides short and long options (e.g., `-r/--report_path`, `-o/--output_path`)
- Executes only under `if __name__ == "__main__":` and not on import

Updated scripts: `aggregate_reports`, `analyze_log`, `count_tokens`, `get_tree`, `misp`, `perf_stats`, `qual_review`, `report_avid` (kept `report_digest` as the canonical example). No specific GitHub issue linked; this addresses CLI consistency and import-side-effect issues.

## Verification

List the steps needed to make sure this thing works


- [ ] `garak -m <model_type> -n <model_name>`
- [ ] Run the tests and ensure they pass `python -m pytest tests/`
- [ ] Generate a small report to use for analysis tools:
  - [ ] `python -m garak -m test.Blank -p test.Blank --report_prefix _cli_std_check`
- [ ] Verify each analyze CLI runs with help text and version banner:
  - [ ] `python -m garak.analyze.aggregate_reports --help`
  - [ ] `python -m garak.analyze.analyze_log --help`
  - [ ] `python -m garak.analyze.count_tokens --help`
  - [ ] `python -m garak.analyze.get_tree --help`
  - [ ] `python -m garak.analyze.misp --help`
  - [ ] `python -m garak.analyze.perf_stats --help`
  - [ ] `python -m garak.analyze.qual_review --help`
  - [ ] `python -m garak.analyze.report_avid --help`
- [ ] Run each tool against the generated report (replace `<REPORT>` with the path to `_cli_std_check.report.jsonl`):
  - [ ] `python -m garak.analyze.analyze_log -r <REPORT>`
  - [ ] `python -m garak.analyze.count_tokens -r <REPORT>`
  - [ ] `python -m garak.analyze.get_tree -r <REPORT>`
  - [ ] `python -m garak.analyze.misp -u`
  - [ ] `python -m garak.analyze.perf_stats -r <REPORT> <REPORT>`
  - [ ] `python -m garak.analyze.qual_review -r <REPORT>`
  - [ ] `python -m garak.analyze.aggregate_reports -o agg.jsonl <REPORT> <REPORT>`
  - [ ] `python -m garak.analyze.report_avid -r <REPORT>`
  - [ ] `python -m garak.analyze.report_digest -r <REPORT>`
