### PR TITLE
Use ABC to hide abstract PackageHallucinationProbe from --list_probes

### DIFF
--- a/garak/_plugins.py
+++ b/garak/_plugins.py
@@ -57,6 +57,7 @@ class PluginCache:
             name
             for name, klass in inspect.getmembers(base_klass, inspect.isclass)
             if klass.__module__.startswith(base_klass.__name__)
+            and not inspect.isabstract(klass)
         ]
 
     def _load_plugin_cache(self):
@@ -420,6 +421,10 @@ def load_plugin(path, break_on_fail=True, config_root=_config) -> object:
 
     try:
         klass = getattr(mod, plugin_class_name)
+        if inspect.isabstract(klass):
+            raise ValueError(
+                f"Cannot load plugin '{plugin_class_name}': abstract classes are not loadable"
+            )
         if "config_root" not in inspect.signature(klass.__init__).parameters:
             raise ConfigFailure(
                 'Incompatible function signature: plugin must take a "config_root"'

--- a/garak/probes/packagehallucination.py
+++ b/garak/probes/packagehallucination.py
@@ -4,6 +4,7 @@ Trying to get code generations that specify non-existent (and therefore insecure
 packages
 """
 
+from abc import ABC, abstractmethod
 from garak import _config
 import garak.probes
 
@@ -33,8 +34,8 @@ code_tasks = [
 ]
 
 
-class PackageHallucinationProbe(garak.probes.Probe):
-    """Base class for package hallucination probes
+class PackageHallucinationProbe(garak.probes.Probe, ABC):
+    """Abstract base class for package hallucination probes
 
     Generators sometimes recommend importing non-existent packages into code. These
     package names can be found by attackers and then squatted in public package
@@ -42,7 +43,6 @@ class PackageHallucinationProbe(garak.probes.Probe):
     loading malicious squatted packages onto the machine. This is bad. This probe
     checks whether a model will recommend code that uses non-existent packages."""
 
-    active = False
     lang = "*"
     doc_uri = "https://vulcan.io/blog/ai-hallucinations-package-risk"
     tags = [
@@ -51,9 +51,13 @@ class PackageHallucinationProbe(garak.probes.Probe):
         "quality:Robustness:GenerativeMisinformation",
         "payload:malicious:badcode",
     ]
-    language_name = ""
     goal = "base probe for importing non-existent packages"
-    tier = garak.probes.Tier.UNLISTED
+
+    @property
+    @abstractmethod
+    def language_name(self) -> str:
+        """Programming language name - must be overridden by subclasses"""
+        pass
 
     def __init__(self, config_root=_config):
         super().__init__(config_root=config_root)

--- a/garak/resources/plugin_cache.json
+++ b/garak/resources/plugin_cache.json
@@ -27,7 +27,7 @@
         "quality:Security:Integrity"
       ],
       "tier": 3,
-      "mod_time": "2025-10-01 13:06:16 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.ansiescape.AnsiRaw": {
       "description": "Probe for eliciting raw ANSI control codes from a model",
@@ -56,7 +56,7 @@
         "quality:Security:Integrity"
       ],
       "tier": 1,
-      "mod_time": "2025-10-01 13:06:16 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.ansiescape.AnsiRawTokenizerHF": {
       "description": "Probe for checking a tokenizer for potentially malicious ANSI escape sequences",
@@ -80,7 +80,7 @@
         "owasp:llm05"
       ],
       "tier": 1,
-      "mod_time": "2025-10-01 13:06:16 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.atkgen.Tox": {
       "description": "Automatic attack generation, trying to elicit toxic outputs from the model.",
@@ -124,7 +124,7 @@
         "payload:unwanted"
       ],
       "tier": 2,
-      "mod_time": "2025-08-28 19:55:49 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.audio.AudioAchillesHeel": {
       "description": "Audio is the Achilles Heel",
@@ -153,7 +153,7 @@
         "quality:Security:PromptStability"
       ],
       "tier": 9,
-      "mod_time": "2025-06-12 16:14:56 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.av_spam_scanning.EICAR": {
       "description": "Does the model check its output for viruses? Try to send the EICAR code through",
@@ -181,7 +181,7 @@
         "quality:Security:Adversarial"
       ],
       "tier": 9,
-      "mod_time": "2025-05-16 07:39:54 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.av_spam_scanning.GTUBE": {
       "description": "Does the model check its output for spam? Try to send the GTUBE code through",
@@ -209,7 +209,7 @@
         "quality:Security:Adversarial"
       ],
       "tier": 9,
-      "mod_time": "2025-05-16 07:39:54 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.av_spam_scanning.GTphish": {
       "description": "Does the model check its output for phishing? Try to send the GTphish code through",
@@ -237,7 +237,7 @@
         "quality:Security:Adversarial"
       ],
       "tier": 9,
-      "mod_time": "2025-05-16 07:39:54 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.base.Probe": {
       "description": "Base class for objects that define and execute LLM evaluations",
@@ -259,7 +259,7 @@
       ],
       "tags": [],
       "tier": 9,
-      "mod_time": "2025-08-28 13:46:07 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.base.TreeSearchProbe": {
       "DEFAULT_PARAMS": {
@@ -286,7 +286,7 @@
       ],
       "tags": [],
       "tier": 9,
-      "mod_time": "2025-08-28 13:46:07 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.continuation.ContinueSlursReclaimedSlurs": {
       "description": "Continue partial word with slur or reclaimed slur.",
@@ -316,7 +316,7 @@
         "payload:unwanted:hatespeech"
       ],
       "tier": 2,
-      "mod_time": "2025-06-27 13:34:35 +0000"
+      "mod_time": "2025-08-29 13:44:15 +0000"
     },
     "probes.continuation.ContinueSlursReclaimedSlursFull": {
       "description": "Continue partial word with slur or reclaimed slur.",
@@ -346,7 +346,7 @@
         "payload:unwanted:hatespeech"
       ],
       "tier": 2,
-      "mod_time": "2025-06-27 13:34:35 +0000"
+      "mod_time": "2025-08-29 13:44:15 +0000"
     },
     "probes.dan.Ablation_Dan_11_0": {
       "description": "Ablation experiements over the DAN 11.0 prompt",
@@ -374,7 +374,7 @@
         "payload:jailbreak"
       ],
       "tier": 2,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "probes.dan.AntiDAN": {
       "description": "Anti-DAN",
@@ -402,7 +402,7 @@
         "owasp:llm01"
       ],
       "tier": 9,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "probes.dan.AutoDAN": {
       "description": "Probe leveraging AutoDAN attack generation",
@@ -430,7 +430,7 @@
         "payload:jailbreak"
       ],
       "tier": 2,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "probes.dan.AutoDANCached": {
       "description": "Probe leveraging generated AutoDAN prompts",
@@ -458,7 +458,7 @@
         "payload:jailbreak"
       ],
       "tier": 2,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "probes.dan.ChatGPT_Developer_Mode_RANTI": {
       "description": "ChatGPT DevMode + Ranti",
@@ -486,7 +486,7 @@
         "owasp:llm01"
       ],
       "tier": 9,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "probes.dan.ChatGPT_Developer_Mode_v2": {
       "description": "ChatGPT Developer Mode v2",
@@ -514,7 +514,7 @@
         "payload:jailbreak"
       ],
       "tier": 9,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "probes.dan.ChatGPT_Image_Markdown": {
       "description": "ChatGPT Markdown Image Unlocker / markdown injection",
@@ -542,7 +542,7 @@
         "payload:jailbreak"
       ],
       "tier": 9,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "probes.dan.DAN_Jailbreak": {
       "description": "DAN Jailbreak",
@@ -570,7 +570,7 @@
         "payload:jailbreak"
       ],
       "tier": 9,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "probes.dan.DUDE": {
       "description": "DUDE",
@@ -598,7 +598,7 @@
         "payload:jailbreak"
       ],
       "tier": 9,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "probes.dan.DanInTheWild": {
       "description": "A subset of jailbreaks from the DanInTheWild jailbreak library.",
@@ -625,7 +625,7 @@
         "payload:jailbreak"
       ],
       "tier": 1,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "probes.dan.DanInTheWildFull": {
       "description": "A library of jailbreaks.",
@@ -652,7 +652,7 @@
         "payload:jailbreak"
       ],
       "tier": 1,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "probes.dan.Dan_10_0": {
       "description": "DAN 10.0",
@@ -680,7 +680,7 @@
         "payload:jailbreak"
       ],
       "tier": 9,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "probes.dan.Dan_11_0": {
       "description": "DAN 11.0",
@@ -709,7 +709,7 @@
         "payload:jailbreak"
       ],
       "tier": 9,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "probes.dan.Dan_6_0": {
       "description": "DAN 6.0",
@@ -737,7 +737,7 @@
         "payload:jailbreak"
       ],
       "tier": 9,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "probes.dan.Dan_6_2": {
       "description": "DAN 6.2",
@@ -765,7 +765,7 @@
         "payload:jailbreak"
       ],
       "tier": 9,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "probes.dan.Dan_7_0": {
       "description": "DAN 7.0",
@@ -793,7 +793,7 @@
         "payload:jailbreak"
       ],
       "tier": 9,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "probes.dan.Dan_8_0": {
       "description": "DAN 8.0",
@@ -821,7 +821,7 @@
         "payload:jailbreak"
       ],
       "tier": 9,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "probes.dan.Dan_9_0": {
       "description": "DAN 9.0",
@@ -849,7 +849,7 @@
         "payload:jailbreak"
       ],
       "tier": 9,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "probes.dan.STAN": {
       "description": "STAN",
@@ -877,7 +877,7 @@
         "payload:jailbreak"
       ],
       "tier": 9,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "probes.divergence.Repeat": {
       "description": "See if a model starts giving other data when asked to repeat a string indefinitely",
@@ -908,7 +908,7 @@
         "payload:leak:training"
       ],
       "tier": 2,
-      "mod_time": "2025-09-23 17:38:16 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.divergence.RepeatExtended": {
       "description": "See if a model starts giving other data when asked to repeat a string indefinitely",
@@ -939,7 +939,7 @@
         "payload:leak:training"
       ],
       "tier": 2,
-      "mod_time": "2025-09-23 17:38:16 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.divergence.RepeatedToken": {
       "description": "Repeated token destabilization attack from Dropbox LLM security research.",
@@ -976,7 +976,7 @@
         "payload:unwanted:denial_of_service"
       ],
       "tier": 1,
-      "mod_time": "2025-09-23 17:38:16 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.doctor.Bypass": {
       "description": "Implement Policy Puppetry Bypass",
@@ -1003,7 +1003,7 @@
         "cwe:1427"
       ],
       "tier": 2,
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.doctor.BypassLeet": {
       "description": "Implement Policy Puppetry Bypass",
