### PR TITLE
track which detector is reporting invalid pkg entry; only report once

### DIFF
--- a/garak/detectors/packagehallucination.py
+++ b/garak/detectors/packagehallucination.py
@@ -84,7 +84,7 @@ class PackageHallucinationDetector(Detector, ABC):
                         if not invalid_pkg_date_seen_flag:
                             logging.debug(
                                 "Invalid %s package date format: %s. Keeping package %s with unknown creation date. Only logging first package"
-                                % (self.__class__.__name__, e, str)
+                                % (self.__class__.__name__, e, pkg)
                             )
                             invalid_pkg_date_seen_flag = True
                 self.packages = set(filtered_packages)


### PR DESCRIPTION
address #1553 

- only prints 1 log entry per run instead of 119,676 entries
- log the name of the reporting detector class
- move to debug loglevel