### PR TITLE
Handle unrecognized probes and detectors in report digest generation

### DIFF
--- a/garak/analyze/rebuild_cis.py
+++ b/garak/analyze/rebuild_cis.py
@@ -82,6 +82,7 @@ def rebuild_cis_for_report(
         update_eval_entries_with_ci,
     )
     from garak.analyze.report_digest import append_report_object, build_digest
+    from garak.exception import ReportIncompatibleError
 
     resolved_output = _resolve_output_path(report_file, output_path, overwrite)
     if resolved_output:
@@ -149,6 +150,9 @@ def rebuild_cis_for_report(
 
         print(f"✅ CIs recalculated and written to: {target_file}")
 
+    except ReportIncompatibleError as e:
+        print(f"❌ Report not compatible with this garak install: {e}")
+        return 1
     except ValueError as e:
         print(f"❌ Invalid report data: {e}")
         return 1

--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -9,6 +9,7 @@ import datetime
 import html
 import importlib
 import json
+import logging
 import markdown
 import os
 import pprint
@@ -26,6 +27,7 @@ from garak.data import path as data_path
 import garak.analyze
 import garak.analyze.calibration
 from garak.evaluators.base import CI_DISPLAY_MIN_WIDTH
+from garak.exception import ReportIncompatibleError
 
 if not _config.loaded:
     _config.load_config()
@@ -128,7 +130,15 @@ def _init_populate_result_db(evals, taxonomy=None):
         groups = []
         if taxonomy is not None:
             # get the probe tags
-            tags = garak._plugins.PluginCache.plugin_info(f"probes.{pm}.{pc}")["tags"]
+            try:
+                tags = garak._plugins.PluginCache.plugin_info(f"probes.{pm}.{pc}")[
+                    "tags"
+                ]
+            except (KeyError, TypeError, ValueError) as e:
+                raise ReportIncompatibleError(
+                    f"Report references unknown probe probes.{pm}.{pc}; "
+                    "the report was likely generated with a different garak version"
+                ) from e
             for tag in tags:
                 if tag.split(":")[0] == taxonomy:
                     groups.append(":".join(tag.split(":")[1:]))
@@ -140,7 +150,18 @@ def _init_populate_result_db(evals, taxonomy=None):
         for group in groups:
             cursor.execute(
                 "insert into results values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (pm, group, pc, detector, score, instances, passes, confidence, ci_lower, ci_upper),
+                (
+                    pm,
+                    group,
+                    pc,
+                    detector,
+                    score,
+                    instances,
+                    passes,
+                    confidence,
+                    ci_lower,
+                    ci_upper,
+                ),
             )
 
     return conn, cursor
@@ -252,9 +273,16 @@ def _get_probe_result_summaries(cursor, probe_group) -> List[tuple]:
 
 def _get_probe_info(probe_module, probe_class, absolute_score) -> dict:
     probe_classpath = f"probes.{probe_module}.{probe_class}"
-    probe_plugin_info = garak._plugins.PluginCache.plugin_info(probe_classpath)
-    probe_description = probe_plugin_info["description"]
-    probe_tags = probe_plugin_info["tags"]
+    try:
+        probe_plugin_info = garak._plugins.PluginCache.plugin_info(probe_classpath)
+        probe_description = probe_plugin_info["description"]
+        probe_tags = probe_plugin_info["tags"]
+        probe_tier = probe_plugin_info["tier"]
+    except (KeyError, TypeError, ValueError) as e:
+        raise ReportIncompatibleError(
+            f"Report references unknown probe {probe_classpath}; "
+            "the report was likely generated with a different garak version"
+        ) from e
     probe_plugin_name = f"{probe_module}.{probe_class}"
     return {
         "probe_name": probe_plugin_name,
@@ -263,7 +291,7 @@ def _get_probe_info(probe_module, probe_class, absolute_score) -> dict:
             absolute_score, garak.analyze.ABSOLUTE_DEFCON_BOUNDS
         ),
         "probe_descr": html.escape(probe_description),
-        "probe_tier": probe_plugin_info["tier"],
+        "probe_tier": probe_tier,
         "probe_tags": probe_tags,
     }
 
@@ -275,7 +303,7 @@ def _get_detectors_info(cursor, probe_group: str, probe_class: str) -> List[dict
         (probe_group, probe_class),
     )
     rows = res.fetchall()
