### PR TITLE
reporting: have `qual_review` support `report.jsonl` eval entries from 0.13.3 and earlier

### DIFF
--- a/garak/analyze/qual_review.py
+++ b/garak/analyze/qual_review.py
@@ -51,12 +51,16 @@ def qual_review(report_path: str) -> None:
 
     with open(report_path, "r", encoding="utf-8") as report_file:
         g = (json.loads(line.strip()) for line in report_file if line.strip())
+        total_key = None
         for record in g:
             if record["entry_type"] == "eval":
+                if not total_key:
+                    if "total_evaluated" in record:
+                        total_key = "total_evaluated"
+                    else:
+                        total_key = "total"
                 passrate = (
-                    record["passed"] / record["total_evaluated"]
-                    if record["total_evaluated"] > 0
-                    else 0
+                    record["passed"] / record[total_key] if record[total_key] > 0 else 0
                 )
                 probe_module, probe_classname = record["probe"].split(".", 1)
                 detector = record["detector"].replace("detector.", "")


### PR DESCRIPTION
The `eval` entries in report.jsonl were updated in 0.14.0.pre1 to remove the `total` entry and add `total_processed` and `total_evaluated`. 

`qual_review` relies on these totals to make assessments, but is often used with garak report.jsonl files from earlier versions

This PR enables the previous format and assumes `total` is `total_evaluated`

## Testing

* run `garak.analyze.qual_review` on a report from the current version of garak without `KeyError`s
* run `garak.analyze.qual_review` on a report from garak 0.13.3 or earlier without `KeyError`s