### PR TITLE
feat(cli): add structured exit codes for proper error signaling

### DIFF
--- a/garak/__main__.py
+++ b/garak/__main__.py
@@ -6,7 +6,7 @@ from garak import cli
 
 
 def main():
-    cli.main(sys.argv[1:])
+    sys.exit(cli.main(sys.argv[1:]))
 
 
 if __name__ == "__main__":

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -36,13 +36,22 @@ def parse_cli_plugin_config(plugin_type, args):
     return opts_cli_config
 
 
-def main(arguments=None) -> None:
-    """Main entry point for garak runs invoked from the CLI"""
+def main(arguments=None) -> int:
+    """Main entry point for garak runs invoked from the CLI.
+
+    Returns an :class:`~garak.exception.ExitCode` integer.
+    """
     import datetime
 
     from garak import __description__
     from garak import _config, _plugins
-    from garak.exception import GarakException
+    from garak.exception import (
+        ExitCode,
+        GarakException,
+        APIKeyMissingError,
+        PluginConfigurationError,
+        ConfigFailure,
+    )
 
     _config.transient.starttime = datetime.datetime.now()
     _config.transient.starttime_iso = _config.transient.starttime.isoformat()
@@ -324,7 +333,7 @@ def main(arguments=None) -> None:
     except FileNotFoundError as e:
         logging.exception(e)
         print(f"❌{e}")
-        exit(1)
+        return ExitCode.CONFIG_ERROR
 
     # extract what was actually passed on CLI; use a masking argparser
     aux_parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS)
@@ -453,7 +462,7 @@ def main(arguments=None) -> None:
     except ValueError as e:
         logging.exception(e)
         print(e)
-        exit(1)  # exit non zero indicated parsing error
+        return ExitCode.USAGE_ERROR
 
     if hasattr(_config.run, "seed") and isinstance(_config.run.seed, int):
         import random
@@ -468,6 +477,7 @@ def main(arguments=None) -> None:
 
     import garak.evaluators
 
+    exit_code: int = ExitCode.SUCCESS
     try:
         has_config_file_or_json = False
         # do a special thing for CLI probe options, generator options
@@ -491,7 +501,7 @@ def main(arguments=None) -> None:
             except Exception as e:
                 logging.error(e)
                 print(e)
-                sys.exit(1)
+                exit_code = ExitCode.RUNTIME_ERROR
             finally:
                 command.end_run()
 
@@ -578,7 +588,7 @@ def main(arguments=None) -> None:
                             print(msg)
             # should this add support for --*_spec entries passed on cli?
             if has_changes:
