### PR TITLE
probe: Add more unreal pkghallu targets

### DIFF
--- a/garak/probes/packagehallucination.py
+++ b/garak/probes/packagehallucination.py
@@ -78,6 +78,9 @@ class PackageHallucinationProbe(garak.probes.Probe, ABC):
         "payload:malicious:badcode",
     ]
     goal = "base probe for importing non-existent packages"
+    DEFAULT_PARAMS = garak.probes.Probe.DEFAULT_PARAMS | {
+        "follow_prompt_cap": True,
+    }
 
     @property
     @abstractmethod
@@ -95,7 +98,8 @@ class PackageHallucinationProbe(garak.probes.Probe, ABC):
                         "<task>", code_task
                     )
                 )
-        self._prune_data(cap=self.soft_probe_prompt_cap)
+        if self.follow_prompt_cap:
+            self._prune_data(cap=self.soft_probe_prompt_cap)
 
 
 class Python(PackageHallucinationProbe):

--- a/tests/probes/test_probes_packagehallucination.py
+++ b/tests/probes/test_probes_packagehallucination.py
@@ -1,26 +1,49 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import importlib
+import pytest
+from garak import _plugins
 import garak.probes.packagehallucination
 
+PROBES = [
+    classname
+    for (classname, active) in _plugins.enumerate_plugins("probes")
+    if classname.startswith("probes.packagehallucination")
+]
 
-def test_promptcount():
-    languages = {
-        "Python": garak.probes.packagehallucination.Python(),
-        "Ruby": garak.probes.packagehallucination.Ruby(),
-        "JavaScript": garak.probes.packagehallucination.JavaScript(),
-        "Rust": garak.probes.packagehallucination.Rust(),
-        "Perl": garak.probes.packagehallucination.Perl(),
-        "Dart": garak.probes.packagehallucination.Dart(),
-        "Raku": garak.probes.packagehallucination.RakuLand(),
-    }
+
+@pytest.fixture(autouse=True)
+def reload_config(request):
+    # reload config before and after each test
+    def reload():
+        importlib.reload(garak._config)
+
+    reload()
+    request.addfinalizer(reload)
+
+
+@pytest.mark.parametrize("classname", PROBES)
+def test_soft_promptcount(classname):
+    language_probe = _plugins.load_plugin(classname)
+
+    expected_count = garak._config.run.soft_probe_prompt_cap
+
+    assert (
+        len(language_probe.prompts) == expected_count
+    ), f"{language_probe.__name__} prompt count mismatch. Expected {expected_count}, got {len(language_probe.prompts)}"
+
+
+@pytest.mark.parametrize("classname", PROBES)
+def test_full_promptcount(classname):
+    garak._config.run.soft_probe_prompt_cap = float("inf")
+
+    language_probe = _plugins.load_plugin(classname)
 
     expected_count = len(garak.probes.packagehallucination.stub_prompts) * len(
         garak.probes.packagehallucination.code_tasks
     )
 
-    for language in languages:
-        language_probe = languages[language]
-        assert (
-            len(language_probe.prompts) == expected_count
-        ), f"{language} prompt count mismatch. Expected {expected_count}, got {len(language_probe.prompts)}"
+    assert (
+        len(language_probe.prompts) == expected_count
+    ), f"{language_probe.__name__} prompt count mismatch. Expected {expected_count}, got {len(language_probe.prompts)}"


### PR DESCRIPTION
We noticed during the pkghallu research work https://arxiv.org/abs/2501.19012 that most of the existing prompts focused on target tasks that were real, or at least grounded in reality, and the probe only had one task involving fictional technology. This update

* adds 11 more fictional tasks, so we have 12 fictional and 12 non-fictional
* enhances the prompt templating setup
* adds three more task framings
* has `packagehallucination` probes follow `run.soft_probe_prompt_cap`