@@ -1030,7 +1030,7 @@
         "cwe:1427"
       ],
       "tier": 2,
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.doctor.Puppetry": {
       "description": "Implement Policy Puppetry Prompt Injection",
@@ -1057,7 +1057,7 @@
         "cwe:1427"
       ],
       "tier": 2,
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.donotanswer.DiscriminationExclusionToxicityHatefulOffensive": {
       "description": "Implementation of discrimination_exclusion_toxicity_hateful_offensive probes in DoNotAnswer_Prompts",
@@ -1085,7 +1085,7 @@
         "quality:Behavioral:ContentSafety:Profanity"
       ],
       "tier": 9,
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.donotanswer.HumanChatbox": {
       "description": "Implementation of human_chatbox probes in DoNotAnswer_Prompts",
@@ -1110,7 +1110,7 @@
         "quality:Behavioral:ContentSafety:Unauthorized"
       ],
       "tier": 9,
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.donotanswer.InformationHazard": {
       "description": "Implementation of information_hazard probes in DoNotAnswer_Prompts",
@@ -1136,7 +1136,7 @@
         "quality:Security:Confidentiality"
       ],
       "tier": 9,
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.donotanswer.MaliciousUses": {
       "description": "Implementation of malicious_uses probes in DoNotAnswer_Prompts",
@@ -1160,7 +1160,7 @@
         "quality:Behavioral:ContentSafety:LegalGoodsServices"
       ],
       "tier": 9,
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.donotanswer.MisinformationHarms": {
       "description": "Implementation of misinformation_harms probes in DoNotAnswer_Prompts",
@@ -1186,7 +1186,7 @@
         "owasp:llm09"
       ],
       "tier": 9,
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.dra.DRA": {
       "description": "DRA (Disguise and Reconstruction Attack)",
@@ -1220,7 +1220,7 @@
         "payload:jailbreak"
       ],
       "tier": 1,
-      "mod_time": "2025-09-30 07:48:45 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.dra.DRAAdvanced": {
       "description": "DRA (Disguise and Reconstruction Attack) - Version with detoxify",
@@ -1255,7 +1255,7 @@
         "payload:jailbreak"
       ],
       "tier": 1,
-      "mod_time": "2025-09-30 07:48:45 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.encoding.InjectAscii85": {
       "description": "Probe for susceptibility to base85 encoded injections",
@@ -1291,7 +1291,7 @@
         "payload:generic"
       ],
       "tier": 2,
-      "mod_time": "2025-09-08 12:35:41 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.encoding.InjectAtbash": {
       "description": "Atbash Probe Credit: Nakul-Rajpal",
@@ -1327,7 +1327,7 @@
         "payload:generic"
       ],
       "tier": 2,
-      "mod_time": "2025-09-08 12:35:41 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.encoding.InjectBase16": {
       "description": "Probe for susceptibility to base16 encoded injections\"",
@@ -1363,7 +1363,7 @@
         "payload:generic"
       ],
       "tier": 2,
-      "mod_time": "2025-09-08 12:35:41 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.encoding.InjectBase2048": {
       "description": "Probe for susceptibility to Base2048 encoding injections",
@@ -1399,7 +1399,7 @@
         "payload:generic"
       ],
       "tier": 2,
-      "mod_time": "2025-09-08 12:35:41 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.encoding.InjectBase32": {
       "description": "Probe for susceptibility to base32 encoded injections",
@@ -1435,7 +1435,7 @@
         "payload:generic"
       ],
       "tier": 2,
-      "mod_time": "2025-09-08 12:35:41 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.encoding.InjectBase64": {
       "description": "Probe for susceptibility to base64 encoded injections",
@@ -1471,7 +1471,7 @@
         "payload:generic"
       ],
       "tier": 1,
-      "mod_time": "2025-09-08 12:35:41 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.encoding.InjectBraille": {
       "description": "Probe for susceptibility to Braille encoding injections. Credit Wally#3422",
@@ -1507,7 +1507,7 @@
         "payload:generic"
       ],
       "tier": 2,
-      "mod_time": "2025-09-08 12:35:41 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.encoding.InjectEcoji": {
       "description": "Probe for susceptibility to Ecoji encoding.",
@@ -1543,7 +1543,7 @@
         "payload:generic"
       ],
       "tier": 2,
-      "mod_time": "2025-09-08 12:35:41 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.encoding.InjectHex": {
       "description": "Probe for susceptibility to hex encoded injections",
@@ -1579,7 +1579,7 @@
         "payload:generic"
       ],
       "tier": 2,
-      "mod_time": "2025-09-08 12:35:41 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.encoding.InjectLeet": {
       "description": "Probe for susceptibility to 31337 encoding.",
@@ -1615,7 +1615,7 @@
         "payload:generic"
       ],
       "tier": 2,
-      "mod_time": "2025-09-08 12:35:41 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.encoding.InjectMime": {
       "description": "Probe for susceptibility to MIME encoding injections",
@@ -1651,7 +1651,7 @@
         "payload:generic"
       ],
       "tier": 2,
-      "mod_time": "2025-09-08 12:35:41 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.encoding.InjectMorse": {
       "description": "Probe for susceptibility to Morse encoding. Credit Wally#3422",
@@ -1687,7 +1687,7 @@
         "payload:generic"
       ],
       "tier": 2,
-      "mod_time": "2025-09-08 12:35:41 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.encoding.InjectNato": {
       "description": "Probe for susceptibility to Nato phonetic alphabet encoding.",
@@ -1723,7 +1723,7 @@
         "payload:generic"
       ],
       "tier": 2,
-      "mod_time": "2025-09-08 12:35:41 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.encoding.InjectQP": {
       "description": "Probe for susceptibility to QP encoded injections",
@@ -1759,7 +1759,7 @@
         "payload:generic"
       ],
       "tier": 1,
-      "mod_time": "2025-09-08 12:35:41 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.encoding.InjectROT13": {
       "description": "Probe for susceptibility to ROT13 encoding injections",
@@ -1795,7 +1795,7 @@
         "payload:generic"
       ],
       "tier": 2,
-      "mod_time": "2025-09-08 12:35:41 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.encoding.InjectSneakyBits": {
       "description": "Probe for susceptibility to unicode variant selector ASCII smuggling",
@@ -1831,7 +1831,7 @@
         "payload:generic"
       ],
       "tier": 2,
-      "mod_time": "2025-09-08 12:35:41 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.encoding.InjectUU": {
       "description": "Probe for susceptibility to UU encoded injections",
@@ -1867,7 +1867,7 @@
         "payload:generic"
       ],
       "tier": 1,
-      "mod_time": "2025-09-08 12:35:41 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.encoding.InjectUnicodeTagChars": {
       "description": "Probe for susceptibility to unicode tag ASCII smuggling",
@@ -1904,7 +1904,7 @@
         "payload:generic"
       ],
       "tier": 1,
-      "mod_time": "2025-09-08 12:35:41 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.encoding.InjectUnicodeVariantSelectors": {
       "description": "Probe for susceptibility to unicode variant selector ASCII smuggling",
@@ -1940,7 +1940,7 @@
         "payload:generic"
       ],
       "tier": 2,
-      "mod_time": "2025-09-08 12:35:41 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.encoding.InjectZalgo": {
       "description": "Probe for susceptibility to Zalgo encoding.",
@@ -1976,7 +1976,7 @@
         "payload:generic"
       ],
       "tier": 2,
-      "mod_time": "2025-09-08 12:35:41 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.exploitation.JinjaTemplatePythonInjection": {
       "description": "Attempts to execute Python code via Jinja templating",
@@ -2012,7 +2012,7 @@
         "cwe:1336"
       ],
       "tier": 1,
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.exploitation.SQLInjectionEcho": {
       "description": "Attempts to get the target to echo a SQL statement.",
@@ -2046,7 +2046,7 @@
         "cwe:1427"
       ],
       "tier": 1,
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.exploitation.SQLInjectionSystem": {
       "description": "Attempts to inject untrusted SQL commands into a SQL statement.",
@@ -2080,7 +2080,7 @@
         "cwe:1427"
       ],
       "tier": 1,
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.fileformats.HF_Files": {
       "description": "Get a manifest of files associated with a Hugging Face generator",
@@ -2107,7 +2107,7 @@
         "owasp:llm05"
       ],
       "tier": 1,
-      "mod_time": "2025-05-16 07:39:54 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.glitch.Glitch": {
       "description": "Probe model for glitch tokens that provoke unusual behavior",
@@ -2135,7 +2135,7 @@
         "payload:generic"
       ],
       "tier": 3,
-      "mod_time": "2025-05-16 07:39:54 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.glitch.GlitchFull": {
       "description": "Probe model for glitch tokens that provoke unusual behavior",
@@ -2163,7 +2163,7 @@
         "payload:generic"
       ],
       "tier": 3,
-      "mod_time": "2025-05-16 07:39:54 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.goodside.Davidjl": {
       "description": "Exploit the ' davidjl' magic token",
@@ -2191,7 +2191,7 @@
         "payload:generic"
       ],
       "tier": 3,
-      "mod_time": "2025-06-27 13:34:35 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.goodside.Tag": {
       "description": "Exploit UTF tag page encoding for user-invisible prompt injection",
@@ -2218,7 +2218,7 @@
         "quality:Security:PromptStability"
       ],
       "tier": 1,
-      "mod_time": "2025-06-27 13:34:35 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.goodside.ThreatenJSON": {
       "description": "Will model strip preamble and give JSON?",
@@ -2245,7 +2245,7 @@
         "payload:generic"
       ],
       "tier": 2,
-      "mod_time": "2025-06-27 13:34:35 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.goodside.WhoIsRiley": {
       "description": "Probe for misinfo about Riley Goodside",
@@ -2273,7 +2273,7 @@
         "payload:hallucination"
       ],
       "tier": 2,
-      "mod_time": "2025-06-27 13:34:35 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.grandma.Slurs": {
       "description": "Use the grandma attack to get ethnic slurs.",
@@ -2306,7 +2306,7 @@
         "avid-effect:security:S0300"
       ],
       "tier": 1,
-      "mod_time": "2025-07-03 13:47:02 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.grandma.Substances": {
       "description": "Use the grandma attack to get instructions for harmful items.",
@@ -2339,7 +2339,7 @@
         "quality:Behavioral:ContentSafety:LegalGoodsServices"
       ],
       "tier": 1,
-      "mod_time": "2025-07-03 13:47:02 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.grandma.Win10": {
       "description": "Will the model yield a Windows 10 product key if we beg it to?",
@@ -2368,7 +2368,7 @@
         "quality:Behavioral:ContentSafety:LegalGoodsServices"
       ],
       "tier": 2,
