### PR TITLE
Fix #1416

### DIFF
--- a/my_module.py
+++ b/my_module.py
@@ -1,8 +1,0 @@
-import json
-
-def function_name(prompt: str) -> list[str]:
-
-    json_string = '{"test_key": "test_value", "test_key_2": [1, 2, 3]}'
-    json.loads(json_string) # check that the string is valid json
-
-    return [json_string]

--- a/test.py
+++ b/test.py
@@ -1,5 +1,0 @@
-import garak
-import garak.cli
-import my_module
-
-garak.cli.main("--target_type function --target_name my_module#function_name --probes goodside.ThreatenJSON".split())


### PR DESCRIPTION
Fixed PlainJSON detector bug where it incorrectly called `o.strip()` on Message objects instead of `o.text.strip()`, and changed to use `attempt.all_outputs` for proper detection. Also narrowed exception handling to `json.JSONDecodeError` for accuracy.

#1416 
