### PR TITLE
bugfix: ASR figures in probe docs are now actual ASRs

### DIFF
--- a/docs/source/_ext/garak_ext.py
+++ b/docs/source/_ext/garak_ext.py
@@ -14,7 +14,9 @@ class ShowASRDirective(SphinxDirective):
 
     def run(self) -> list:
         rst = ""
-        with open("../../garak/data/calibration/calibration.json", encoding="utf-8") as f:
+        with open(
+            "../../garak/data/calibration/calibration.json", encoding="utf-8"
+        ) as f:
             calibration = json.load(f)
             for key in sorted(calibration.keys()):
                 if key.startswith(self.env.docname.replace("garak.probes.", "")):
@@ -23,12 +25,13 @@ class ShowASRDirective(SphinxDirective):
                     probe_ref = f":obj:`~garak.probes.{probe}`"
                     detector_ref = f":obj:`~garak.detectors.{detector}`"
 
-                    rst += f"\n* {probe_ref}: {100*scores["mu"]:.1f}%, with detector: {detector_ref}"
+                    rst += f"\n* {probe_ref}: {100*(1-scores["mu"]):.1f}% with detector {detector_ref}"
 
         if rst:
             rst = (
-                """\nAttacks with these probes have the following attack success rates (ASR) in a recent `evaluation <https://github.com/NVIDIA/garak/blob/main/garak/data/calibration/bag.md>`_:\n"""
+                """\nAttacks with the following calibrated probes have the following attack success rates (ASR) in a recent `evaluation <https://github.com/NVIDIA/garak/blob/main/garak/data/calibration/bag.md>`_:\n"""
                 + rst
+                + "\n\n **Note:** Not all probes are calibrated, so this data might not cover every class in the module."
             )
 
         return self._parse_rst(rst)

--- a/garak/data/calibration/bag.md
+++ b/garak/data/calibration/bag.md
@@ -25,6 +25,8 @@ It's possible to get a great Z-score and a low absolute score. This means that w
 
 We artificially bound standard deviations at a non-zero minimum, to represent the inherent uncertainty in using an incomplete sample of all LLMs, and to make Z-score calculation possible even when the bag perfectly agrees.
 
+NB: Values in `calibration.json` are pass rates, not attack success rates. To calculate mean ASR, take 1-μ.
+
 ## When is the bag updated?
 
 The first benchmark is in summer 2024. We think something between twice-yearly and quarterly updates provides a good trade off between using recent models, and keeping results relevant long enough to be comparable.


### PR DESCRIPTION
* prev was pass rate
* added a note to `bag.md` to clarify what is measured in the calibration

testing:
* [x] check that ASR in docs is `1-pass rate` in calibration 
* [x] e.g. that `leakreplay` `-Cloze` attacks have low-ish ASR, but above 0
* [x] e.g. that `leakreplay` `-Complete` attacks have lower ASR than the `-Cloze` attacks