### PR TITLE
test: isolate _config in all tests

### DIFF
--- a/garak/analyze/aggregate_reports.py
+++ b/garak/analyze/aggregate_reports.py
@@ -177,4 +177,5 @@ def main(argv=None) -> None:
 
 
 if __name__ == "__main__":
+    sys.stdout.reconfigure(encoding="utf-8")
     main()

--- a/tests/langservice/probes/test_probes_base.py
+++ b/tests/langservice/probes/test_probes_base.py
@@ -37,7 +37,7 @@ openai_api_key_missing = not os.getenv("OPENAI_API_KEY")
 
 
 @pytest.fixture(autouse=True)
-def probe_pre_req(classname):
+def probe_pre_req(classname, request):
     # this sets up config for probes that access _config still
     _config.run.seed = 42
     local_config_path = str(
@@ -56,6 +56,11 @@ def probe_pre_req(classname):
     # since this does not go through cli generations must be set
     _, module, klass = classname.split(".")
     _config.plugins.probes[module][klass]["generations"] = 1
+
+    def close_report():
+        temp_report_file.close()
+
+    request.addfinalizer(close_report)
 
 
 RESPONSE_SAMPLES = [

--- a/tests/probes/test_probes_leakreplay.py
+++ b/tests/probes/test_probes_leakreplay.py
@@ -20,18 +20,22 @@ def test_leakreplay_hitlog():
 
 
 def test_leakreplay_output_count():
-    generations = 1
-    garak._config.load_base_config()
-    garak._config.transient.reportfile = open(os.devnull, "w+", encoding="utf-8")
-    garak._config.plugins.probes["leakreplay"]["generations"] = generations
-    a = garak.attempt.Attempt(prompt=garak.attempt.Message("test"))
-    p = garak._plugins.load_plugin(
-        "probes.leakreplay.LiteratureCloze", config_root=garak._config
-    )
-    g = garak._plugins.load_plugin("generators.test.Blank", config_root=garak._config)
-    p.generator = g
-    results = p._execute_all([a])
-    assert len(a.outputs) == generations
+    with open(os.devnull, "w+", encoding="utf-8") as fh:
+        generations = 1
+        garak._config.load_base_config()
+        garak._config.transient.reportfile = fh
+        garak._config.plugins.probes["leakreplay"]["generations"] = generations
+        a = garak.attempt.Attempt(prompt=garak.attempt.Message("test"))
+        p = garak._plugins.load_plugin(
+            "probes.leakreplay.LiteratureCloze", config_root=garak._config
+        )
+        g = garak._plugins.load_plugin(
+            "generators.test.Blank", config_root=garak._config
+        )
+        p.generator = g
+        p._execute_all([a])
+        garak._config.transient.reportfile = None
+        assert len(a.outputs) == generations
 
 
 def test_leakreplay_handle_incomplete_attempt():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -95,19 +95,6 @@ for p in _config.reporting_params:
     param_locs[p] = "reporting"
 
 
-@pytest.fixture(autouse=True)
-def reload_config(request):
-    def reload():
-        if _config.transient.reportfile is not None:
-            _config.transient.reportfile.close()
-            if os.path.exists(_config.transient.report_filename):
-                os.remove(_config.transient.report_filename)
-        importlib.reload(_config)
-
-    request.addfinalizer(reload)
-    reload()
-
-
 @pytest.fixture
 def allow_site_config(request):
     site_cfg_moved = False

--- a/tests/test_internal_structures.py
+++ b/tests/test_internal_structures.py
@@ -28,7 +28,6 @@ from garak.detectors.mitigation import MitigationBypass
 
 @pytest.fixture(autouse=True)
 def _config_loaded():
-    importlib.reload(garak._config)
     garak._config.load_base_config()
     garak._config.plugins.probes["test"]["generations"] = 1
     temp_report_file = tempfile.NamedTemporaryFile(
@@ -40,7 +39,6 @@ def _config_loaded():
     )
 
     yield
-    temp_report_file.close()
 
 
 def test_generator_consume_attempt_generator():


### PR DESCRIPTION
The `_config` namespace is utilized _globally_. This revision ensures a clean configuration environment exists before each test and ensures post test cleanup of files connected to config that may have been created during the test.

## Verification

List the steps needed to make sure this thing works

- [ ] **Verify** automation tests complete without warnings of orphaned files
