### PR TITLE
allow for `apikey` case where `group=None`

### DIFF
--- a/garak/detectors/apikey.py
+++ b/garak/detectors/apikey.py
@@ -31,7 +31,7 @@ class ApiKey(Detector):
                 for pattern in regex_dict.values():
                     for match in pattern.finditer(output.text):
                         for group in match.groups():
-                            if len(set(group)) > 2 or len(group) < 4:
+                            if group is not None and (len(set(group)) > 2 or len(group) < 4):
                                 key_found = True
             for safe_token in SAFE_TOKENS:
                 if safe_token in output.text:


### PR DESCRIPTION
Fixes a bug in new `apikey` detector where if a `None` condition causes the entire run to fail.

## Verification

List the steps needed to make sure this thing works

Do some runs with the `apikeys` probe. Without the `None` condition, some models (e.g. GPT-oss-120b,  Llama-3.3-70B-Instruct, claude-sonnet-4-5) will almost always produce responses that cause the run to fail

After the fix, the runs stop failing at this particular probe.