### PR TITLE
update LangChain generator for 1.x library support

### DIFF
--- a/garak/generators/langchain.py
+++ b/garak/generators/langchain.py
@@ -38,9 +38,13 @@ class LangChainLLMGenerator(Generator):
         "frequency_penalty": 0.0,
         "presence_penalty": 0.0,
         "stop": [],
+        "model_provider": None,
+        "configurable_fields": None,
     }
-    extra_dependency_names = ["langchain.llms"]
+    extra_dependency_names = ["langchain.chat_models"]
     generator_family_name = "LangChain"
+
+    _unsafe_attributes = ["generator"]
 
     def __init__(self, name="", config_root=_config):
         self.name = name
@@ -48,8 +52,22 @@ class LangChainLLMGenerator(Generator):
         self.fullname = f"LangChain LLM {self.name}"
 
         super().__init__(self.name, config_root=config_root)
+        self._load_unsafe()
 
-        self.generator = getattr(self.langchain_llms, self.name)()
+    def _load_unsafe(self):
+        configured_fields = {}
+        if configured_fields:
+            for field in self.configurable_fields:
+                if hasattr(self, field):
+                    configured_fields[field] = getattr(self, field)
+
+        # if not already added pass thru an configured `api_key`
+        if hasattr(self, "api_key") and not configured_fields.get("api_key", None):
+            configured_fields["api_key"] = self.api_key
+
+        self.generator = self.langchain_chat_models.init_chat_model(
+            self.name, configurable_fields=self.configurable_fields, **configured_fields
+        )
 
     def _call_model(
         self, prompt: Conversation, generations_this_call: int = 1
@@ -60,8 +78,9 @@ class LangChainLLMGenerator(Generator):
         This calls invoke once per generation; invoke() seems to have the best
         support across LangChain LLM integrations.
         """
-        # Should this be expanded to process a whole conversation in some way?
-        return [Message(r) for r in self.generator.invoke(prompt.last_message().text)]
+        conv = self._conversation_to_list(prompt)
+        resp = self.generator.invoke(conv)
+        return [Message(resp.content)]
 
 
 DEFAULT_CLASS = "LangChainLLMGenerator"

--- a/garak/generators/langchain.py
+++ b/garak/generators/langchain.py
@@ -56,7 +56,7 @@ class LangChainLLMGenerator(Generator):
 
     def _load_unsafe(self):
         configured_fields = {}
-        if configured_fields:
+        if self.configurable_fields:
             for field in self.configurable_fields:
                 if hasattr(self, field):
                     configured_fields[field] = getattr(self, field)

--- a/garak/generators/langchain.py
+++ b/garak/generators/langchain.py
@@ -80,7 +80,7 @@ class LangChainLLMGenerator(Generator):
         """
         conv = self._conversation_to_list(prompt)
         resp = self.generator.invoke(conv)
-        return [Message(resp.content)]
+        return [Message(resp.content)] if hasattr(resp, "content") else [None]
 
 
 DEFAULT_CLASS = "LangChainLLMGenerator"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ dependencies = [
   "accelerate>=0.23.0",
   "avidtools==0.1.2",
   "stdlibs>=2022.10.9",
-  "langchain>=0.3.25,<1.0.0",
+  "langchain>=1.2.1",
   "nemollm>=0.3.0",
   "cmd2==2.4.3",
   "torch>=2.6.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ nltk>=3.9.1
 accelerate>=0.23.0
 avidtools==0.1.2
 stdlibs>=2022.10.9
-langchain>=0.3.25,<1.0.0
+langchain>=1.2.1
 nemollm>=0.3.0
 cmd2==2.4.3
 torch>=2.6.0


### PR DESCRIPTION
Update langchain support for 1.x library. This maintains the limited support in this generator as being for direct model `invoke()` calls and expands the generator to support `Conversation` based prompts using the OpenAI format.

Enhancement also supports injection of a specific `model_provider` as defined in the 1.x langchain chat interface and forwarding of `configurable_fields` passed as a `set` via configuration.

## Verification

List the steps needed to make sure this thing works

- [ ] `garak -t langchain -n <model_name>`
- [ ] **Verify** various proxied models work with probes

