### PR TITLE
rm `jinja2` direct dependency requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,6 @@ dependencies = [
   "google-api-python-client>=2.0",
   "backoff>=2.1.1",
   "rapidfuzz>=3.0.0",
-  "jinja2>=3.1.6",
   "nltk>=3.9.1",
   "accelerate>=0.23.0",
   "avidtools==0.1.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ replicate>=0.8.3
 google-api-python-client>=2.0
 backoff>=2.1.1
 rapidfuzz>=3.0.0
-jinja2>=3.1.6
 nltk>=3.9.1
 accelerate>=0.23.0
 avidtools==0.1.2


### PR DESCRIPTION
Remove direct dependency on `jinja2`.

Since reporting presentation has switched to a new system, the `jinja2` dependency is no longer directly required by garak.

## Verification

- [ ] Generate a report from any run
- [ ] `python -m pytest tests/test_reqs.py`