### PR TITLE
Enforce soft_probe_prompt_cap in GCGCached probe

### DIFF
--- a/garak/probes/suffix.py
+++ b/garak/probes/suffix.py
@@ -51,6 +51,10 @@ class GCGCached(garak.probes.Probe):
         prompts.append(" ".join([prompt1, suffix]))
         prompts.append(" ".join([prompt2, suffix]))
 
+    def __init__(self, config_root=_config):
+        super().__init__(config_root=config_root)
+        self._prune_data(self.soft_probe_prompt_cap)
+
 
 class GCG(garak.probes.Probe):
     """Greedy Coordinate Gradient probe

--- a/tests/probes/test_probes_suffix.py
+++ b/tests/probes/test_probes_suffix.py
@@ -5,14 +5,15 @@ from garak import _config
 
 
 def test_gcgcached_respects_soft_probe_prompt_cap():
+    cap = 10
     original_cap = _config.run.soft_probe_prompt_cap
-    _config.run.soft_probe_prompt_cap = 10
+    _config.run.soft_probe_prompt_cap = cap
     try:
         from garak.probes.suffix import GCGCached
 
         probe = GCGCached()
         assert (
-            len(probe.prompts) <= 10
-        ), f"GCGCached has {len(probe.prompts)} prompts, expected at most 10"
+            len(probe.prompts) <= cap
+        ), f"GCGCached has {len(probe.prompts)} prompts, expected at most {cap}"
     finally:
         _config.run.soft_probe_prompt_cap = original_cap

--- a/tests/probes/test_probes_suffix.py
+++ b/tests/probes/test_probes_suffix.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Portions Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from garak import _config
+
+
+def test_gcgcached_respects_soft_probe_prompt_cap():
+    original_cap = _config.run.soft_probe_prompt_cap
+    _config.run.soft_probe_prompt_cap = 10
+    try:
+        from garak.probes.suffix import GCGCached
+
+        probe = GCGCached()
+        assert (
+            len(probe.prompts) <= 10
+        ), f"GCGCached has {len(probe.prompts)} prompts, expected at most 10"
+    finally:
+        _config.run.soft_probe_prompt_cap = original_cap


### PR DESCRIPTION
Reference #1562

GCGCached builds its full prompt list at class definition time (13 suffixes × 2 base prompts = 26 prompts) and never consults `run.soft_probe_prompt_cap`. This means setting a cap has no effect on how many prompts GCGCached issues.

This PR adds an `__init__` method that calls `self._prune_data(self.soft_probe_prompt_cap)` after `super().__init__()`, following the same pattern used by `DanInTheWild` in `dan.py`. When the cap is set lower than the total prompt count, prompts are randomly sampled down to the cap.

Verified locally: with `soft_probe_prompt_cap = 10`, GCGCached now produces 10 prompts instead of 26. Added a test in `tests/probes/test_probes_suffix.py` to confirm the behavior.