### PR TITLE
fix: handle None response.choices in OpenAICompatible

### DIFF
--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -327,7 +327,7 @@ class OpenAICompatible(Generator):
             else:
                 raise e
 
-        if not hasattr(response, "choices"):
+        if not hasattr(response, "choices") or response.choices is None:
             logging.debug(
                 "Did not get a well-formed response, retrying. Expected object with .choices member, got: '%s'"
                 % repr(response)

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -327,7 +327,7 @@ class OpenAICompatible(Generator):
             else:
                 raise e
 
-        if not hasattr(response, "choices") or response.choices is None:
+        if not hasattr(response, "choices"):
             logging.debug(
                 "Did not get a well-formed response, retrying. Expected object with .choices member, got: '%s'"
                 % repr(response)
@@ -337,6 +337,12 @@ class OpenAICompatible(Generator):
                 raise garak.exception.GeneratorBackoffTrigger(msg)
             else:
                 return [None]
+        if response.choices is None:
+            logging.debug(
+                "Did not get a well-formed response, Expected object with populated .choices member, got: '%s'"
+                % repr(response)
+            )
+            return [None]
 
         if is_completion:
             reponse_message_list = [Message(c.text) for c in response.choices]

--- a/tests/_assets/generators/openai.json
+++ b/tests/_assets/generators/openai.json
@@ -63,6 +63,7 @@
          }
       }
    },
+   
    "chat" : {
       "code" : 200,
       "json" : {
@@ -136,5 +137,16 @@
          ],
          "object" : "list"
       }
+   },
+   "azure_chat_null_choices": {
+      "code": 200,
+      "json": {
+         "choices": null,
+         "created": 1724052469,
+         "id": "chatcmpl-9xr5pU1EE4XQw9Bd0QOgkFZ82cAS9",
+         "model": "gpt-4o-2024-05-13",
+         "object": "chat.completion"
+      }
    }
 }
+

--- a/tests/generators/test_azure.py
+++ b/tests/generators/test_azure.py
@@ -73,3 +73,20 @@ def test_azureopenai_chat(respx_mock, openai_compat_mocks):
     assert len(output) == 1
     for item in output:
         assert isinstance(item, Message)
+
+
+@pytest.mark.usefixtures("set_fake_env")
+@pytest.mark.respx(base_url="https://garak.example.com/")
+def test_azureopenai_chat_null_choices(respx_mock, openai_compat_mocks):
+    mock_response = openai_compat_mocks["azure_chat_null_choices"]
+    extended_request = "openai/deployments/"
+    extended_request += DEFAULT_DEPLOYMENT_NAME
+    extended_request += "/chat/completions?api-version="
+    extended_request += AzureOpenAIGenerator.api_version
+    respx_mock.post(extended_request).mock(
+        return_value=httpx.Response(mock_response["code"], json=mock_response["json"])
+    )
+    generator = AzureOpenAIGenerator(name=DEFAULT_DEPLOYMENT_NAME)
+    conv = Conversation([Turn("user", Message("Hello OpenAI!"))])
+    output = generator.generate(conv, 1)
+    assert output == [None]


### PR DESCRIPTION
## What this fixes

`response.choices` can be `None` when endpoints such as AWS Bedrock or Azure
return HTTP 200 with a filtered or refused response. The existing guard only
checked for the absence of the `.choices` attribute via `hasattr()`, so a
`None` value passed through and caused an unhandled `TypeError` that crashed
the entire garak run.

One-line fix: extend the condition to also catch `response.choices is None`,
reusing the existing retry/fallback logic already in place.

Fixes #1525

## Verification

- Reproducing the exact crash requires an AWS or Azure endpoint that returns
  `choices: null`. The fix is a one-line guard on an already-tested code path.
- `python -m pytest tests/generators/ -v` passes.
- `python -m garak --target_type test.Blank --probes dan.Dan_11_0` runs cleanly.