### PR TITLE
chore: add optional pre-commit hook for garak-report

### DIFF
--- a/garak-report/README.md
+++ b/garak-report/README.md
@@ -227,6 +227,39 @@ garak/garak/analyze/ui/
 - Styles use CSS-in-JS or plain modules
 - All state handled via React hooks
 
+### Optional: Set up pre-commit hooks
+
+The repo uses [pre-commit](https://pre-commit.com/) for Python hooks. To add garak-report checks, append the following to `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: local
+    hooks:
+      - id: garak-report-lint
+        name: garak-report lint
+        entry: bash -c 'cd garak-report && yarn lint --max-warnings=0'
+        language: system
+        files: ^garak-report/.*\.(ts|tsx)$
+        pass_filenames: false
+      - id: garak-report-typecheck
+        name: garak-report typecheck
+        entry: bash -c 'cd garak-report && yarn check'
+        language: system
+        files: ^garak-report/.*\.(ts|tsx)$
+        pass_filenames: false
+      - id: garak-report-test
+        name: garak-report test
+        entry: bash -c 'cd garak-report && yarn test'
+        language: system
+        files: ^garak-report/
+        pass_filenames: false
+```
+
+Then install/update the hooks:
+
+```bash
+pre-commit install
+```
+
 ---
 
 ## ✅ Testing & Coverage
@@ -250,6 +283,28 @@ CI (or your pre-commit hook) can simply invoke `yarn test`; the build will fail 
 The UI lives in `garak-report/`, while the Python core lives in the repo root.  If you prefer to stay at the root you can delegate Yarn commands:
 
 ```bash
+# one-off
+yarn --cwd garak-report dev
+
+# or create a root-level package.json with convenience scripts:
+{
+  "name": "garak-root",
+  "private": true,
+  "scripts": {
+    "ui:dev": "yarn --cwd garak-report dev",
+    "ui:build": "yarn --cwd garak-report build",
+    "ui:test": "yarn --cwd garak-report test"
+  }
+}
+```
+
+---
+
+## 📄 License
+
+This project is licensed under the [Apache License 2.0](./LICENSE.txt).  
+© 2023–2025 NVIDIA Corporation
+
 # one-off
 yarn --cwd garak-report dev
 

--- a/garak-report/tools/dev/pre-commit-hook.sh
+++ b/garak-report/tools/dev/pre-commit-hook.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Standalone pre-commit hook for garak-report
+#
+# RECOMMENDED: Add hooks to .pre-commit-config.yaml instead (see README.md)
+#
+# Alternative (standalone, may interfere with other hooks):
+#   ln -sf ../../garak-report/tools/dev/pre-commit-hook.sh .git/hooks/pre-commit
+#
+# To disable:
+#   rm .git/hooks/pre-commit
+#
+
+set -e
+
+cd "$(git rev-parse --show-toplevel)/garak-report"
+
+echo "🔍 Running pre-commit checks..."
+
+# Check if there are staged files in garak-report
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep "^garak-report/.*\.\(ts\|tsx\)$" || true)
+
+if [ -n "$STAGED_FILES" ]; then
+    echo "📝 Linting staged files..."
+    yarn lint --max-warnings=0
+    
+    echo "✨ Checking formatting..."
+    yarn format --check
+fi
+
+echo "🔎 Type checking..."
+yarn check
+
+echo "🧪 Running tests..."
+yarn test
+
+echo "✅ All checks passed!"


### PR DESCRIPTION
## What this change does

Adds an optional pre-commit hook for `garak-report` frontend development. The hook runs lint, format, typecheck, and tests before each commit.

Following the [Metasploit-style guidance approach](https://docs.metasploit.com/docs/development/get-started/setting-up-a-metasploit-development-environment.html#set-up-msftidy-to-run-before-each-git-commit-and-after-each-git-merge-to-quickly-identify-potential-issues-with-your-contributions), developers opt-in by symlinking - no auto-install or forced hooks.

**Files added:**
- `garak-report/tools/dev/pre-commit-hook.sh` - the hook script
- Updated `garak-report/README.md` with setup instructions

---

## Verification

- [ ] Enable the hook:
  ```bash
  ln -sf ../../garak-report/tools/dev/pre-commit-hook.sh .git/hooks/pre-commit
  ```
- [ ] Make a test commit in `garak-report/` - hook should run lint, format, typecheck, tests
- [ ] **Verify** hook blocks commits when checks fail
- [ ] **Verify** hook passes when all checks pass
- [ ] Disable the hook:
  ```bash
  rm .git/hooks/pre-commit
  ```
- [ ] **Verify** commits work normally without the hook
