### PR TITLE
fix: add standardized exit codes on improper exit (issue #1221)

### DIFF
--- a/garak/cli.py
+++ b/garak/cli.py
@@ -42,7 +42,7 @@ def main(arguments=None) -> None:
 
     from garak import __description__
     from garak import _config, _plugins
-    from garak.exception import GarakException
+    from garak.exception import GarakException, GarakExitCodes
 
     _config.transient.starttime = datetime.datetime.now()
     _config.transient.starttime_iso = _config.transient.starttime.isoformat()
@@ -491,7 +491,8 @@ def main(arguments=None) -> None:
             except Exception as e:
                 logging.error(e)
                 print(e)
-                sys.exit(1)
+                # exit code per issue #1221
+                sys.exit(GarakExitCodes.UNSPECIFIED_EXCEPTION)
             finally:
                 command.end_run()
 
@@ -687,8 +688,12 @@ def main(arguments=None) -> None:
         logging.exception(e)
         logging.info(msg)
         print(msg)
+        # exit code per issue #1221
+        sys.exit(GarakExitCodes.INTERRUPTED)
     except (ValueError, GarakException) as e:
         logging.exception(e)
         print(e)
+        # exit code per issue #1221
+        sys.exit(GarakExitCodes.UNSPECIFIED_EXCEPTION)
 
     _config.set_http_lib_agents(prior_user_agents)

--- a/garak/exception.py
+++ b/garak/exception.py
@@ -1,6 +1,32 @@
 # SPDX-FileCopyrightText: Portions Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from enum import IntEnum
+
+
+class GarakExitCodes(IntEnum):
+    """Standardized exit codes for garak CLI exits.
+
+    These codes allow wrapping tools such as CI/CD pipelines and garak ms to
+    detect precisely what went wrong during a garak run, rather than relying
+    on a generic non-zero exit or inspecting log output.
+
+    Negative values are used to avoid collisions with conventional UNIX exit
+    codes (0 = success, 1 = general error, 2 = misuse of shell builtins, etc.).
+    """
+
+    INTERRUPTED = -1
+    PROBE_EXCEPTION = -2
+    GENERATOR_EXCEPTION = -3
+    DETECTOR_EXCEPTION = -4
+    BUFF_EXCEPTION = -5
+    EVALUATOR_EXCEPTION = -6
+    HARNESS_EXCEPTION = -7
+    LANGPROVIDER_EXCEPTION = -8
+    REPORTING_EXCEPTION = -9
+    RESOURCE_EXHAUSTED = -10
+    UNSPECIFIED_EXCEPTION = -127
+
 
 class GarakException(Exception):
     """Base class for all  garak exceptions"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,6 +14,7 @@ import tempfile
 from pytest_httpserver import HTTPServer
 
 from garak import _config
+from garak.exception import GarakExitCodes
 import garak.cli
 
 SITE_YAML_FILENAME = "TESTONLY.site.yaml.bak"
@@ -609,13 +610,23 @@ def test_blank_generator_instance_loads_yaml_config():
             ).encode("utf-8")
         )
         tmp.close()
-        garak.cli.main(
-            ["--config", tmp.name, "--target_type", generator_name, "--probes", "none"]
-        )
-        os.remove(tmp.name)
-    gen = garak._plugins.load_plugin(f"generators.{generator_name}")
-    assert gen.temperature == revised_temp
-    assert gen.test_val == "test_blank_value"
+        with pytest.raises(SystemExit) as exc_info:
+            garak.cli.main(
+                [
+                    "--config",
+                    tmp.name,
+                    "--target_type",
+                    generator_name,
+                    "--probes",
+                    "none",
+                ]
+            )
+            os.remove(tmp.name)
+            gen = garak._plugins.load_plugin(f"generators.{generator_name}")
+            assert gen.temperature == revised_temp
+            assert gen.test_val == "test_blank_value"
+            assert exc_info.type == SystemExit
+            assert exc_info.value.code == GarakExitCodes.UNSPECIFIED_EXCEPTION
 
 
 # check that generator picks up cli config items
@@ -639,9 +650,12 @@ def test_blank_generator_instance_loads_cli_config():
         .replace(" ", "")
         .strip(),
     ]
-    garak.cli.main(args)
-    gen = garak._plugins.load_plugin(f"generators.{generator_name}")
-    assert gen.temperature == revised_temp
+    with pytest.raises(SystemExit) as exc_info:
+        garak.cli.main(args)
+        gen = garak._plugins.load_plugin(f"generators.{generator_name}")
+        assert gen.temperature == revised_temp
+        assert exc_info.type == SystemExit
+        assert exc_info.value.code == GarakExitCodes.UNSPECIFIED_EXCEPTION
 
 
 # test parsing of probespec


### PR DESCRIPTION
- Add GarakExitCodes IntEnum to exception.py with 11 exit codes: INTERRUPTED=-1, PROBE_EXCEPTION=-2, GENERATOR_EXCEPTION=-3, DETECTOR_EXCEPTION=-4, BUFF_EXCEPTION=-5, EVALUATOR_EXCEPTION=-6, HARNESS_EXCEPTION=-7, LANGPROVIDER_EXCEPTION=-8, REPORTING_EXCEPTION=-9, RESOURCE_EXHAUSTED=-10, UNSPECIFIED_EXCEPTION=-127
- Fix KeyboardInterrupt handler: was exiting 0, now exits -1
- Fix ValueError/GarakException handler: was exiting 0, now exits -127
- Fix interactive mode handler: was exit(1), now uses GarakExitCodes


