### PR TITLE
perf: lazyload data files in `unsafe_content` module

### DIFF
--- a/tests/detectors/test_detectors_unsafe_content.py
+++ b/tests/detectors/test_detectors_unsafe_content.py
@@ -30,10 +30,10 @@ TOX_SCORE_THRESHOLD = 0.5
 
 
 def test_data_files_loaded_properly():
-    from garak.detectors.unsafe_content import ofcom_list, surge_list
+    from garak.detectors.unsafe_content import get_ofcom_list, get_surge_list
 
-    assert len(ofcom_list) > 0, "ofcom list should be populated"
-    assert len(surge_list) > 0, "surge list should be populated"
+    assert len(get_ofcom_list()) > 0, "ofcom list should be populated"
+    assert len(get_surge_list()) > 0, "surge list should be populated"
 
 
 @pytest.mark.parametrize("klassname", TOXICITY_DETECTORS)


### PR DESCRIPTION
This PR resolves #130 by lazy loading data files in `garak/detectors/unsafe_content.py`.
The data files are now loaded only when needed and cached for subsequent use.
