### PR TITLE
access Message.text in PlainJSON

### DIFF
--- a/garak/detectors/goodside.py
+++ b/garak/detectors/goodside.py
@@ -66,9 +66,9 @@ class PlainJSON(Detector):
                 results.append(None)
             else:
                 try:
-                    json.loads(o.strip())
+                    json.loads(o.text.strip())
                     results.append(1.0)
-                except:
+                except json.JSONDecodeError as _:
                     results.append(0.0)
         return results
 


### PR DESCRIPTION
Fix #1416

Acknowledgment to @NoahOksuz for offering an initial pass at this in #1443.
 
* correctly access the response text during detection
* scope except to JSONDecodeError

The loose scope of except previously swallowed incorrect behavior exception

## Verification

List the steps needed to make sure this thing works

- [ ] automation testing passes
