### PR TITLE
docs: reorganise detector metrics out of code reference section

### DIFF
--- a/docs/source/detector_metrics.rst
+++ b/docs/source/detector_metrics.rst
@@ -1,5 +1,5 @@
-Detector Metrics: F1 Score and Ranking
-======================================
+Detector Quality Metrics
+========================
 
 Detectors in garak attempt to identify specific failure modes in model outputs. To assess detector performance, they must be evaluated against labeled benchmark datasets where the ground truth is known. This evaluation process measures how accurately each detector identifies its target failure mode.
 
@@ -147,6 +147,8 @@ Key Fields
 - **metadata**: Evaluation metadata including date, random seed, dataset configuration, and any errors encountered
 
 The primary ranking metric is ``hit_f1`` under each detector's metrics.
+
+.. _Confidence Intervals:
 
 Confidence Intervals
 --------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,13 +38,11 @@ Check out the :doc:`usage` section for further information, including :doc:`inst
    configurable
    cliref
    reporting
-   translation
-   ascii_smuggling
    faster
    FAQ <https://github.com/NVIDIA/garak/blob/main/FAQ.md>
 
 .. toctree::
-   :caption: Reference
+   :caption: Code Reference
    :maxdepth: 1
    :hidden:
 
@@ -54,7 +52,6 @@ Check out the :doc:`usage` section for further information, including :doc:`inst
    cli
    command
    detectors
-   detector_metrics
    evaluators
    exception
    generators
@@ -68,6 +65,15 @@ Check out the :doc:`usage` section for further information, including :doc:`inst
    _plugins
    analyze
 
+.. toctree:: 
+   :caption: Technologies
+   :maxdepth: 1
+   :hidden:
+
+   detector_metrics
+   translation
+   ascii_smuggling
+   analyze.tbsa
 
 .. toctree::
    :caption: Extending and Contributing


### PR DESCRIPTION
This section was in the "Code reference" section which was otherwise describing code & API

It and a few others don't fit well in the "Using garak" right-nav section

Added a "Technologies" right-nav section for the deep-dive material we have, like this and a few others