-    
+
     return [
         {
             "detector": row[0],
@@ -302,10 +330,16 @@ def _get_probe_detector_details(
     calibration_used = False
     detector = re.sub(r"[^0-9A-Za-z_.]", "", detector)
     detector_module, detector_class = detector.split(".")
-    detector_cache_entry = garak._plugins.PluginCache.plugin_info(
-        f"detectors.{detector_module}.{detector_class}"
-    )
-    detector_description = detector_cache_entry["description"]
+    try:
+        detector_cache_entry = garak._plugins.PluginCache.plugin_info(
+            f"detectors.{detector_module}.{detector_class}"
+        )
+        detector_description = detector_cache_entry["description"]
+    except (KeyError, TypeError, ValueError) as e:
+        raise ReportIncompatibleError(
+            f"Report references unknown detector detectors.{detector_module}.{detector_class}; "
+            "the report was likely generated with a different garak version"
+        ) from e
 
     zscore = calibration.get_z_score(
         probe_module,
@@ -366,10 +400,16 @@ def _get_probe_detector_details(
         result["confidence"] = confidence
         result["absolute_confidence_lower"] = 1.0 - ci_upper  # Inverted
         result["absolute_confidence_upper"] = 1.0 - ci_lower  # Inverted
-        
+
         # Suppress zero-width CIs in HTML display (convert to 0-1 scale)
-        ci_width = abs(result["absolute_confidence_upper"] - result["absolute_confidence_lower"]) * 100
-        result["show_confidence_interval"] = (ci_width > CI_DISPLAY_MIN_WIDTH)
+        ci_width = (
+            abs(
+                result["absolute_confidence_upper"]
+                - result["absolute_confidence_lower"]
+            )
+            * 100
+        )
+        result["show_confidence_interval"] = ci_width > CI_DISPLAY_MIN_WIDTH
 
     return result
 
@@ -595,7 +635,19 @@ if __name__ == "__main__":
     digest = _get_report_digest(report_path)
     if not digest or taxonomy_specified:
         # Rebuild digest when taxonomy is specified, even if one already exists
-        digest = build_digest(report_path)
+        try:
+            digest = build_digest(report_path)
+        except ReportIncompatibleError as e:
+            print(
+                f"Report at {report_path} is not compatible with this garak install: {e}",
+                file=sys.stderr,
+            )
+            print(
+                "No HTML report was generated. "
+                "Regenerate the report with a matching garak version, or install the version that produced it.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         if write_digest_suffix:
             with open(report_path, "a+", encoding="utf-8") as reportfile:
                 append_report_object(reportfile, digest)

--- a/garak/exception.py
+++ b/garak/exception.py
@@ -36,3 +36,7 @@ class ConfigFailure(GarakException):
 
 class PayloadFailure(GarakException):
     """Problem instantiating/using payloads"""
+
+
+class ReportIncompatibleError(GarakException):
+    """Report references plugins unknown to the current garak install; the report is not compatible with this version"""

--- a/tests/analyze/test_report_digest.py
+++ b/tests/analyze/test_report_digest.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import pytest
+
+from garak import _config
+import garak.analyze.report_digest
+from garak.exception import ReportIncompatibleError
+
+
+def _write_report_with_eval(tmp_path, eval_entry):
+    report_path = tmp_path / "unknown_plugin.report.jsonl"
+    with open(
+        "tests/_assets/analyze/test.report.jsonl",
+        encoding="utf-8",
+    ) as f:
+        setup_line = f.readline()
+        init_line = f.readline()
+    with open(report_path, "w", encoding="utf-8") as out:
+        out.write(setup_line)
+        out.write(init_line)
+        out.write(json.dumps(eval_entry, ensure_ascii=False) + "\n")
+    return str(report_path)
+
+
+def test_build_digest_raises_on_unknown_probe(tmp_path) -> None:
+    _config.load_base_config()
+    _config.reporting.taxonomy = "owasp"
+    eval_entry = {
+        "entry_type": "eval",
+        "probe": "does_not_exist.NoSuchProbe",
+        "detector": "always.Pass",
+        "passed": 1,
+        "total_evaluated": 1,
+        "fails": 0,
+        "nones": 0,
+        "total_processed": 1,
+    }
+    report_path = _write_report_with_eval(tmp_path, eval_entry)
+
+    with pytest.raises(ReportIncompatibleError) as exc_info:
+        garak.analyze.report_digest.build_digest(report_path)
+    assert "does_not_exist.NoSuchProbe" in str(exc_info.value)
+
+
+def test_build_digest_raises_on_unknown_detector(tmp_path) -> None:
+    _config.load_base_config()
+    _config.reporting.taxonomy = None
+    eval_entry = {
+        "entry_type": "eval",
+        "probe": "test.Test",
+        "detector": "does_not_exist.NoSuchDetector",
+        "passed": 1,
+        "total_evaluated": 1,
+        "fails": 0,
+        "nones": 0,
+        "total_processed": 1,
+    }
+    report_path = _write_report_with_eval(tmp_path, eval_entry)
+
+    with pytest.raises(ReportIncompatibleError) as exc_info:
+        garak.analyze.report_digest.build_digest(report_path)
+    assert "does_not_exist.NoSuchDetector" in str(exc_info.value)


### PR DESCRIPTION
Fixes #1024
The three PluginCache.plugin_info() call sites in report_digest.py crash with a ValueError when a report references a probe or detector that no longer exists in the current codebase (e.g. due to a rename between versions).
This PR wraps each call in try/except, logs a warning, and continues report generation with placeholder values instead of crashing.
Changes:

_init_populate_result_db (line ~131): falls back to empty tags, grouping the probe under "other"
_get_probe_info (line ~255): uses the classpath as description, empty tags, and None tier
_get_probe_detector_details (line ~305): uses the detector name as its description

Tested with a JSONL file referencing a nonexistent probe class. Before the fix it crashed with ValueError. After the fix it generates a valid HTML report and logs a warning.