### PR TITLE
task: add report tests automation

### DIFF
--- a/.github/workflows/test_report_build.yaml
+++ b/.github/workflows/test_report_build.yaml
@@ -1,0 +1,79 @@
+name: Garak Report Artifact Tests
+
+on:
+  pull_request: 
+    paths:
+      - 'garak-report/**'
+  workflow_dispatch:
+
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  id-token: none
+  issues: none
+  discussions: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+jobs:
+  index_check:
+    name: Report HTML Index Up-To-Date
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ["25"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v6.2.0
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install report dependencies
+        run: |
+          cd garak-report
+          corepack enable
+          yarn install
+      - name: Build React Report
+        run: |
+          cd garak-report
+          yarn build
+          set +e
+          git diff --exit-code > /dev/null
+          if [ $? -ne 0 ]; then
+            set -e
+            echo "Report build shows uncommitted changes, please commit an updated garak/analyze/ui/index.html"
+            exit 1
+          else
+            echo "Report build is up-to-date"
+          fi
+
+  report_tests:
+    name: Report Testing
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ["25"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v6.2.0
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install report dependencies
+        run: |
+          cd garak-report
+          corepack enable
+          yarn install
+
+      - name: Yarn Testing
+        run: |
+          cd garak-report
+          yarn test
+
+


### PR DESCRIPTION
These tests offer early feedback on reporting react application changes related incoming PRs.

* run only when a PR changes `garak-report` path
* check for report index updates
* run yarn tests

Validation can be reviewed in my fork's action results.