### PR TITLE
Make GoogleTranslator multiprocessing-safe

### DIFF
--- a/garak/langproviders/remote.py
+++ b/garak/langproviders/remote.py
@@ -169,7 +169,14 @@ class GoogleTranslator(LangProvider):
 
     ENV_VAR = "GOOGLE_APPLICATION_CREDENTIALS"
     DEFAULT_PARAMS = {"project_id": None}
+    def __getstate__(self):
+        state = dict(self.__dict__)
+        state["client"] = None
+        return state
 
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.client = None
     def _validate_env_var(self):
         """Override standard API key selection to enable provision of json credential file"""
         import os


### PR DESCRIPTION
Tell us what this change does

GoogleTranslator stores a live Google Cloud Translation client on the instance, which cannot be pickled when parallel_attempts > 1 and causes a PicklingError during multiprocessing startup.

This change prevents the client from being pickled and allows it to be recreated per worker process, following the same pattern used by RivaTranslator.

Fixes #1515
Related issue: https://github.com/NVIDIA/garak/issues/1515

Verification
Supporting configuration such as generator configuration file
run:
  target_lang: ar
  parallel_attempts: 4

langproviders:
  - language: en,ar
    model_type: remote.GoogleTranslator

Command used for verification
python -m garak \
  --config test_google_translate.yaml \
  --model_type openai \
  --model_name gpt-4o

Run the tests and ensure they pass
python -m pytest tests/

Verify the thing does what it should

Garak starts successfully with parallel_attempts > 1

GoogleTranslator is initialized per worker process

No PicklingError occurs during multiprocessing startup

Probes are queued and begin execution

Verify the thing does not do what it should not

The Google Cloud Translation client is not pickled

Multiprocessing worker initialization does not fail

Additional information

No hardware-specific requirements

Uses Google Cloud Translation API for verification

No new dependencies introduced
