### PR TITLE
correct _mint_attempt conversation support

### DIFF
--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -198,13 +198,6 @@ class Probe(Configurable):
                 turns = prompt.turns
             except ValueError as e:
                 turns.extend(prompt.turns)
-        elif hasattr(self, "system_prompt") and self.system_prompt:
-            turns.append(
-                garak.attempt.Turn(
-                    role="system",
-                    content=garak.attempt.Message(text=self.system_prompt, lang=lang),
-                )
-            )
         if isinstance(prompt, str):
             turns.append(
                 garak.attempt.Turn(

--- a/tests/probes/test_probes.py
+++ b/tests/probes/test_probes.py
@@ -180,3 +180,5 @@ def test_mint_attempt_with_run_system_prompt(prompt):
         assert isinstance(turn, Turn)
     assert attempt.prompt.last_message().text == "test example"
     assert attempt.prompt.last_message("system").text == expected_system_prompt
+    system_message = [turn for turn in attempt.prompt.turns if turn.role == "system"]
+    assert len(system_message) == 1


### PR DESCRIPTION
#1337 added system prompt support that is expected to handle `Conversation` objects, however subsequent testing of this unused code path surfaces incorrect handling of the existing list of `Turn` objects.

In the scenario where a `Conversation` was passed that does not already contain a `system_prompt` message the existing turns should `extend` the intermediate list with the `system` prompt message prepended.

In the scenario where a `Conversation` was passed and no system_prompt exists at all, the intent is for the local `turns` list to still be empty and the original object passed as prompt will simply pass thru to the attempt creation.

## Verification

List the steps needed to make sure this thing works

- [ ] new automation test cases pass
