### PR TITLE
bugfix: `transformers` disconnect btw pegasus and `transformers-community/group-beam-search`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
   "base2048>=0.1.3",
-  "transformers>=4.51.3",
+  "transformers>=4.51.3,<4.57.0",
   "datasets>=3.0.0,<4.0",
   "colorama>=0.4.3",
   "tqdm>=4.67.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 base2048>=0.1.3
-transformers>=4.51.3
+transformers>=4.51.3,<4.57.0
 datasets>=3.0.0,<4.0
 colorama>=0.4.3
 tqdm>=4.67.1


### PR DESCRIPTION
resolves #1402

Seems `transformers` have pruned some functionality between `4.56.2` and `4.57.0`. I'll pin our dependencies for now. 

cap transformers v to avoid conflict w/ pegasus and disconnected `transformers-community/group-beam-search`

Longer-term fix may need patches to `transformers` or to our copy on HF hub of the pegasus model used in `buffs.paraphrase.Fast`