-      "mod_time": "2025-07-03 13:47:02 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.grandma.Win11": {
       "description": "Will the model yield a Windows 11 product key if we beg it to?",
@@ -2397,7 +2397,7 @@
         "quality:Behavioral:ContentSafety:LegalGoodsServices"
       ],
       "tier": 2,
-      "mod_time": "2025-07-03 13:47:02 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.latentinjection.LatentInjectionFactSnippetEiffel": {
       "description": "String-based latent prompt injections in fact snippets on the Eiffel Tower",
@@ -2428,7 +2428,7 @@
         "quality:Security:PromptStability"
       ],
       "tier": 1,
-      "mod_time": "2025-06-27 16:42:09 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.latentinjection.LatentInjectionFactSnippetEiffelFull": {
       "description": "String-based latent prompt injections in fact snippets on the Eiffel Tower",
@@ -2459,7 +2459,7 @@
         "quality:Security:PromptStability"
       ],
       "tier": 1,
-      "mod_time": "2025-06-27 16:42:09 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.latentinjection.LatentInjectionFactSnippetLegal": {
       "description": "String-based latent prompt injections in legal snippets",
@@ -2490,7 +2490,7 @@
         "quality:Security:PromptStability"
       ],
       "tier": 1,
-      "mod_time": "2025-06-27 16:42:09 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.latentinjection.LatentInjectionFactSnippetLegalFull": {
       "description": "String-based latent prompt injections in legal snippets",
@@ -2521,7 +2521,7 @@
         "quality:Security:PromptStability"
       ],
       "tier": 1,
-      "mod_time": "2025-06-27 16:42:09 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.latentinjection.LatentInjectionReport": {
       "description": "String-based latent prompt injections via a report",
@@ -2549,7 +2549,7 @@
         "quality:Security:PromptStability"
       ],
       "tier": 1,
-      "mod_time": "2025-06-27 16:42:09 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.latentinjection.LatentInjectionReportFull": {
       "description": "String-based latent prompt injections via a report",
@@ -2577,7 +2577,7 @@
         "quality:Security:PromptStability"
       ],
       "tier": 1,
-      "mod_time": "2025-06-27 16:42:09 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.latentinjection.LatentInjectionResume": {
       "description": "String-based latent prompt injections via a resume",
@@ -2603,7 +2603,7 @@
         "quality:Security:PromptStability"
       ],
       "tier": 1,
-      "mod_time": "2025-06-27 16:42:09 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.latentinjection.LatentInjectionResumeFull": {
       "description": "String-based latent prompt injections via a resume",
@@ -2629,7 +2629,7 @@
         "quality:Security:PromptStability"
       ],
       "tier": 1,
-      "mod_time": "2025-06-27 16:42:09 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.latentinjection.LatentInjectionTranslationEnFr": {
       "description": "String-based latent prompt injections via translation",
@@ -2657,7 +2657,7 @@
         "quality:Security:PromptStability"
       ],
       "tier": 1,
-      "mod_time": "2025-06-27 16:42:09 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.latentinjection.LatentInjectionTranslationEnFrFull": {
       "description": "String-based latent prompt injections via translation",
@@ -2685,7 +2685,7 @@
         "quality:Security:PromptStability"
       ],
       "tier": 1,
-      "mod_time": "2025-06-27 16:42:09 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.latentinjection.LatentInjectionTranslationEnZh": {
       "description": "Latent prompt injection in Chinese context (\u7b80\u4f53\u5b57)",
@@ -2713,7 +2713,7 @@
         "quality:Security:PromptStability"
       ],
       "tier": 1,
-      "mod_time": "2025-06-27 16:42:09 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.latentinjection.LatentInjectionTranslationEnZhFull": {
       "description": "Latent prompt injection in Chinese context (\u7b80\u4f53\u5b57)",
@@ -2741,7 +2741,7 @@
         "quality:Security:PromptStability"
       ],
       "tier": 1,
-      "mod_time": "2025-06-27 16:42:09 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.latentinjection.LatentJailbreak": {
       "description": "Implementation of Latent Jailbreak, using latent prompt injection-",
@@ -2769,7 +2769,7 @@
         "quality:Security:PromptStability"
       ],
       "tier": 1,
-      "mod_time": "2025-06-27 16:42:09 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.latentinjection.LatentJailbreakFull": {
       "description": "Implementation of Latent Jailbreak, using latent prompt injection-",
@@ -2797,7 +2797,7 @@
         "quality:Security:PromptStability"
       ],
       "tier": 1,
-      "mod_time": "2025-06-27 16:42:09 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.latentinjection.LatentWhois": {
       "description": "Latent prompt injections in whois probe reports",
@@ -2823,7 +2823,7 @@
         "quality:Security:PromptStability"
       ],
       "tier": 1,
-      "mod_time": "2025-06-27 16:42:09 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.latentinjection.LatentWhoisSnippet": {
       "description": "String-based latent prompt injections in whois reports",
@@ -2854,7 +2854,7 @@
         "quality:Security:PromptStability"
       ],
       "tier": 1,
-      "mod_time": "2025-06-27 16:42:09 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.latentinjection.LatentWhoisSnippetFull": {
       "description": "String-based latent prompt injections in whois reports",
@@ -2885,7 +2885,7 @@
         "quality:Security:PromptStability"
       ],
       "tier": 1,
-      "mod_time": "2025-06-27 16:42:09 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.leakreplay.GuardianCloze": {
       "description": "Lightweight version of Guardian cloze test for data leakage.",
@@ -2913,7 +2913,7 @@
         "payload:leak:training"
       ],
       "tier": 2,
-      "mod_time": "2025-08-13 22:01:46 +0000"
+      "mod_time": "2025-09-04 14:42:46 +0000"
     },
     "probes.leakreplay.GuardianClozeFull": {
       "description": "Test for data leakage on Guardian articles with masked entities in a cloze test format.",
@@ -2941,7 +2941,7 @@
         "payload:leak:training"
       ],
       "tier": 2,
-      "mod_time": "2025-08-13 22:01:46 +0000"
+      "mod_time": "2025-09-04 14:42:46 +0000"
     },
     "probes.leakreplay.GuardianComplete": {
       "description": "Lightweight version of Guardian completion test for data leakage.",
@@ -2969,7 +2969,7 @@
         "payload:leak:training"
       ],
       "tier": 1,
-      "mod_time": "2025-08-13 22:01:46 +0000"
+      "mod_time": "2025-09-04 14:42:46 +0000"
     },
     "probes.leakreplay.GuardianCompleteFull": {
       "description": "Test for data leakage on Guardian articles through text completion.",
@@ -2997,7 +2997,7 @@
         "payload:leak:training"
       ],
       "tier": 1,
-      "mod_time": "2025-08-13 22:01:46 +0000"
+      "mod_time": "2025-09-04 14:42:46 +0000"
     },
     "probes.leakreplay.LiteratureCloze": {
       "description": "Lightweight version of literature cloze test for data leakage.",
@@ -3025,7 +3025,7 @@
         "payload:leak:training"
       ],
       "tier": 2,
-      "mod_time": "2025-08-13 22:01:46 +0000"
+      "mod_time": "2025-09-04 14:42:46 +0000"
     },
     "probes.leakreplay.LiteratureClozeFull": {
       "description": "Test for data leakage on literature passages with masked entities in a cloze test format.",
@@ -3053,7 +3053,7 @@
         "payload:leak:training"
       ],
       "tier": 2,
-      "mod_time": "2025-08-13 22:01:46 +0000"
+      "mod_time": "2025-09-04 14:42:46 +0000"
     },
     "probes.leakreplay.LiteratureComplete": {
       "description": "Lightweight version of literature completion test for data leakage.",
@@ -3081,7 +3081,7 @@
         "payload:leak:training"
       ],
       "tier": 2,
-      "mod_time": "2025-08-13 22:01:46 +0000"
+      "mod_time": "2025-09-04 14:42:46 +0000"
     },
     "probes.leakreplay.LiteratureCompleteFull": {
       "description": "Test for data leakage on literature passages through text completion.",
@@ -3109,7 +3109,7 @@
         "payload:leak:training"
       ],
       "tier": 2,
-      "mod_time": "2025-08-13 22:01:46 +0000"
+      "mod_time": "2025-09-04 14:42:46 +0000"
     },
     "probes.leakreplay.NYTCloze": {
       "description": "Lightweight version of NYT cloze test for data leakage.",
@@ -3137,7 +3137,7 @@
         "payload:leak:training"
       ],
       "tier": 2,
-      "mod_time": "2025-08-13 22:01:46 +0000"
+      "mod_time": "2025-09-04 14:42:46 +0000"
     },
     "probes.leakreplay.NYTClozeFull": {
       "description": "Test for data leakage on New York Times articles with masked entities in a cloze test format.",
@@ -3165,7 +3165,7 @@
         "payload:leak:training"
       ],
       "tier": 2,
-      "mod_time": "2025-08-13 22:01:46 +0000"
+      "mod_time": "2025-09-04 14:42:46 +0000"
     },
     "probes.leakreplay.NYTComplete": {
       "description": "Lightweight version of NYT completion test for data leakage.",
@@ -3193,7 +3193,7 @@
         "payload:leak:training"
       ],
       "tier": 1,
-      "mod_time": "2025-08-13 22:01:46 +0000"
+      "mod_time": "2025-09-04 14:42:46 +0000"
     },
     "probes.leakreplay.NYTCompleteFull": {
       "description": "Test for data leakage on New York Times articles through text completion.",
@@ -3221,7 +3221,7 @@
         "payload:leak:training"
       ],
       "tier": 1,
-      "mod_time": "2025-08-13 22:01:46 +0000"
+      "mod_time": "2025-09-04 14:42:46 +0000"
     },
     "probes.leakreplay.PotterCloze": {
       "description": "Lightweight version of Harry Potter cloze test for data leakage.",
@@ -3249,7 +3249,7 @@
         "payload:leak:training"
       ],
       "tier": 2,
-      "mod_time": "2025-08-13 22:01:46 +0000"
+      "mod_time": "2025-09-04 14:42:46 +0000"
     },
     "probes.leakreplay.PotterClozeFull": {
       "description": "Test for data leakage on Harry Potter text with masked entities in a cloze test format.",
@@ -3277,7 +3277,7 @@
         "payload:leak:training"
       ],
       "tier": 2,
-      "mod_time": "2025-08-13 22:01:46 +0000"
+      "mod_time": "2025-09-04 14:42:46 +0000"
     },
     "probes.leakreplay.PotterComplete": {
       "description": "Lightweight version of Harry Potter completion test for data leakage.",
@@ -3305,7 +3305,7 @@
         "payload:leak:training"
       ],
       "tier": 1,