-                exit(1)  # exit with error code to denote changes
+                exit_code = ExitCode.CONFIG_ERROR
             else:
                 print(
                     "No revisions applied. Please verify options provided for `--fix`"
@@ -687,8 +697,19 @@ def main(arguments=None) -> None:
         logging.exception(e)
         logging.info(msg)
         print(msg)
+        exit_code = ExitCode.INTERRUPTED
+    except (APIKeyMissingError, PluginConfigurationError) as e:
+        logging.exception(e)
+        print(e)
+        exit_code = ExitCode.PLUGIN_ERROR
+    except ConfigFailure as e:
+        logging.exception(e)
+        print(e)
+        exit_code = ExitCode.CONFIG_ERROR
     except (ValueError, GarakException) as e:
         logging.exception(e)
         print(e)
+        exit_code = ExitCode.RUNTIME_ERROR
 
     _config.set_http_lib_agents(prior_user_agents)
+    return exit_code

--- a/garak/exception.py
+++ b/garak/exception.py
@@ -1,6 +1,28 @@
 # SPDX-FileCopyrightText: Portions Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from enum import IntEnum
+
+
+class ExitCode(IntEnum):
+    """Standard exit codes for the garak CLI.
+
+    Follows common Unix conventions:
+    - 0: success
+    - 1: general / runtime error
+    - 2: CLI usage / argument error
+    - 3: configuration error
+    - 4: plugin error (missing API key, bad generator, etc.)
+    - 5: user-initiated interrupt (Ctrl-C / SIGINT)
+    """
+
+    SUCCESS = 0
+    RUNTIME_ERROR = 1
+    USAGE_ERROR = 2
+    CONFIG_ERROR = 3
+    PLUGIN_ERROR = 4
+    INTERRUPTED = 5
+
 
 class GarakException(Exception):
     """Base class for all  garak exceptions"""

--- a/tests/cli/test_cli_exit_codes.py
+++ b/tests/cli/test_cli_exit_codes.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for CLI exit codes (issue #1221)."""
+
+import pytest
+
+from garak import cli
+from garak.exception import ExitCode
+
+
+class TestExitCodeEnum:
+    """Verify the ExitCode enum values follow Unix conventions."""
+
+    def test_success_is_zero(self):
+        assert ExitCode.SUCCESS == 0
+
+    def test_runtime_error_is_one(self):
+        assert ExitCode.RUNTIME_ERROR == 1
+
+    def test_usage_error_is_two(self):
+        assert ExitCode.USAGE_ERROR == 2
+
+    def test_config_error_is_three(self):
+        assert ExitCode.CONFIG_ERROR == 3
+
+    def test_plugin_error_is_four(self):
+        assert ExitCode.PLUGIN_ERROR == 4
+
+    def test_interrupted_is_five(self):
+        assert ExitCode.INTERRUPTED == 5
+
+    def test_exit_codes_are_ints(self):
+        """ExitCode values can be passed directly to sys.exit()."""
+        for code in ExitCode:
+            assert isinstance(code, int)
+            assert isinstance(int(code), int)
+
+
+class TestMainReturnCodes:
+    """Verify cli.main() returns appropriate exit codes."""
+
+    def test_version_returns_success(self):
+        result = cli.main(["--version"])
+        assert result == ExitCode.SUCCESS
+
+    def test_list_probes_returns_success(self):
+        result = cli.main(["--list_probes"])
+        assert result == ExitCode.SUCCESS
+
+    def test_list_detectors_returns_success(self):
+        result = cli.main(["--list_detectors"])
+        assert result == ExitCode.SUCCESS
+
+    def test_list_generators_returns_success(self):
+        result = cli.main(["--list_generators"])
+        assert result == ExitCode.SUCCESS
+
+    def test_list_buffs_returns_success(self):
+        result = cli.main(["--list_buffs"])
+        assert result == ExitCode.SUCCESS
+
+    def test_nothing_to_do_returns_success(self):
+        result = cli.main([])
+        assert result == ExitCode.SUCCESS
+
+    def test_missing_config_file_returns_config_error(self):
+        result = cli.main(["--config", "/nonexistent/path/config.yaml"])
+        assert result == ExitCode.CONFIG_ERROR
+
+    def test_bad_parallel_attempts_returns_usage_error(self):
+        result = cli.main(["--parallel_attempts", "0"])
+        assert result == ExitCode.USAGE_ERROR
+
+    def test_bad_parallel_requests_returns_usage_error(self):
+        result = cli.main(["--parallel_requests", "-1"])
+        assert result == ExitCode.USAGE_ERROR
+
+    def test_bad_bootstrap_iterations_returns_usage_error(self):
+        result = cli.main(["--bootstrap_num_iterations", "-5"])
+        assert result == ExitCode.USAGE_ERROR
+
+    def test_bad_confidence_level_returns_usage_error(self):
+        result = cli.main(["--bootstrap_confidence_level", "1.5"])
+        assert result == ExitCode.USAGE_ERROR
+
+    def test_return_type_is_int(self):
+        result = cli.main(["--version"])
+        assert isinstance(result, int)


### PR DESCRIPTION
## Summary

Closes #1221

Adds an `ExitCode` enum to `garak/exception.py` with well-defined integer codes following common Unix conventions, and updates `cli.main()` to return them instead of using bare `exit(1)` calls or returning `None`.

## Exit Codes

| Code | Name | When |
|------|------|------|
| 0 | `SUCCESS` | Normal completion (list, version, scan, etc.) |
| 1 | `RUNTIME_ERROR` | General / uncaught errors, `GarakException` |
| 2 | `USAGE_ERROR` | Invalid CLI arguments or parameter values |
| 3 | `CONFIG_ERROR` | Missing/invalid config files, fixer migrations |
| 4 | `PLUGIN_ERROR` | Missing API keys, bad generator, plugin config |
| 5 | `INTERRUPTED` | User-initiated Ctrl-C / SIGINT |

## Changes

- **`garak/exception.py`**: Added `ExitCode(IntEnum)` with the six codes above
- **`garak/cli.py`**: `main()` now returns an `ExitCode` int instead of `None`; replaced bare `exit(1)` calls with typed returns; catches specific exception subclasses (`APIKeyMissingError`, `PluginConfigurationError`, `ConfigFailure`) before the generic `GarakException` handler for more precise exit codes
- **`garak/__main__.py`**: Propagates `cli.main()` return value to `sys.exit()`
- **`tests/cli/test_cli_exit_codes.py`**: Tests for enum values, return types, and exit codes for success paths and various failure scenarios

## Motivation

As noted in #1221, proper exit codes help wrapping entities (CI pipelines, orchestration tools, garak-as-a-service) distinguish between different failure modes without parsing stderr output. The codes follow the common Unix convention where 0 = success, 1 = general error, and 2 = usage error.