### PR TITLE
doc: rm links to doc source; show links to github code source

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,2 +1,3 @@
 sphinx
 sphinx-rtd-theme
+sphinx-github-style

--- a/docs/source/_static/css/garak_theme.css
+++ b/docs/source/_static/css/garak_theme.css
@@ -132,3 +132,11 @@ a.icon {
     /* font-family:  Lato, proxima-nova, Helvetica Neue, Arial, sans-serif;*/
     font-family: Arial, Helvetica, Sans-Serif;
 }
+.linkcode-link {
+    color: #fff;
+    font-size: 80%;
+    margin-left: 10px;
+}
+.linkcode-link::after {
+    content: none;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,8 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
-    "garak_ext"
+    "garak_ext",
+    "sphinx_github_style",
 ]
 
 intersphinx_mapping = {
@@ -33,7 +34,10 @@ exclude_patterns = []
 html_theme = "sphinx_rtd_theme"
 
 # These folders are copied to the documentation's HTML output
-html_static_path = ['_static']
+html_static_path = ["_static"]
+
+# disable link to doc source
+html_show_sourcelink = False
 
 # These paths are either relative to html_static_path
 # or fully qualified paths (eg. https://...)
@@ -43,6 +47,14 @@ html_css_files = [
 
 # -- Options for EPUB output
 epub_show_urls = "footnote"
+
+# -- options for github links
+linkcode_link_text = "Source"
+linkcode_url = "https://github.com/NVIDIA/garak"
+
+# hide module paths
+add_module_names = False
+autodoc_preserve_defaults = False
 
 import os
 import sys


### PR DESCRIPTION
see title

example in practice:

<img width="192" height="118" alt="image" src="https://github.com/user-attachments/assets/2855cdf0-81bf-4ab9-9438-937178326e35" />

("Source" here links to github / main branch)