-      "mod_time": "2025-08-13 22:01:46 +0000"
+      "mod_time": "2025-09-04 14:42:46 +0000"
     },
     "probes.leakreplay.PotterCompleteFull": {
       "description": "Test for data leakage on Harry Potter text through completion.",
@@ -3333,7 +3333,7 @@
         "payload:leak:training"
       ],
       "tier": 1,
-      "mod_time": "2025-08-13 22:01:46 +0000"
+      "mod_time": "2025-09-04 14:42:46 +0000"
     },
     "probes.lmrc.Anthropomorphisation": {
       "description": "Providing output that encourages anthropomorphisation of AI systems",
@@ -3357,7 +3357,7 @@
         "risk-cards:lmrc:anthropomorphisation"
       ],
       "tier": 3,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.lmrc.Bullying": {
       "description": "Generation of repeated threats, denigration",
@@ -3384,7 +3384,7 @@
         "payload:unwanted:violence"
       ],
       "tier": 2,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.lmrc.Deadnaming": {
       "description": "Mentioning a name that a person does not wish to be associated with",
@@ -3410,7 +3410,7 @@
         "avid-effect:performance:P0401"
       ],
       "tier": 2,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.lmrc.Profanity": {
       "description": "Using profane words, especially when not prompted to do so.",
@@ -3448,7 +3448,7 @@
         "payload:unwanted:profanity"
       ],
       "tier": 3,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.lmrc.QuackMedicine": {
       "description": "Promoting non-scientific medicine.",
@@ -3476,7 +3476,7 @@
         "payload:dangerous:medical"
       ],
       "tier": 2,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.lmrc.SexualContent": {
       "description": "Content that discusses bodies and interactions in a sexual manner, or other sexually explicit material",
@@ -3506,7 +3506,7 @@
         "payload:unwanted:sexual"
       ],
       "tier": 2,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.lmrc.Sexualisation": {
       "description": "Causal or overt sexual objectification, reducing a person or group of people to sexual objects.",
@@ -3538,7 +3538,7 @@
         "payload:unwanted:sexual"
       ],
       "tier": 2,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.lmrc.SlurUsage": {
       "description": "Using an identity-based slur in a non-reclaimed way - either directly or recommending the consumer to use in speech/action.",
@@ -3568,7 +3568,7 @@
         "payload:unwanted:hatespeech"
       ],
       "tier": 2,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.malwaregen.Evasion": {
       "description": "Will the model write code to help avoid anti-malware?",
@@ -3594,7 +3594,7 @@
         "quality:Behavioral:ContentSafety:LegalGoodsServices"
       ],
       "tier": 2,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.malwaregen.Payload": {
       "description": "Will the model help write code for malware payloads?",
@@ -3619,7 +3619,7 @@
         "quality:Behavioral:ContentSafety:LegalGoodsServices"
       ],
       "tier": 2,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.malwaregen.SubFunctions": {
       "description": "Will the system write code helpful in malware?",
@@ -3645,7 +3645,7 @@
         "quality:Behavioral:ContentSafety:LegalGoodsServices"
       ],
       "tier": 2,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.malwaregen.TopLevel": {
       "description": "Will the system return code when asked to write malware?",
@@ -3671,7 +3671,7 @@
         "quality:Behavioral:ContentSafety:LegalGoodsServices"
       ],
       "tier": 2,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.misleading.FalseAssertion": {
       "description": "Does the model reject [questions based on] false claims?",
@@ -3701,7 +3701,7 @@
         "payload:hallucination"
       ],
       "tier": 2,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.packagehallucination.Dart": {
       "description": "Attempts to generate Dart code including hallucinated pub.dev packages",
@@ -3728,7 +3728,7 @@
         "payload:malicious:badcode"
       ],
       "tier": 1,
-      "mod_time": "2025-09-23 20:19:35 +0000"
+      "mod_time": "2025-10-06 14:45:52 +0000"
     },
     "probes.packagehallucination.JavaScript": {
       "description": "Attempts to generate JavaScript code including hallucinated npm packages",
@@ -3755,34 +3755,7 @@
         "payload:malicious:badcode"
       ],
       "tier": 1,
-      "mod_time": "2025-09-23 20:19:35 +0000"
-    },
-    "probes.packagehallucination.PackageHallucinationProbe": {
-      "description": "Base class for package hallucination probes",
-      "DEFAULT_PARAMS": {},
-      "active": false,
-      "doc_uri": "https://vulcan.io/blog/ai-hallucinations-package-risk",
-      "extended_detectors": [],
-      "goal": "base probe for importing non-existent packages",
-      "lang": "*",
-      "modality": {
-        "in": [
-          "text"
-        ]
-      },
-      "parallelisable_attempts": true,
-      "primary_detector": null,
-      "recommended_detector": [
-        "always.Fail"
-      ],
-      "tags": [
-        "owasp:llm09",
-        "owasp:llm02",
-        "quality:Robustness:GenerativeMisinformation",
-        "payload:malicious:badcode"
-      ],
-      "tier": 9,
-      "mod_time": "2025-09-23 20:19:35 +0000"
+      "mod_time": "2025-10-06 14:45:52 +0000"
     },
     "probes.packagehallucination.Perl": {
       "description": "Attempts to generate Perl code including hallucinated MetaCPAN packages",
@@ -3809,7 +3782,7 @@
         "payload:malicious:badcode"
       ],
       "tier": 1,
-      "mod_time": "2025-09-23 20:19:35 +0000"
+      "mod_time": "2025-10-06 14:45:52 +0000"
     },
     "probes.packagehallucination.Python": {
       "description": "Attempts to generate Python3 code including hallucinated packages",
@@ -3836,7 +3809,7 @@
         "payload:malicious:badcode"
       ],
       "tier": 1,
-      "mod_time": "2025-09-23 20:19:35 +0000"
+      "mod_time": "2025-10-06 14:45:52 +0000"
     },
     "probes.packagehallucination.RakuLand": {
       "description": "Attempts to generate Raku code including hallucinated raku.land packages",
@@ -3863,7 +3836,7 @@
         "payload:malicious:badcode"
       ],
       "tier": 1,
-      "mod_time": "2025-09-23 20:19:35 +0000"
+      "mod_time": "2025-10-06 14:45:52 +0000"
     },
     "probes.packagehallucination.Ruby": {
       "description": "Attempts to generate Ruby code including hallucinated gems",
@@ -3890,7 +3863,7 @@
         "payload:malicious:badcode"
       ],
       "tier": 1,
-      "mod_time": "2025-09-23 20:19:35 +0000"
+      "mod_time": "2025-10-06 14:45:52 +0000"
     },
     "probes.packagehallucination.Rust": {
       "description": "Attempts to generate Rust code including hallucinated crates.io packages",
@@ -3917,7 +3890,7 @@
         "payload:malicious:badcode"
       ],
       "tier": 1,
-      "mod_time": "2025-09-23 20:19:35 +0000"
+      "mod_time": "2025-10-06 14:45:52 +0000"
     },
     "probes.phrasing.FutureTense": {
       "description": "Attempt to evade safeguards by setting requests in the future tense",
@@ -3943,7 +3916,7 @@
         "payload:jailbreak"
       ],
       "tier": 2,
-      "mod_time": "2025-09-29 12:09:21 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.phrasing.FutureTenseFull": {
       "description": "Will the system give unsafe responses when asked to write about weapon creation or dangerous behavior?",
@@ -3969,7 +3942,7 @@
         "payload:jailbreak"
       ],
       "tier": 2,
-      "mod_time": "2025-09-29 12:09:21 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.phrasing.PastTense": {
       "description": "Attempt to evade safeguards by setting requests in the past tense",
@@ -3995,7 +3968,7 @@
         "payload:jailbreak"
       ],
       "tier": 2,
-      "mod_time": "2025-09-29 12:09:21 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.phrasing.PastTenseFull": {
       "description": "Will the system give unsafe responses when asked to write about weapon creation or dangerous behavior?",
@@ -4021,7 +3994,7 @@
         "payload:jailbreak"
       ],
       "tier": 2,
-      "mod_time": "2025-09-29 12:09:21 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.promptinject.HijackHateHumans": {
       "description": "PromptInject is a framework that assembles prompts in a modular fashion to provide a quantitative analysis of the robustness of LLMs to adversarial prompt attacks. trophy Best Paper Awards @ NeurIPS ML Safety Workshop 2022",
@@ -4049,7 +4022,7 @@
         "payload:unwanted:violence"
       ],
       "tier": 2,
-      "mod_time": "2025-07-10 19:16:02 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.promptinject.HijackHateHumansFull": {
       "description": "PromptInject is a framework that assembles prompts in a modular fashion to provide a quantitative analysis of the robustness of LLMs to adversarial prompt attacks. trophy Best Paper Awards @ NeurIPS ML Safety Workshop 2022",
@@ -4077,7 +4050,7 @@
         "payload:unwanted:violence"
       ],
       "tier": 2,
-      "mod_time": "2025-07-10 19:16:02 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.promptinject.HijackKillHumans": {
       "description": "PromptInject is a framework that assembles prompts in a modular fashion to provide a quantitative analysis of the robustness of LLMs to adversarial prompt attacks. trophy Best Paper Awards @ NeurIPS ML Safety Workshop 2022",
@@ -4105,7 +4078,7 @@
         "payload:unwanted:violence"
       ],
       "tier": 2,
-      "mod_time": "2025-07-10 19:16:02 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.promptinject.HijackKillHumansFull": {
       "description": "PromptInject is a framework that assembles prompts in a modular fashion to provide a quantitative analysis of the robustness of LLMs to adversarial prompt attacks. trophy Best Paper Awards @ NeurIPS ML Safety Workshop 2022",
@@ -4133,7 +4106,7 @@
         "payload:unwanted:violence"
       ],
       "tier": 2,
-      "mod_time": "2025-07-10 19:16:02 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.promptinject.HijackLongPrompt": {
       "description": "PromptInject is a framework that assembles prompts in a modular fashion to provide a quantitative analysis of the robustness of LLMs to adversarial prompt attacks. trophy Best Paper Awards @ NeurIPS ML Safety Workshop 2022",
@@ -4161,7 +4134,7 @@
         "payload:unwanted:violence"
       ],
       "tier": 2,
-      "mod_time": "2025-07-10 19:16:02 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.promptinject.HijackLongPromptFull": {
       "description": "PromptInject is a framework that assembles prompts in a modular fashion to provide a quantitative analysis of the robustness of LLMs to adversarial prompt attacks. trophy Best Paper Awards @ NeurIPS ML Safety Workshop 2022",
@@ -4189,7 +4162,7 @@
         "payload:unwanted:violence"
       ],
       "tier": 2,
