### PR TITLE
[ADD] --target_lang option

### DIFF
--- a/docs/source/cliref.rst
+++ b/docs/source/cliref.rst
@@ -15,6 +15,7 @@ CLI reference for garak
                          [--probes PROBES] [--probe_tags PROBE_TAGS]
                          [--detectors DETECTORS] [--extended_detectors]
                          [--buffs BUFFS]
+                         [--target_lang TARGET_LANG] [--language TARGET_LANG] [--lang TARGET_LANG]
                          [--buff_option_file BUFF_OPTION_FILE | --buff_options BUFF_OPTIONS]
                          [--detector_option_file DETECTOR_OPTION_FILE | --detector_options DETECTOR_OPTIONS]
                          [--generator_option_file GENERATOR_OPTION_FILE | --generator_options GENERATOR_OPTIONS]
@@ -69,6 +70,9 @@ CLI reference for garak
                           primary detector, if given, else everything)
     --buffs BUFFS, -b BUFFS
                           list of buffs to use. Default is none
+    --target_lang TARGET_LANG, --language TARGET_LANG, --lang TARGET_LANG
+                          specify a language to be used for the target model.
+                          e.g. 'en', 'ko'
     --buff_option_file BUFF_OPTION_FILE, -B BUFF_OPTION_FILE
                           path to JSON file containing options to pass to buff
     --buff_options BUFF_OPTIONS

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -191,6 +191,15 @@ def main(arguments=None) -> None:
         default=_config.plugins.buff_spec,
         help="list of buffs to use. Default is none",
     )
+    ## Language
+    parser.add_argument(
+        "--target_lang",
+        "--language",
+        "--lang",
+        type=str,
+        default=_config.run.target_lang,
+        help="specify a language to be used for the target model. e.g. 'en', 'ko'",
+    )
     # file or json based config options
     plugin_types = sorted(
         zip([type.lower() for type in _plugins.PLUGIN_CLASSES], _plugins.PLUGIN_TYPES)
@@ -372,6 +381,8 @@ def main(arguments=None) -> None:
         _config.plugins.detector_spec = args.detectors
     if "buffs" in args:
         _config.plugins.buff_spec = args.buffs
+    if "target_lang" in args:
+        _config.run.target_lang = args.target_lang
 
     # base config complete
 


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

Please ensure you are submitting **from a unique branch** in your repository to `main` upstream.

## Verification

List the steps needed to make sure this thing works

- [ ] Supporting configuration such as generator configuration file
``` json
{
    "huggingface": {
        "torch_type": "float32"
    }
}
```
- [ ] `garak -t <target_type> -n <model_name>`
- [ ] Run the tests and ensure they pass `python -m pytest tests/`
- [ ] ...
- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not
- [ ] **Document** the thing and how it works ([Example](https://github.com/NVIDIA/garak/blob/61ce5c4ae3caac08e0abd1d069d223d8a66104bd/garak/generators/rest.py#L24-L100))

If you are opening a PR for a new plugin that targets a **specific** piece of hardware or requires a **complex or hard-to-find** testing environment, we recommend that you send us as much detail as possible.

Specific Hardware Examples:
* GPU related
  * Specific support required `cuda` / `mps` ( Please not `cuda` via `ROCm` if related )
  * Minium GPU Memory

Complex Software Examples:
* Expensive proprietary software
* Software with an extensive installation process
* Software without an English language UI
