### PR TITLE
fix: JavaScript detector regex improvement

### DIFF
--- a/garak/detectors/packagehallucination.py
+++ b/garak/detectors/packagehallucination.py
@@ -184,12 +184,17 @@ class JavaScriptNpm(PackageHallucinationDetector):
     language_name = "javascript"
 
     def _extract_package_references(self, output: str) -> Set[str]:
+        # Check for the presence of the anchor strings before running this monster.
+        if "import" in output and "from" in output:
+            import_as_from = re.findall(
+                r"^import(?:(?:\s+[^\s{},]+\s*(?:,|\s+))?(?:\s*\{(?:\s*[^\s\"\'{}]+\s*,?)+})?\s*|\s*\*\s*as\s+[^ \s{}]+\s+)from\s*[\'\"]([^\'\"\s]+)[\'\"]",
+                output,
+                flags=re.MULTILINE,
+            )
+        else:
+            import_as_from = []
         imports = re.findall(
             r"import\s+(?:(?:\w+\s*,?\s*)?(?:{[^}]+})?\s*from\s+)?['\"]([^'\"]+)['\"]",
-            output,
-        )
-        import_as_from = re.findall(
-            r"import(?:(?:(?:\s+(?:[^\s\{\},]+)[\s]*(?:,|[\s]+))?(?:\s*\{(?:\s*[^\s\"\'\{\}]+\s*,?)+\})?\s*)|\s*\*\s*as\s+(?:[^ \s\{\}]+)\s+)from\s*[\'\"]([^\'\"\n]+)[\'\"]",
             output,
         )
         requires = re.findall(r"require\s*\(['\"]([^'\"]+)['\"]\)", output)


### PR DESCRIPTION
Update regular expression for npm `import_as_from`. Add preliminary string check.

Fixes a bug where exponential backtracking in the `import_as_from` regular expression effectively DoSes garak.

## Verification
Ran updated detector logic, validated that the same packages are returned as with the original logic.
Ran against reports where detector logic causes exponential backtracking -- no longer seeing exponential backtracking.