-      "mod_time": "2025-07-10 19:16:02 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.realtoxicityprompts.RTPBlank": {
       "description": "Implementation of probes in RealToxicityPrompts",
@@ -4217,7 +4190,7 @@
         "payload:unwanted"
       ],
       "tier": 1,
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.realtoxicityprompts.RTPFlirtation": {
       "description": "Implementation of flirtation probes in RealToxicityPrompts",
@@ -4246,7 +4219,7 @@
         "payload:unwanted"
       ],
       "tier": 3,
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.realtoxicityprompts.RTPIdentity_Attack": {
       "description": "Implementation of identity_attack probes in RealToxicityPrompts",
@@ -4277,7 +4250,7 @@
         "payload:hatespeech"
       ],
       "tier": 3,
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.realtoxicityprompts.RTPInsult": {
       "description": "Implementation of insult probes in RealToxicityPrompts",
@@ -4307,7 +4280,7 @@
         "payload:unwanted"
       ],
       "tier": 3,
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.realtoxicityprompts.RTPProfanity": {
       "description": "Implementation of profanity probes in RealToxicityPrompts",
@@ -4336,7 +4309,7 @@
         "payload:unwanted:profanity"
       ],
       "tier": 3,
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.realtoxicityprompts.RTPSevere_Toxicity": {
       "description": "Implementation of severe_toxicity probes in RealToxicityPrompts",
@@ -4364,7 +4337,7 @@
         "payload:unwanted"
       ],
       "tier": 3,
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.realtoxicityprompts.RTPSexually_Explicit": {
       "description": "Implementation of sexually_explicit probes in RealToxicityPrompts",
@@ -4392,7 +4365,7 @@
         "payload:unwanted:sexual"
       ],
       "tier": 3,
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.realtoxicityprompts.RTPThreat": {
       "description": "Implementation of threat probes in RealToxicityPrompts",
@@ -4422,7 +4395,7 @@
         "payload:unwanted:violence"
       ],
       "tier": 3,
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.sata.MLM": {
       "description": "Masked Language Model Simple Assistive Task Probe",
@@ -4455,7 +4428,7 @@
         "payload:jailbreak"
       ],
       "tier": 2,
-      "mod_time": "2025-08-06 16:58:50 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.smuggling.FunctionMasking": {
       "description": "FunctionMasking probe",
@@ -4481,7 +4454,7 @@
         "payload:jailbreak"
       ],
       "tier": 3,
-      "mod_time": "2025-09-30 21:51:47 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.smuggling.HypotheticalResponse": {
       "description": "HypotheticalResponse probe",
@@ -4507,7 +4480,7 @@
         "payload:jailbreak"
       ],
       "tier": 3,
-      "mod_time": "2025-09-30 21:51:47 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.snowball.GraphConnectivity": {
       "description": "Probe asking for impossible flight routings",
@@ -4534,7 +4507,7 @@
         "payload:hallucination"
       ],
       "tier": 2,
-      "mod_time": "2025-05-16 07:39:54 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.snowball.GraphConnectivityFull": {
       "description": "Probe asking for impossible flight routings",
@@ -4561,7 +4534,7 @@
         "payload:hallucination"
       ],
       "tier": 2,
-      "mod_time": "2025-05-16 07:39:54 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.snowball.Primes": {
       "description": "Ask model to check a list of higher primes",
@@ -4588,7 +4561,7 @@
         "payload:hallucination"
       ],
       "tier": 3,
-      "mod_time": "2025-05-16 07:39:54 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.snowball.PrimesFull": {
       "description": "Ask model to check a list of higher primes",
@@ -4615,7 +4588,7 @@
         "payload:hallucination"
       ],
       "tier": 3,
-      "mod_time": "2025-05-16 07:39:54 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.snowball.Senators": {
       "description": "Asking for senators that don't exist",
@@ -4642,7 +4615,7 @@
         "payload:hallucination"
       ],
       "tier": 3,
-      "mod_time": "2025-05-16 07:39:54 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.snowball.SenatorsFull": {
       "description": "Asking for senators that don't exist",
@@ -4669,7 +4642,7 @@
         "payload:hallucination"
       ],
       "tier": 3,
-      "mod_time": "2025-05-16 07:39:54 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.suffix.BEAST": {
       "description": "BEAST probe",
@@ -4696,7 +4669,7 @@
         "payload:jailbreak"
       ],
       "tier": 2,
-      "mod_time": "2025-08-04 16:35:47 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.suffix.GCG": {
       "description": "Greedy Coordinate Gradient probe",
@@ -4723,7 +4696,7 @@
         "payload:jailbreak"
       ],
       "tier": 2,
-      "mod_time": "2025-08-04 16:35:47 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.suffix.GCGCached": {
       "description": "Greedy Coordinate Gradient Cached probe",
@@ -4750,7 +4723,7 @@
         "payload:jailbreak"
       ],
       "tier": 2,
-      "mod_time": "2025-08-04 16:35:47 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.tap.PAIR": {
       "description": "Prompt Automatic Iterative Refinement automatic jailbreak",
@@ -4801,7 +4774,7 @@
         "payload:jailbreak"
       ],
       "tier": 2,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.tap.TAP": {
       "description": "Tree of Attacks with Pruning Probe, generating new attacks against the target",
@@ -4852,7 +4825,7 @@
         "payload:jailbreak"
       ],
       "tier": 2,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.tap.TAPCached": {
       "description": "Tree of Attacks with Pruning Probe using cached attacks",
@@ -4881,7 +4854,7 @@
         "payload:jailbreak"
       ],
       "tier": 2,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.test.Blank": {
       "description": "Blank prompt",
@@ -4903,7 +4876,7 @@
       ],
       "tags": [],
       "tier": 9,
-      "mod_time": "2025-05-09 12:45:38 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.test.Test": {
       "description": "Test probe",
@@ -4925,7 +4898,7 @@
       ],
       "tags": [],
       "tier": 9,
-      "mod_time": "2025-05-09 12:45:38 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.topic.WordnetAllowedWords": {
       "description": "Use Wordnet to find out if a model will discuss terms near but not in its allowed set",
@@ -4961,7 +4934,7 @@
         "quality:Security:Confidentiality"
       ],
       "tier": 9,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.topic.WordnetBlockedWords": {
       "description": "Use Wordnet to explore which topics a model will respond to around blocked words",
@@ -4997,7 +4970,7 @@
         "quality:Security:Confidentiality"
       ],
       "tier": 9,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.topic.WordnetControversial": {
       "description": "Ask model to respond on a set on controversial topics.",
@@ -5040,7 +5013,7 @@
         "quality:Security:Confidentiality"
       ],
       "tier": 2,
-      "mod_time": "2025-05-20 09:39:47 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.visual_jailbreak.FigStep": {
       "description": "Using image modality to assist jailbreak.",
@@ -5067,7 +5040,7 @@
         "payload:jailbreak"
       ],
       "tier": 2,
-      "mod_time": "2025-07-02 22:27:38 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.visual_jailbreak.FigStepFull": {
       "description": "Using image modality to assist jailbreak.",
@@ -5094,7 +5067,7 @@
         "payload:jailbreak"
       ],
       "tier": 2,
-      "mod_time": "2025-07-02 22:27:38 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "probes.web_injection.ColabAIDataLeakage": {
       "description": "Leak data via image rendering as demonstrated against Gemini in Colab.",
@@ -5128,7 +5101,7 @@
         "cwe:352"
       ],
       "tier": 1,
-      "mod_time": "2025-09-30 21:00:42 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.web_injection.MarkdownImageExfil": {
       "description": "Can we get the model to write embedded assets exfiltrating text in the URI?",
@@ -5163,7 +5136,7 @@
         "cwe:352"
       ],
       "tier": 1,
-      "mod_time": "2025-09-30 21:00:42 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.web_injection.MarkdownURIImageExfilExtended": {
       "description": "Generalized implementation of data exfiltration exploits through Markdown URIs.",
@@ -5195,7 +5168,7 @@
         "cwe:352"
       ],
       "tier": 1,
-      "mod_time": "2025-09-30 21:00:42 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.web_injection.MarkdownURINonImageExfilExtended": {
       "description": "Generalized implementation of data exfiltration exploits through Markdown URIs.",
@@ -5227,7 +5200,7 @@
         "cwe:352"
       ],
       "tier": 1,
-      "mod_time": "2025-09-30 21:00:42 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.web_injection.MarkdownXSS": {
       "description": "Perform cross site scripting attacks using Markdown Javascript rendering via prompt injection.",
@@ -5262,7 +5235,7 @@
         "cwe:79"
       ],
       "tier": 1,
-      "mod_time": "2025-09-30 21:00:42 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.web_injection.PlaygroundMarkdownExfil": {
       "description": "Markdown image URI exfil exploit published 2023 Sept 29.",
@@ -5296,7 +5269,7 @@
         "cwe:352"
       ],
       "tier": 1,
-      "mod_time": "2025-09-30 21:00:42 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.web_injection.StringAssemblyDataExfil": {
       "description": "Prompt injection for manipulating state",
@@ -5328,7 +5301,7 @@
         "cwe:352"
       ],
       "tier": 1,
-      "mod_time": "2025-09-30 21:00:42 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "probes.web_injection.TaskXSS": {
       "description": "Perform cross site scripting attacks via prompt injection.",
@@ -5366,7 +5339,7 @@
         "cwe:79"
       ],
       "tier": 1,
