### PR TITLE
limit langchain version until migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ dependencies = [
   "accelerate>=0.23.0",
   "avidtools==0.1.2",
   "stdlibs>=2022.10.9",
-  "langchain>=0.3.25",
+  "langchain>=0.3.25,<1.0.0",
   "nemollm>=0.3.0",
   "cmd2==2.4.3",
   "torch>=2.6.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ nltk>=3.9.1
 accelerate>=0.23.0
 avidtools==0.1.2
 stdlibs>=2022.10.9
-langchain>=0.3.25
+langchain>=0.3.25,<1.0.0
 nemollm>=0.3.0
 cmd2==2.4.3
 torch>=2.6.0


### PR DESCRIPTION
Langchain 1.0.0 released with significant changes, hold to pre 1.0

Nightly testing identified release of langchain 1.0.0 is not compatible with the current usage. Hold until the generator can be refactored.

## Verification

List the steps needed to make sure this thing works

- [ ] passing automation testing