-      "mod_time": "2025-09-30 21:00:42 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     }
   },
   "detectors": {
@@ -5387,7 +5360,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-07-02 06:55:12 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.always.Pass": {
       "description": "Always Pass (for testing & prototyping)",
@@ -5406,7 +5379,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-07-02 06:55:12 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.always.Passthru": {
       "description": "Send existing attempt detection results; use first detector",
@@ -5425,7 +5398,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-07-02 06:55:12 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.always.Random": {
       "description": "Always return a random result (for testing & prototyping)",
@@ -5444,7 +5417,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-07-02 06:55:12 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.ansiescape.Escaped": {
       "description": "pick up escaped ANSI escape sequences",
@@ -5464,7 +5437,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-09-16 15:38:35 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.ansiescape.Raw": {
       "description": "pick up raw ANSI escape sequences",
@@ -5484,7 +5457,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-09-16 15:38:35 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.base.Detector": {
       "description": "Base class for objects that define a way of detecting a probe hit / LLM failure",
@@ -5503,7 +5476,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-09-02 21:22:52 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.base.FileDetector": {
       "description": "Detector subclass for processing attempts whose outputs are filenames for checking",
@@ -5523,7 +5496,7 @@
       "recall": 0.0,
       "tags": [],
       "valid_format": "local filename",
-      "mod_time": "2025-09-02 21:22:52 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.base.HFDetector": {
       "description": "Detector using a Hugging Face model",
@@ -5550,7 +5523,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-09-02 21:22:52 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.base.StringDetector": {
       "description": "Subclass of Detector using list of substrings as detection triggers",
@@ -5570,7 +5543,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-09-02 21:22:52 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.base.TriggerListDetector": {
       "description": "Subclass of Detector using attempt's notes[triggers] as list of strings to match",
@@ -5589,7 +5562,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-09-02 21:22:52 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.continuation.Continuation": {
       "description": "Detect if model intiates / continues a trigger word",
@@ -5608,7 +5581,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-08-13 22:01:46 +0000"
+      "mod_time": "2025-09-04 17:19:14 +0000"
     },
     "detectors.dan.AntiDAN": {
       "description": "Do we get an ANTI-DAN positive?",
@@ -5630,7 +5603,7 @@
       "tags": [
         "avid-effect:security:S0403"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "detectors.dan.DAN": {
       "description": "Do we get a [DAN] positive?",
@@ -5652,7 +5625,7 @@
       "tags": [
         "avid-effect:security:S0403"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "detectors.dan.DANJailbreak": {
       "description": "Do we get a [\ud83d\udd13JAILBREAK] positive?",
@@ -5674,7 +5647,7 @@
       "tags": [
         "avid-effect:security:S0403"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "detectors.dan.DUDE": {
       "description": "Do we get a DUDE positive?",
@@ -5696,7 +5669,7 @@
       "tags": [
         "avid-effect:security:S0403"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "detectors.dan.DevMode": {
       "description": "Do we get a dev mode v2 positive?",
@@ -5718,7 +5691,7 @@
       "tags": [
         "avid-effect:security:S0403"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "detectors.dan.MarkdownLink": {
       "description": "Look for markdown links",
@@ -5740,7 +5713,7 @@
       "tags": [
         "avid-effect:security:S0403"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "detectors.dan.STAN": {
       "description": "Do we get a STAN positive?",
@@ -5762,7 +5735,7 @@
       "tags": [
         "avid-effect:security:S0403"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-10-06 13:47:22 +0000"
     },
     "detectors.divergence.RepeatDiverges": {
       "description": "Subclass of Detector using attempt's notes[triggers] as list of strings to match",
@@ -5781,7 +5754,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-09-16 18:15:13 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.divergence.RepeatedToken": {
       "description": "Garak-compatible detector for repeated token hallucinations.",
@@ -5805,7 +5778,7 @@
         "quality:Security:PromptStability",
         "payload:unwanted:denial_of_service"
       ],
-      "mod_time": "2025-09-16 18:15:13 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.encoding.DecodeApprox": {
       "description": "Is there a partial hash decoding?",
@@ -5825,7 +5798,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-04-18 22:06:15 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.encoding.DecodeMatch": {
       "description": "Is there a direct decoding of anything in attempt[\"notes\"][\"triggers\"]?",
@@ -5845,7 +5818,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-04-18 22:06:15 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.exploitation.JinjaTemplateDetector": {
       "description": "Detect that a valid jinja template was provided.",
@@ -5877,7 +5850,7 @@
         "cwe:1426",
         "cwe:1427"
       ],
-      "mod_time": "2025-08-08 14:23:52 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.exploitation.PythonCodeExecution": {
       "description": "Detect the presence of python that will execute commands on the system.",
@@ -5908,7 +5881,7 @@
         "cwe:1426",
         "cwe:1427"
       ],
-      "mod_time": "2025-08-08 14:23:52 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.exploitation.SQLiEcho": {
       "description": "Detect if the system echoes the provided SQL injection.",
@@ -5937,7 +5910,7 @@
         "cwe:1426",
         "cwe:1427"
       ],
-      "mod_time": "2025-08-08 14:23:52 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.exploitation.SQLiSuccess": {
       "description": "Detect if the system returns a \"SUCCESS\" message.",
@@ -5967,7 +5940,7 @@
         "cwe:1426",
         "cwe:1427"
       ],
-      "mod_time": "2025-08-08 14:23:52 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.fileformats.FileIsExecutable": {
       "description": "Magic check if file is portable or linear executable (exe/dll/vxd/..)",
@@ -5987,7 +5960,7 @@
       "recall": 0.0,
       "tags": [],
       "valid_format": "local filename",
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.fileformats.FileIsPickled": {
       "description": "Check whether a file is pickled.",
@@ -6007,7 +5980,7 @@
       "recall": 0.0,
       "tags": [],
       "valid_format": "local filename",
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.fileformats.PossiblePickleName": {
       "description": "Guess if filenames look like pickles",
@@ -6027,7 +6000,7 @@
       "recall": 0.0,
       "tags": [],
       "valid_format": null,
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.goodside.Glitch": {
       "description": "Inverse trigger list detector - hit if trigger absent",
@@ -6046,7 +6019,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-07-02 06:55:12 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.goodside.PlainJSON": {
       "description": "Is the output valid JSON with no preamble?",
@@ -6065,7 +6038,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-07-02 06:55:12 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.goodside.RileyIsnt": {
       "description": "Look for mentions of being Canadian, female pronouns, being a singer",
@@ -6085,7 +6058,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-07-02 06:55:12 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.judge.ModelAsJudge": {
       "description": "Uses the configured model to detect responses that attained the probe goal",
@@ -6109,7 +6082,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-09-02 21:22:52 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.judge.Refusal": {
       "description": "Uses the configured model to detect if the responses is a refusal to answer",
@@ -6131,7 +6104,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-09-02 21:22:52 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.knownbadsignatures.EICAR": {
       "description": "Is the EICAR test string present?",
@@ -6153,7 +6126,7 @@
       "tags": [
         "avid-effect:security:S0301"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.knownbadsignatures.GTUBE": {
       "description": "Is the GTUBE test string present?",
@@ -6175,7 +6148,7 @@
       "tags": [
         "avid-effect:security:S0301"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.knownbadsignatures.GTphish": {
       "description": "Is the GTphish test string present?",
@@ -6197,7 +6170,7 @@
       "tags": [
         "avid-effect:security:S0301"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.leakreplay.StartsWith": {
       "description": "Subclass of Detector using attempt's notes[triggers] as list of strings to match",
@@ -6216,7 +6189,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-06-12 16:14:56 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.lmrc.Anthro": {
       "description": "Looking for first person pronoun uses",
@@ -6238,7 +6211,7 @@
       "tags": [
         "risk-cards:lmrc:anthropomorphisation"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.lmrc.QuackMedicine": {
       "description": "Keywords related to Quack Medicine detector",
@@ -6261,7 +6234,7 @@
         "risk-cards:lmrc:quack_medicine",
         "avid-effect:ethics:E0402"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.malwaregen.AnyCode": {
       "description": "Detects programming languages",
@@ -6280,7 +6253,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-08-25 19:24:36 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.misleading.MustContradictNLI": {
       "description": "This detector is looking for the model to contradict a claim.",
@@ -6309,7 +6282,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-08-20 13:55:46 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.misleading.MustRefuteClaimKW": {
       "description": "Looking for strings indicating a refutation",
@@ -6329,7 +6302,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-08-20 13:55:46 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.misleading.MustRefuteClaimModel": {
       "description": "Using garak-llm/refutation_detector_distilbert to detect model refutations",
@@ -6358,7 +6331,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-08-20 13:55:46 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.mitigation.MitigationBypass": {
       "description": "Detect if a string response does not contain a mitigation message.",
@@ -6381,7 +6354,7 @@
         "avid-effect:security:S0403",
         "avid-effect:performance:P0204"
       ],
-      "mod_time": "2025-07-02 06:55:12 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.mitigation.Prefixes": {
       "description": "Detect failure prefixes",
@@ -6401,7 +6374,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-07-02 06:55:12 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.packagehallucination.Dart": {
       "description": "Check if the output tries to use a Dart package not listed on pub.dev (2025-08-11 snapshot)",
@@ -6423,7 +6396,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-09-24 16:40:21 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.packagehallucination.JavaScriptNpm": {
       "description": "Check if the output tries to import or require an npm package not listed in the npm registry",
@@ -6445,7 +6418,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-09-24 16:40:21 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.packagehallucination.PackageHallucinationDetector": {
       "description": "Base class for package hallucination detectors",
@@ -6467,7 +6440,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-09-24 16:40:21 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.packagehallucination.Perl": {
       "description": "Check if the output tries to use a Perl module not listed in MetaCPAN's provides list collected on 2025-08-11",
@@ -6489,7 +6462,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-09-24 16:40:21 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.packagehallucination.PythonPypi": {
       "description": "Check if the output tries to import a package not listed in stdlib or a pypi archive listing",
@@ -6511,7 +6484,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-09-24 16:40:21 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.packagehallucination.RakuLand": {
       "description": "Check if the output tries to use a Raku module not listed in raku.land collected on 2025-08-11",
@@ -6533,7 +6506,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-09-24 16:40:21 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.packagehallucination.RubyGems": {
       "description": "Check if the output tries to require a gem not listed in the Ruby standard library or RubyGems",
@@ -6555,7 +6528,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-09-24 16:40:21 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.packagehallucination.RustCrates": {
       "description": "Check if the output tries to use a Rust crate not listed in the crates.io registry",
@@ -6577,7 +6550,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-09-24 16:40:21 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.perspective.Attack_On_Author": {
       "description": "Targets: Attack on the author of an article or post.",
@@ -6599,7 +6572,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.perspective.Attack_On_Commenter": {
       "description": "Targets: Attack on fellow commenter.",
@@ -6621,7 +6594,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.perspective.Flirtation": {
       "description": "Targets: Pickup lines, complimenting appearance, subtle sexual innuendos, etc.",
@@ -6644,7 +6617,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.perspective.Identity_Attack": {
       "description": "Targets: Negative or hateful comments targeting someone because of their identity.",
@@ -6668,7 +6641,7 @@
         "avid-effect:ethics:E0302",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.perspective.Identity_Attack_Experimental": {
       "description": "Targets: Negative or hateful comments targeting someone because of their identity.",
@@ -6692,7 +6665,7 @@
         "avid-effect:ethics:E0302",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.perspective.Incoherent": {
       "description": "Targets: Difficult to understand, nonsensical.",
@@ -6713,7 +6686,7 @@
       "tags": [
         "avid-effect:performance:P0204"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.perspective.Inflammatory": {
       "description": "Targets: Intending to provoke or inflame.",
@@ -6736,7 +6709,7 @@
         "avid-effect:ethics:E0302",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.perspective.Insult": {
       "description": "Targets: Insulting, inflammatory, or negative comment towards a person or a group of people.",
@@ -6759,7 +6732,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.perspective.Insult_Experimental": {
       "description": "Targets: Insulting, inflammatory, or negative comment towards a person or a group of people.",
@@ -6781,7 +6754,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.perspective.Likely_To_Reject": {
       "description": "Targets: Overall measure of the likelihood for the comment to be rejected according to the NYT's moderation.",
@@ -6800,7 +6773,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.perspective.Obscene": {
       "description": "Targets: Obscene or vulgar language such as cursing.",
@@ -6822,7 +6795,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.perspective.Profanity": {
       "description": "Targets: Swear words, curse words, or other obscene or profane language.",
@@ -6844,7 +6817,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.perspective.Profanity_Experimental": {
       "description": "Targets: Swear words, curse words, or other obscene or profane language.",
@@ -6866,7 +6839,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.perspective.Severe_Toxicity": {
       "description": "Targets: A very hateful, aggressive, disrespectful comment or otherwise very likely to make a user leave a discussion or give up on sharing their perspective. This attribute is much less sensitive to more mild forms of toxicity, such as comments that include positive uses of curse words.",
@@ -6887,7 +6860,7 @@
       "tags": [
         "avid-effect:ethics:E0301"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.perspective.Severe_Toxicity_Experimental": {
       "description": "Targets: A very hateful, aggressive, disrespectful comment or otherwise very likely to make a user leave a discussion or give up on sharing their perspective. This attribute is much less sensitive to more mild forms of toxicity, such as comments that include positive uses of curse words.",
@@ -6910,7 +6883,7 @@
         "avid-effect:ethics:E0302",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.perspective.Sexually_Explicit": {
       "description": "Targets: Contains references to sexual acts, body parts, or other lewd content.",
@@ -6931,7 +6904,7 @@
       "tags": [
         "avid-effect:ethics:E0301"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.perspective.Spam": {
       "description": "Targets: Irrelevant and unsolicited commercial content.",
@@ -6952,7 +6925,7 @@
       "tags": [
         "avid-effect:performance:P0204"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.perspective.Threat": {
       "description": "Targets: Describes an intention to inflict pain, injury, or violence against an individual or group.",
@@ -6975,7 +6948,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0400"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.perspective.Threat_Experimental": {
       "description": "Targets: Describes an intention to inflict pain, injury, or violence against an individual or group.",
@@ -6997,7 +6970,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.perspective.Toxicity": {
       "description": "Targets: A rude, disrespectful, or unreasonable comment that is likely to make people leave a discussion.",
@@ -7018,7 +6991,7 @@
       "tags": [
         "avid-effect:ethics:E0301"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.perspective.Toxicity_Experimental": {
       "description": "Targets: A rude, disrespectful, or unreasonable comment that is likely to make people leave a discussion.",
@@ -7040,7 +7013,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.perspective.Unsubstantial": {
       "description": "Targets: Trivial or short comments",
@@ -7061,7 +7034,7 @@
       "tags": [
         "avid-effect:performance:P0204"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.productkey.Win5x5": {
       "description": "Do we see a product key in the form of five groups of five characters?",
@@ -7080,7 +7053,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-06-12 16:14:56 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.promptinject.AttackRogueString": {
       "description": "Detect if model emits trigger string",
@@ -7099,7 +7072,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-08-08 14:23:52 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.shields.Down": {
       "description": "Checks for strings commonly returned by a security system when guardrails are",
@@ -7126,7 +7099,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-07-02 06:55:12 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.shields.Up": {
       "description": "Checks for strings commonly returned when a security system is",
@@ -7156,7 +7129,7 @@
       "precision": 0.0,
       "recall": 0.0,
       "tags": [],
-      "mod_time": "2025-07-02 06:55:12 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.snowball.DontStartNo": {
       "description": "Response should start no, or contain a negation, to pass",
@@ -7177,7 +7150,7 @@
       "tags": [
         "avid:performance:P0204"
       ],
-      "mod_time": "2025-06-12 16:14:56 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.snowball.DontStartYes": {
       "description": "Response should start yes, or contain an affirmation, to pass",
@@ -7198,7 +7171,7 @@
       "tags": [
         "avid:performance:P0204"
       ],
-      "mod_time": "2025-06-12 16:14:56 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.unsafe_content.LDNOOBW": {
       "description": "List of Dirty, Naughty, Obscene, and Otherwise Bad Words (English)",
@@ -7222,7 +7195,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.unsafe_content.Martin_haDistilbert": {
       "description": "Using backup of martin-ha/toxic-comment-model DistilBERT to detect toxic content",
@@ -7253,7 +7226,7 @@
       "tags": [
         "avid-effect:ethics:E0301"
       ],
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.unsafe_content.OfcomOffensiveDiscriminatory": {
       "description": "UK OFCOM potentially offensive list: discriminatory",
@@ -7277,7 +7250,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.unsafe_content.OfcomOffensiveGeneral": {
       "description": "UK OFCOM potentially offensive list: general",
@@ -7300,7 +7273,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.unsafe_content.OfcomOffensiveMentalHealth": {
       "description": "UK OFCOM potentially offensive list: mental health",
@@ -7324,7 +7297,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.unsafe_content.OfcomOffensiveRaceEthnic": {
       "description": "UK OFCOM potentially offensive list: race / ethnic",
@@ -7348,7 +7321,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.unsafe_content.OfcomOffensiveSexGender": {
       "description": "UK OFCOM potentially offensive list: sex & gender",
@@ -7372,7 +7345,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.unsafe_content.OfcomOffensiveSexual": {
       "description": "UK OFCOM potentially offensive list: sexual",
@@ -7394,7 +7367,7 @@
       "tags": [
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.unsafe_content.S_nlpDetox": {
       "description": "Using s-nlp Roberta model to detect toxic content",
@@ -7425,7 +7398,7 @@
       "tags": [
         "avid-effect:ethics:E0301"
       ],
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.unsafe_content.SlursReclaimedSlurs": {
       "description": "Slurs and reclaimed slurs. Detects presence of any of the items from an ethnic slur list, regardless of context.",
@@ -7450,7 +7423,7 @@
         "avid-effect:ethics:E0302",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.unsafe_content.SurgeProfanityAnimalReferences": {
       "description": "Surge AI list: animal references",
@@ -7473,7 +7446,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.unsafe_content.SurgeProfanityBodilyFluids": {
       "description": "Surge AI list: bodily fluids / excrement",
@@ -7495,7 +7468,7 @@
       "tags": [
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.unsafe_content.SurgeProfanityMentalDisability": {
       "description": "Surge AI list: mental disability",
@@ -7519,7 +7492,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.unsafe_content.SurgeProfanityPhysicalAttributes": {
       "description": "Surge AI list: physical attributes",
@@ -7542,7 +7515,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.unsafe_content.SurgeProfanityPhysicalDisability": {
       "description": "Surge AI list: physical disability",
@@ -7566,7 +7539,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.unsafe_content.SurgeProfanityPolitical": {
       "description": "Surge AI list: political",
@@ -7591,7 +7564,7 @@
         "avid-effect:ethics:E0302",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.unsafe_content.SurgeProfanityRacialEthnic": {
       "description": "Surge AI list: racial / ethnic",
@@ -7615,7 +7588,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.unsafe_content.SurgeProfanityReligious": {
       "description": "Surge AI list: religious offense",
@@ -7638,7 +7611,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.unsafe_content.SurgeProfanitySexual": {
       "description": "Surge AI list: sexual anatomy / sexual acts",
@@ -7660,7 +7633,7 @@
       "tags": [
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.unsafe_content.SurgeProfanitySexualOrientationGender": {
       "description": "Surge AI list: sexual orientation / gender",
@@ -7684,7 +7657,7 @@
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401"
       ],
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.unsafe_content.ToxicCommentModel": {
       "description": "Garak's default toxicity detector",
@@ -7715,7 +7688,7 @@
       "tags": [
         "avid-effect:ethics:E0301"
       ],
-      "mod_time": "2025-07-16 13:33:05 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.visual_jailbreak.FigStep": {
       "description": "Looks for specific strings in the output - these should be strings inserted by image",
@@ -7737,7 +7710,7 @@
       "tags": [
         "avid-effect:security:S0403"
       ],
-      "mod_time": "2025-04-17 08:31:20 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "detectors.web_injection.MarkdownExfilBasic": {
       "description": "Detect markdown images with fqdn, absolute path, and populated q= parameter",
@@ -7758,7 +7731,7 @@
       "tags": [
         "avid-effect:security:S0301"
       ],
-      "mod_time": "2025-09-08 15:03:44 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.web_injection.MarkdownExfilContent": {
       "description": "As the basic detector, MarkdownExfilBasic, but did we exfiltrate anything?",
@@ -7779,7 +7752,7 @@
       "tags": [
         "avid-effect:security:S0301"
       ],
-      "mod_time": "2025-09-08 15:03:44 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.web_injection.MarkdownExfilExtendedImage": {
       "description": "Extended version of MarkdownExfilBasic that searches for a larger variety of Markdown URI formats",
@@ -7800,7 +7773,7 @@
       "tags": [
         "avid-effect:security:S0301"
       ],
-      "mod_time": "2025-09-08 15:03:44 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.web_injection.MarkdownExfilExtendedNonImage": {
       "description": "Extended version of MarkdownExfilBasic that searches for a larger variety of Markdown URI formats",
@@ -7821,7 +7794,7 @@
       "tags": [
         "avid-effect:security:S0301"
       ],
-      "mod_time": "2025-09-08 15:03:44 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.web_injection.PlaygroundMarkdownExfil": {
       "description": "As the basic detector, MarkdownExfilBasic, searching specifically for PlaygroundMarkdownExfil",
@@ -7842,7 +7815,7 @@
       "tags": [
         "avid-effect:security:S0301"
       ],
-      "mod_time": "2025-09-08 15:03:44 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "detectors.web_injection.XSS": {
       "description": "Look for cross site scripting (XSS) attempts by payload.",
@@ -7864,7 +7837,7 @@
       "tags": [
         "cwe:79"
       ],
-      "mod_time": "2025-09-08 15:03:44 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     }
   },
   "generators": {
@@ -7903,7 +7876,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": true,
-      "mod_time": "2025-09-25 15:10:32 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.base.Generator": {
       "description": "Base class for objects that wrap an LLM or other text-to-text service",
@@ -7927,7 +7900,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-08-26 14:02:31 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.cohere.CohereGenerator": {
       "description": "Interface to Cohere's python library for their text2text model.",
@@ -7958,7 +7931,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-08-26 14:02:31 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.function.Multiple": {
       "description": "Pass a function to call as a generator.",
@@ -7977,7 +7950,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": true,
-      "mod_time": "2025-09-25 15:10:32 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.function.Single": {
       "description": "Pass a function to call as a generator.",
@@ -7996,7 +7969,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-09-25 15:10:32 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.ggml.GgmlGenerator": {
       "description": "Generator interface for ggml models in gguf format.",
@@ -8031,7 +8004,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-09-25 15:10:32 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.groq.GroqChat": {
       "description": "Wrapper for Groq-hosted LLM models.",
@@ -8076,7 +8049,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-09-25 15:10:32 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.guardrails.NeMoGuardrails": {
       "description": "Generator wrapper for NeMo Guardrails.",
@@ -8100,7 +8073,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-09-25 15:10:32 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.huggingface.InferenceAPI": {
       "description": "Get text generations from Hugging Face Inference API",
@@ -8127,7 +8100,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": true,
-      "mod_time": "2025-09-25 15:13:06 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.huggingface.InferenceEndpoint": {
       "description": "Interface for Hugging Face private endpoints",
@@ -8154,7 +8127,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-09-25 15:13:06 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.huggingface.LLaVA": {
       "description": "Get LLaVA ([ text + image ] -> text) generations",
@@ -8184,7 +8157,7 @@
       },
       "parallel_capable": false,
       "supports_multiple_generations": false,
-      "mod_time": "2025-09-25 15:13:06 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.huggingface.Model": {
       "description": "Get text generations from a locally-run Hugging Face model",
@@ -8213,7 +8186,7 @@
       },
       "parallel_capable": false,
       "supports_multiple_generations": true,
-      "mod_time": "2025-09-25 15:13:06 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.huggingface.OptimumPipeline": {
       "description": "Get text generations from a locally-run Hugging Face pipeline using NVIDIA Optimum",
@@ -8242,7 +8215,7 @@
       },
       "parallel_capable": false,
       "supports_multiple_generations": true,
-      "mod_time": "2025-09-25 15:13:06 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.huggingface.Pipeline": {
       "description": "Get text generations from a locally-run Hugging Face pipeline",
@@ -8271,7 +8244,7 @@
       },
       "parallel_capable": false,
       "supports_multiple_generations": true,
-      "mod_time": "2025-09-25 15:13:06 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.langchain.LangChainLLMGenerator": {
       "description": "Class supporting LangChain LLM interfaces",
@@ -8301,7 +8274,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-09-25 15:10:32 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.langchain_serve.LangChainServeLLMGenerator": {
       "description": "Class supporting LangChain Serve LLM interfaces via HTTP POST requests.",
@@ -8326,7 +8299,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-06-17 16:15:39 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "generators.litellm.LiteLLMGenerator": {
       "description": "Generator wrapper using LiteLLM to allow access to different providers using the OpenAI API format.",
@@ -8357,7 +8330,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": true,
-      "mod_time": "2025-09-25 15:10:32 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.mistral.MistralGenerator": {
       "description": "Interface for public endpoints of models hosted in Mistral La Plateforme (console.mistral.ai).",
@@ -8382,7 +8355,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-08-26 14:02:31 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.nemo.NeMoGenerator": {
       "description": "Wrapper for the NVIDIA NeMo models via NGC. Expects NGC_API_KEY and ORG_ID environment variables.",
@@ -8413,7 +8386,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-06-17 16:15:39 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "generators.nim.NVMultimodal": {
       "description": "Wrapper for text and image / audio to text NVIDIA NIM microservices hosted on build.nvidia.com and self-hosted.",
@@ -8459,7 +8432,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-09-25 15:10:32 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.nim.NVOpenAIChat": {
       "description": "Wrapper for NVIDIA NIM microservices hosted on build.nvidia.com and self-hosted.",
@@ -8502,7 +8475,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-09-25 15:10:32 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.nim.NVOpenAICompletion": {
       "description": "Wrapper for NVIDIA NIM microservices hosted on build.nvidia.com and self-hosted.",
@@ -8545,7 +8518,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-09-25 15:10:32 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.nim.Vision": {
       "description": "Wrapper for text and image to text NVIDIA NIM microservices hosted on build.nvidia.com and self-hosted.",
@@ -8590,7 +8563,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-09-25 15:10:32 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.nvcf.NvcfChat": {
       "description": "Wrapper for NVIDIA Cloud Functions Chat models via NGC. Expects NVCF_API_KEY environment variable.",
@@ -8623,7 +8596,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-09-25 15:13:06 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.nvcf.NvcfCompletion": {
       "description": "Wrapper for NVIDIA Cloud Functions Completion models via NGC. Expects NVCF_API_KEY environment variables.",
@@ -8656,7 +8629,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-09-25 15:13:06 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.ollama.OllamaGenerator": {
       "description": "Interface for Ollama endpoints",
@@ -8682,7 +8655,7 @@
       },
       "parallel_capable": false,
       "supports_multiple_generations": false,
-      "mod_time": "2025-08-26 14:02:31 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.ollama.OllamaGeneratorChat": {
       "description": "Interface for Ollama endpoints, using the chat functionality",
@@ -8708,7 +8681,7 @@
       },
       "parallel_capable": false,
       "supports_multiple_generations": false,
-      "mod_time": "2025-08-26 14:02:31 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.openai.OpenAICompatible": {
       "description": "Generator base class for OpenAI compatible text2text restful API. Implements shared initialization and execution methods.",
@@ -8744,7 +8717,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": true,
-      "mod_time": "2025-09-25 15:10:32 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.openai.OpenAIGenerator": {
       "description": "Generator wrapper for OpenAI text2text models. Expects API key in the OPENAI_API_KEY environment variable",
@@ -8779,7 +8752,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": true,
-      "mod_time": "2025-09-25 15:10:32 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.openai.OpenAIReasoningGenerator": {
       "description": "Generator wrapper for OpenAI reasoning models, e.g. `o1` family.",
@@ -8819,7 +8792,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-09-25 15:10:32 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.rasa.RasaRestGenerator": {
       "description": "API interface for RASA models",
@@ -8858,7 +8831,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-09-25 15:10:32 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.replicate.InferenceEndpoint": {
       "description": "Interface for private Replicate endpoints.",
@@ -8884,7 +8857,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-06-17 16:15:39 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "generators.replicate.ReplicateGenerator": {
       "description": "Interface for public endpoints of models hosted in Replicate (replicate.com).",
@@ -8910,7 +8883,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-06-17 16:15:39 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "generators.rest.RestGenerator": {
       "description": "Generic API interface for REST models",
@@ -8946,7 +8919,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-09-25 15:10:32 +0000"
+      "mod_time": "2025-10-06 13:47:44 +0000"
     },
     "generators.test.Blank": {
       "description": "This generator always returns the empty string.",
@@ -8970,7 +8943,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": true,
-      "mod_time": "2025-06-18 19:31:49 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "generators.test.BlankVision": {
       "description": "This text+image input generator always returns the empty string.",
@@ -8995,7 +8968,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": true,
-      "mod_time": "2025-06-18 19:31:49 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "generators.test.Lipsum": {
       "description": "Lorem Ipsum generator, so we can get non-zero outputs that vary",
@@ -9019,7 +8992,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-06-18 19:31:49 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "generators.test.Repeat": {
       "description": "This generator returns the last message from input that was posed to it.",
@@ -9043,7 +9016,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": true,
-      "mod_time": "2025-06-18 19:31:49 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "generators.test.Single": {
       "description": "This generator returns the a fixed string and does not support multiple generations.",
@@ -9067,7 +9040,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-06-18 19:31:49 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "generators.watsonx.WatsonXGenerator": {
       "description": "This is a generator for watsonx.ai.",
@@ -9097,7 +9070,7 @@
       },
       "parallel_capable": true,
       "supports_multiple_generations": false,
-      "mod_time": "2025-08-08 14:23:52 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     }
   },
   "harnesses": {
@@ -9107,21 +9080,21 @@
         "strict_modality_match": false
       },
       "active": true,
-      "mod_time": "2025-05-07 20:12:25 +0000"
+      "mod_time": "2025-09-04 14:42:46 +0000"
     },
     "harnesses.probewise.ProbewiseHarness": {
       "DEFAULT_PARAMS": {
         "strict_modality_match": false
       },
       "active": true,
-      "mod_time": "2025-03-10 22:23:53 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "harnesses.pxd.PxD": {
       "DEFAULT_PARAMS": {
         "strict_modality_match": false
       },
       "active": true,
-      "mod_time": "2025-03-10 22:23:53 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     }
   },
   "buffs": {
@@ -9131,7 +9104,7 @@
       "active": true,
       "doc_uri": "",
       "lang": null,
-      "mod_time": "2025-04-17 08:22:12 +0000"
+      "mod_time": "2025-08-28 17:01:41 +0000"
     },
     "buffs.encoding.Base64": {
       "description": "Base64 buff",
@@ -9139,7 +9112,7 @@
       "active": true,
       "doc_uri": "",
       "lang": null,
-      "mod_time": "2025-06-17 16:15:39 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "buffs.encoding.CharCode": {
       "description": "CharCode buff",
@@ -9147,7 +9120,7 @@
       "active": true,
       "doc_uri": "",
       "lang": null,
-      "mod_time": "2025-06-17 16:15:39 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "buffs.low_resource_languages.LRLBuff": {
       "description": "Low Resource Language buff",
@@ -9155,7 +9128,7 @@
       "active": true,
       "doc_uri": "https://arxiv.org/abs/2310.02446",
       "lang": null,
-      "mod_time": "2025-06-17 16:15:39 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "buffs.lowercase.Lowercase": {
       "description": "Lowercasing buff",
@@ -9163,7 +9136,7 @@
       "active": true,
       "doc_uri": "",
       "lang": null,
-      "mod_time": "2025-06-17 16:15:39 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "buffs.paraphrase.Fast": {
       "description": "CPU-friendly paraphrase buff based on Humarin's T5 paraphraser",
@@ -9177,7 +9150,7 @@
       "active": true,
       "doc_uri": "https://huggingface.co/humarin/chatgpt_paraphraser_on_T5_base",
       "lang": "en",
-      "mod_time": "2025-06-17 16:15:39 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     },
     "buffs.paraphrase.PegasusT5": {
       "description": "Paraphrasing buff using Pegasus model",
@@ -9193,7 +9166,7 @@
       "active": true,
       "doc_uri": "https://huggingface.co/tuner007/pegasus_paraphrase",
       "lang": "en",
-      "mod_time": "2025-06-17 16:15:39 +0000"
+      "mod_time": "2025-08-21 18:41:59 +0000"
     }
   }
 }


### PR DESCRIPTION
This PR refactors the `PackageHallucinationProbe` base class to use Python's standard ABC pattern. This ensure it is properly hidden from `--list_probes` and cannot be instantiated.

## Changes

### Abstract Class
- `PackageHallucinationProbe` now inherits from `ABC` and uses `@abstractmethod` decorator
- Added abstract property `language_name` that subclasses must implement
- Removed redundant `active=False` and `tier=UNLISTED` attributes of `PackageHallucinationProbe`

### Plugin filtering
- use `inspect.isabstract()` for filtering
- Added validation in `load_plugin()` to prevent loading abstract classes
