### PR TITLE
fix: modernize Cohere generator (#1384)

### DIFF
--- a/garak/generators/cohere.py
+++ b/garak/generators/cohere.py
@@ -1,21 +1,19 @@
 """Cohere AI model support
 
-Support for Cohere's text generation API. A model name must be specified
-(e.g. 'command-r-plus'). The legacy 'command' model default has been removed
-as Cohere has deprecated it. Set the COHERE_API_KEY environment variable.
+Support for Cohere's text generation API using ClientV2 chat interface.
+A model name must be specified (e.g. 'command-r-plus'). The legacy 'command'
+model default has been removed as Cohere has deprecated it.
+Set the COHERE_API_KEY environment variable.
 
 NOTE: As of Cohere v5.0.0+, the generate API is legacy and chat API is recommended.
-This implementation follows Cohere's official migration guide:
-
-- For v1 API: Uses cohere.Client() to maintain full backward compatibility
-- For v2 API: Uses cohere.ClientV2() for the recommended chat interface
+This implementation uses cohere.ClientV2() exclusively.
 """
 
 import logging
+import warnings
 from typing import List, Union
 
 import backoff
-import tqdm
 
 from garak import _config
 from garak.attempt import Message, Conversation
@@ -26,19 +24,13 @@ from garak.exception import (
 )
 from garak.generators.base import Generator
 
-COHERE_GENERATION_LIMIT = (
-    5  # c.f. https://docs.cohere.com/reference/generate 18 may 2023
-)
-
 
 class CohereGenerator(Generator):
     """Interface to Cohere's python library for their text2text model.
 
     Expects API key in COHERE_API_KEY environment variable.
 
-    Following Cohere's migration guide, this implementation:
-    - For api_version="v1": Uses cohere.Client() with generate() API (supports multiple generations)
-    - For api_version="v2": Uses cohere.ClientV2() with chat() API (recommended, requires multiple API calls)
+    Uses cohere.ClientV2() with the chat() API (recommended in Cohere v5+).
     """
 
     ENV_VAR = "COHERE_API_KEY"
@@ -48,9 +40,6 @@ class CohereGenerator(Generator):
         "p": 0.75,
         "frequency_penalty": 0.0,
         "presence_penalty": 0.0,
-        "stop": [],  # Used for end_sequences in v1 API
-        "preset": None,  # Only used with v1 API
-        "api_version": "v2",  # "v1" for legacy generate API, "v2" for chat API (recommended)
     }
 
     extra_dependency_names = ["cohere"]
@@ -71,166 +60,88 @@ class CohereGenerator(Generator):
                 "The 'command' model is deprecated and will be retired."
             )
 
-        logging.debug(
-            "Cohere generation request limit capped at %s", COHERE_GENERATION_LIMIT
-        )
-
-        # Validate api_version
-        if self.api_version not in ["v1", "v2"]:
-            logging.warning(
-                f"Invalid api_version '{self.api_version}'. Using 'v2' instead."
+        if hasattr(self, "api_version"):
+            warnings.warn(
+                "api_version parameter is deprecated and ignored. "
+                "All requests now use the Cohere v2 chat API (ClientV2).",
+                DeprecationWarning,
+                stacklevel=2,
             )
-            self.api_version = "v2"
 
         self._load_unsafe()
 
     def _load_unsafe(self):
-        """Initialize the Cohere API client based on api_version.
+        """Initialize the Cohere ClientV2 API client.
 
         Called from __init__ and restored via Configurable.__setstate__ on deserialization.
         """
-        if self.api_version == "v1":
-            self.generator = self.cohere.Client(api_key=self.api_key)
-        else:  # api_version == "v2"
-            self.generator = self.cohere.ClientV2(api_key=self.api_key)
+        self.generator = self.cohere.ClientV2(api_key=self.api_key)
 
     @backoff.on_exception(backoff.fibo, GeneratorBackoffTrigger, max_value=70)
-    def _call_cohere_api(self, prompt_text, request_size=COHERE_GENERATION_LIMIT):
-        """Empty prompts raise API errors (e.g. invalid request: prompt must be at least 1 token long).
-        We catch these using the ApiError base class in Cohere v5+.
-        Filtering exceptions based on message instead of type, in backoff, isn't immediately obvious
-        - on the other hand blank prompt / RTP shouldn't hang forever
-        """
-        if not prompt_text:
-            return [Message("")] * request_size
-        else:
-            if self.api_version == "v2":
-                # Use chat API with ClientV2 (recommended in v5+)
-                responses = []
-                # Chat API doesn't support num_generations, so we need to make multiple calls
-                for _ in range(request_size):
-                    try:
-                        response = self.generator.chat(
-                            model=self.name,
-                            messages=prompt_text,
-                            temperature=self.temperature,
-                            max_tokens=self.max_tokens,
-                            k=self.k,
-                            p=self.p,
-                            frequency_penalty=self.frequency_penalty,
-                            presence_penalty=self.presence_penalty,
-                            # Note: stop_sequences/end_sequences, logit_bias, truncate, and preset
-                            # are not supported in the Chat endpoint per Cohere migration guide
-                        )
-
-                        # Extract text from message content
-                        if hasattr(response, "message") and hasattr(
-                            response.message, "content"
-                        ):
-                            # Get the first text content item
-                            for content_item in response.message.content:
-                                if hasattr(content_item, "text"):
-                                    responses.append(content_item.text)
-                                    break
-                            else:
-                                # No text content found
-                                logging.warning(
-                                    "No text content found in chat response"
-                                )
-                                responses.append(str(response))
-                        else:
-                            logging.warning(
-                                "Chat response structure doesn't match expected format"
-                            )
-                            responses.append(str(response))
-                    except Exception as e:
-                        if isinstance(e, self.cohere.errors.NotFoundError):
-                            raise BadGeneratorException(
-                                f"Cohere model '{self.name}' not found (404). "
-                                "Check the model name is valid."
-                            ) from e
-
-                        backoff_exception_types = (
-                            self.cohere.errors.GatewayTimeoutError,
-                            self.cohere.errors.TooManyRequestsError,
-                            self.cohere.errors.ServiceUnavailableError,
-                            self.cohere.errors.InternalServerError,
-                        )
-                        for backoff_exception in backoff_exception_types:
-                            if isinstance(e, backoff_exception):
-                                raise GeneratorBackoffTrigger from e
-                        logging.error(f"Chat API error: {e}")
-                        responses.append(None)
-
-                # Ensure we return the correct number of responses
-                if len(responses) < request_size:
-                    responses.extend([None] * (request_size - len(responses)))
-                return responses
-            else:  # api_version == "v1"
-                # Use legacy generate API with cohere.Client()
-                try:
-                    message = prompt_text[-1]["content"]
-
-                    response = self.generator.generate(
-                        model=self.name,
-                        prompt=message,
-                        temperature=self.temperature,
-                        num_generations=request_size,
-                        max_tokens=self.max_tokens,
-                        preset=self.preset,
-                        k=self.k,
-                        p=self.p,
-                        frequency_penalty=self.frequency_penalty,
-                        presence_penalty=self.presence_penalty,
-                        end_sequences=self.stop,
-                    )
-
-                    # Handle response based on structure
-                    if hasattr(response, "generations"):
-                        return [gen.text for gen in response.generations]
-                    elif isinstance(response, list):
-                        return [g.text for g in response]
-                    elif hasattr(response, "text"):
-                        return [response.text]
-                    else:
-                        return [str(response)]
-                except Exception as e:
-                    if isinstance(e, self.cohere.errors.NotFoundError):
-                        raise BadGeneratorException(
-                            f"Cohere model '{self.name}' not found (404). "
-                            "Check the model name is valid."
-                        ) from e
-
-                    backoff_exception_types = (
-                        self.cohere.errors.GatewayTimeoutError,
-                        self.cohere.errors.TooManyRequestsError,
-                        self.cohere.errors.ServiceUnavailableError,
-                        self.cohere.errors.InternalServerError,
-                    )
-                    for backoff_exception in backoff_exception_types:
-                        if isinstance(e, backoff_exception):
-                            raise GeneratorBackoffTrigger from e
-                    logging.error(f"Generate API error: {e}")
-                    return [None] * request_size
-
     def _call_model(
         self, prompt: Conversation, generations_this_call: int = 1
     ) -> List[Union[Message, None]]:
-        """Cohere's _call_model does sub-batching before calling,
-        and so manages chunking internally"""
-        quotient, remainder = divmod(generations_this_call, COHERE_GENERATION_LIMIT)
-        request_sizes = [COHERE_GENERATION_LIMIT] * quotient
-        if remainder:
-            request_sizes += [remainder]
-        raw_outputs = []
-        generation_iterator = tqdm.tqdm(request_sizes, leave=False)
-        generation_iterator.set_description(self.fullname)
-        for request_size in generation_iterator:
-            raw_outputs += self._call_cohere_api(
-                self._conversation_to_list(prompt), request_size=request_size
-            )
-        # Wrap str results in Message; preserve None as-is
-        return [Message(o) if isinstance(o, str) else o for o in raw_outputs]
+        """Call the Cohere v2 chat API.
+
+        Empty prompts return empty Message objects.
+        """
+        prompt_text = self._conversation_to_list(prompt)
+
+        if not prompt_text:
+            return [Message("")] * generations_this_call
+
+        responses = []
+        for _ in range(generations_this_call):
+            try:
+                response = self.generator.chat(
+                    model=self.name,
+                    messages=prompt_text,
+                    temperature=self.temperature,
+                    max_tokens=self.max_tokens,
+                    k=self.k,
+                    p=self.p,
+                    frequency_penalty=self.frequency_penalty,
+                    presence_penalty=self.presence_penalty,
+                )
+
+                # Extract text from message content
+                if hasattr(response, "message") and hasattr(
+                    response.message, "content"
+                ):
+                    for content_item in response.message.content:
+                        if hasattr(content_item, "text"):
+                            responses.append(Message(content_item.text))
+                            break
+                    else:
+                        logging.warning(
+                            "No text content found in chat response"
+                        )
+                        responses.append(None)
+                else:
+                    logging.warning(
+                        "Chat response structure doesn't match expected format"
+                    )
+                    responses.append(None)
+            except Exception as e:
+                if isinstance(e, self.cohere.errors.NotFoundError):
+                    raise BadGeneratorException(
+                        f"Cohere model '{self.name}' not found (404). "
+                        "Check the model name is valid."
+                    ) from e
+
+                backoff_exception_types = (
+                    self.cohere.errors.GatewayTimeoutError,
+                    self.cohere.errors.TooManyRequestsError,
+                    self.cohere.errors.ServiceUnavailableError,
+                    self.cohere.errors.InternalServerError,
+                )
+                for backoff_exception in backoff_exception_types:
+                    if isinstance(e, backoff_exception):
+                        raise GeneratorBackoffTrigger from e
+                logging.error(f"Chat API error: {e}")
+                responses.append(None)
+
+        return responses
 
 
 DEFAULT_CLASS = "CohereGenerator"

--- a/garak/generators/cohere.py
+++ b/garak/generators/cohere.py
@@ -82,21 +82,17 @@ class CohereGenerator(Generator):
             )
             self.api_version = "v2"
 
-        self._load_client()
+        self._load_unsafe()
 
-    def _load_client(self):
+    def _load_unsafe(self):
         """Initialize the Cohere API client based on api_version.
 
-        Called from __init__ and restored via __setstate__ on deserialization.
+        Called from __init__ and restored via Configurable.__setstate__ on deserialization.
         """
         if self.api_version == "v1":
             self.generator = self.cohere.Client(api_key=self.api_key)
         else:  # api_version == "v2"
             self.generator = self.cohere.ClientV2(api_key=self.api_key)
-
-    def __setstate__(self, d):
-        super().__setstate__(d)
-        self._load_client()
 
     @backoff.on_exception(backoff.fibo, GeneratorBackoffTrigger, max_value=70)
     def _call_cohere_api(self, prompt_text, request_size=COHERE_GENERATION_LIMIT):

--- a/garak/generators/cohere.py
+++ b/garak/generators/cohere.py
@@ -1,9 +1,8 @@
 """Cohere AI model support
 
-Support for Cohere's text generation API. Uses the command model by default,
-but just supply the name of another either on the command line or as the
-constructor param if you want to use that. You'll need to set an environment
-variable called COHERE_API_KEY to your Cohere API key, for this generator.
+Support for Cohere's text generation API. A model name must be specified
+(e.g. 'command-r-plus'). The legacy 'command' model default has been removed
+as Cohere has deprecated it. Set the COHERE_API_KEY environment variable.
 
 NOTE: As of Cohere v5.0.0+, the generate API is legacy and chat API is recommended.
 This implementation follows Cohere's official migration guide:
@@ -20,7 +19,11 @@ import tqdm
 
 from garak import _config
 from garak.attempt import Message, Conversation
-from garak.exception import GeneratorBackoffTrigger
+from garak.exception import (
+    BadGeneratorException,
+    GeneratorBackoffTrigger,
+    TargetNameMissingError,
+)
 from garak.generators.base import Generator
 
 COHERE_GENERATION_LIMIT = (
@@ -54,11 +57,19 @@ class CohereGenerator(Generator):
 
     generator_family_name = "Cohere"
 
-    def __init__(self, name="command", config_root=_config):
+    _unsafe_attributes = ["generator"]
+
+    def __init__(self, name="", config_root=_config):
         self.name = name
         self.fullname = f"Cohere {self.name}"
 
         super().__init__(self.name, config_root=config_root)
+
+        if not self.name:
+            raise TargetNameMissingError(
+                "Model name is required for Cohere (e.g. 'command-r-plus'). "
+                "The 'command' model is deprecated and will be retired."
+            )
 
         logging.debug(
             "Cohere generation request limit capped at %s", COHERE_GENERATION_LIMIT
@@ -71,12 +82,21 @@ class CohereGenerator(Generator):
             )
             self.api_version = "v2"
 
-        # Initialize appropriate client based on API version
-        # Following Cohere's guidance to use Client() for v1 and ClientV2() for v2
+        self._load_client()
+
+    def _load_client(self):
+        """Initialize the Cohere API client based on api_version.
+
+        Called from __init__ and restored via __setstate__ on deserialization.
+        """
         if self.api_version == "v1":
             self.generator = self.cohere.Client(api_key=self.api_key)
         else:  # api_version == "v2"
             self.generator = self.cohere.ClientV2(api_key=self.api_key)
+
+    def __setstate__(self, d):
+        super().__setstate__(d)
+        self._load_client()
 
     @backoff.on_exception(backoff.fibo, GeneratorBackoffTrigger, max_value=70)
     def _call_cohere_api(self, prompt_text, request_size=COHERE_GENERATION_LIMIT):
@@ -128,6 +148,11 @@ class CohereGenerator(Generator):
                             )
                             responses.append(str(response))
                     except Exception as e:
+                        if isinstance(e, self.cohere.errors.NotFoundError):
+                            raise BadGeneratorException(
+                                f"Cohere model '{self.name}' not found (404). "
+                                "Check the model name is valid."
+                            ) from e
 
                         backoff_exception_types = (
                             self.cohere.errors.GatewayTimeoutError,
@@ -137,7 +162,7 @@ class CohereGenerator(Generator):
                         )
                         for backoff_exception in backoff_exception_types:
                             if isinstance(e, backoff_exception):
-                                raise GeneratorBackoffTrigger from e  # bubble up ApiError for backoff handling
+                                raise GeneratorBackoffTrigger from e
                         logging.error(f"Chat API error: {e}")
                         responses.append(None)
 
@@ -147,7 +172,6 @@ class CohereGenerator(Generator):
                 return responses
             else:  # api_version == "v1"
                 # Use legacy generate API with cohere.Client()
-                # Following Cohere's guidance for full backward compatibility
                 try:
                     message = prompt_text[-1]["content"]
 
@@ -167,24 +191,29 @@ class CohereGenerator(Generator):
 
                     # Handle response based on structure
                     if hasattr(response, "generations"):
-                        # Handle the v5+ API response format
                         return [gen.text for gen in response.generations]
+                    elif isinstance(response, list):
+                        return [g.text for g in response]
+                    elif hasattr(response, "text"):
+                        return [response.text]
                     else:
-                        # Try to handle other possible response formats
-                        try:
-                            if isinstance(response, list):
-                                return [g.text for g in response]
-                            elif hasattr(response, "text"):
-                                return [response.text]
-                            else:
-                                # Last resort - try to convert response to string
-                                return [str(response)]
-                        except RuntimeError as e:
-                            logging.error(
-                                f"Failed to extract text from Cohere response: {e}"
-                            )
-                            return [None] * request_size
-                except RuntimeError as e:
+                        return [str(response)]
+                except Exception as e:
+                    if isinstance(e, self.cohere.errors.NotFoundError):
+                        raise BadGeneratorException(
+                            f"Cohere model '{self.name}' not found (404). "
+                            "Check the model name is valid."
+                        ) from e
+
+                    backoff_exception_types = (
+                        self.cohere.errors.GatewayTimeoutError,
+                        self.cohere.errors.TooManyRequestsError,
+                        self.cohere.errors.ServiceUnavailableError,
+                        self.cohere.errors.InternalServerError,
+                    )
+                    for backoff_exception in backoff_exception_types:
+                        if isinstance(e, backoff_exception):
+                            raise GeneratorBackoffTrigger from e
                     logging.error(f"Generate API error: {e}")
                     return [None] * request_size
 
@@ -197,14 +226,15 @@ class CohereGenerator(Generator):
         request_sizes = [COHERE_GENERATION_LIMIT] * quotient
         if remainder:
             request_sizes += [remainder]
-        outputs = []
+        raw_outputs = []
         generation_iterator = tqdm.tqdm(request_sizes, leave=False)
         generation_iterator.set_description(self.fullname)
         for request_size in generation_iterator:
-            outputs += self._call_cohere_api(
+            raw_outputs += self._call_cohere_api(
                 self._conversation_to_list(prompt), request_size=request_size
             )
-        return outputs
+        # Wrap str results in Message; preserve None as-is
+        return [Message(o) if isinstance(o, str) else o for o in raw_outputs]
 
 
 DEFAULT_CLASS = "CohereGenerator"

--- a/tests/generators/test_cohere.py
+++ b/tests/generators/test_cohere.py
@@ -45,6 +45,35 @@ def set_fake_env():
 
 
 @pytest.fixture
+def cohere_config_root():
+    """Provide a config_root dict for CohereGenerator instantiation."""
+    return {
+        "generators": {
+            "cohere": {
+                "CohereGenerator": {
+                    "name": DEFAULT_MODEL_NAME,
+                }
+            }
+        }
+    }
+
+
+@pytest.fixture
+def cohere_v1_config_root():
+    """Provide a config_root dict for CohereGenerator with v1 API."""
+    return {
+        "generators": {
+            "cohere": {
+                "CohereGenerator": {
+                    "name": DEFAULT_MODEL_NAME,
+                    "api_version": "v1",
+                }
+            }
+        }
+    }
+
+
+@pytest.fixture
 def cohere_mock_responses():
     """Provide mock HTTP response specs for Cohere endpoints."""
     return {
@@ -82,9 +111,9 @@ def mock_cohere_endpoint(respx_mock, path, spec):
 # ─── Instantiation & Defaults ─────────────────────────────────────────
 
 
-def test_cohere_instantiation():
-    # Test v2 (default) with explicit model name
-    gen_v2 = CohereGenerator(name=DEFAULT_MODEL_NAME)
+def test_cohere_instantiation(cohere_config_root):
+    # Test v2 (default) with config_root
+    gen_v2 = CohereGenerator(config_root=cohere_config_root)
     assert gen_v2.name == DEFAULT_MODEL_NAME
     assert gen_v2.api_key == "fake-api-key"
     assert hasattr(gen_v2, "generator")
@@ -97,19 +126,19 @@ def test_cohere_missing_model_name():
         CohereGenerator()
 
 
-def test_cohere_missing_api_key():
+def test_cohere_missing_api_key(cohere_config_root):
     var = CohereGenerator.ENV_VAR
     saved = os.environ.pop(var, None)
     try:
         with pytest.raises(APIKeyMissingError):
-            CohereGenerator(name=DEFAULT_MODEL_NAME)
+            CohereGenerator(config_root=cohere_config_root)
     finally:
         if saved is not None:
             os.environ[var] = saved
 
 
-def test_cohere_default_parameters():
-    gen = CohereGenerator(name=DEFAULT_MODEL_NAME)
+def test_cohere_default_parameters(cohere_config_root):
+    gen = CohereGenerator(config_root=cohere_config_root)
     assert gen.api_version == "v2"  # Default should be v2 (chat API)
     assert gen.temperature == CohereGenerator.DEFAULT_PARAMS["temperature"]
     assert gen.max_tokens == CohereGenerator.DEFAULT_PARAMS["max_tokens"]
@@ -120,46 +149,50 @@ def test_cohere_default_parameters():
 # ─── API Version Tests ─────────────────────────────────────────────────────────
 
 
-def test_api_version_validation():
+def test_api_version_validation(cohere_config_root, cohere_v1_config_root):
     # Test invalid api_version gets corrected to v2
-    gen = CohereGenerator(name=DEFAULT_MODEL_NAME)
-    gen.api_version = "invalid"
-    gen.__init__(name=DEFAULT_MODEL_NAME)
+    invalid_config = {
+        "generators": {
+            "cohere": {
+                "CohereGenerator": {
+                    "name": DEFAULT_MODEL_NAME,
+                    "api_version": "invalid",
+                }
+            }
+        }
+    }
+    gen = CohereGenerator(config_root=invalid_config)
     assert gen.api_version == "v2"
 
     # Test v1 is accepted
-    gen = CohereGenerator(name=DEFAULT_MODEL_NAME)
-    gen.api_version = "v1"
-    gen.__init__(name=DEFAULT_MODEL_NAME)
+    gen = CohereGenerator(config_root=cohere_v1_config_root)
     assert gen.api_version == "v1"
 
     # Test v2 is accepted
-    gen = CohereGenerator(name=DEFAULT_MODEL_NAME)
-    gen.api_version = "v2"
-    gen.__init__(name=DEFAULT_MODEL_NAME)
+    gen = CohereGenerator(config_root=cohere_config_root)
     assert gen.api_version == "v2"
 
 
-# ─── _load_client Tests ──────────────────────────────────────────────
+# ─── _load_unsafe Tests ──────────────────────────────────────────────
 
 
-def test_load_client_v1():
-    gen = CohereGenerator(name=DEFAULT_MODEL_NAME)
+def test_load_unsafe_v1(cohere_config_root):
+    gen = CohereGenerator(config_root=cohere_config_root)
     gen.api_version = "v1"
-    gen._load_client()
+    gen._load_unsafe()
     assert isinstance(gen.generator, cohere.Client)
 
 
-def test_load_client_v2():
-    gen = CohereGenerator(name=DEFAULT_MODEL_NAME)
+def test_load_unsafe_v2(cohere_config_root):
+    gen = CohereGenerator(config_root=cohere_config_root)
     gen.api_version = "v2"
-    gen._load_client()
+    gen._load_unsafe()
     assert isinstance(gen.generator, cohere.ClientV2)
 
 
-def test_serialization_restores_client():
-    """Pickling and unpickling should restore the Cohere client."""
-    gen = CohereGenerator(name=DEFAULT_MODEL_NAME)
+def test_serialization_restores_client(cohere_config_root):
+    """Pickling and unpickling should restore the Cohere client via _load_unsafe."""
+    gen = CohereGenerator(config_root=cohere_config_root)
     data = pickle.dumps(gen)
     restored = pickle.loads(data)
     assert hasattr(restored, "generator")
@@ -171,13 +204,11 @@ def test_serialization_restores_client():
 
 
 @pytest.mark.respx(base_url=COHERE_API_BASE)
-def test_cohere_generate_api_respx(respx_mock, cohere_mock_responses):
+def test_cohere_generate_api_respx(respx_mock, cohere_mock_responses, cohere_v1_config_root):
     mock_cohere_endpoint(
         respx_mock, "/v1/generate", cohere_mock_responses["generate_response"]
     )
-    gen = CohereGenerator(name=DEFAULT_MODEL_NAME)
-    gen.api_version = "v1"
-    gen._load_client()
+    gen = CohereGenerator(config_root=cohere_v1_config_root)
     conv = Conversation([Turn("user", Message("Test prompt"))])
     result = gen.generate(conv, generations_this_call=1)
 
@@ -209,13 +240,11 @@ def test_cohere_generate_api_respx(respx_mock, cohere_mock_responses):
     ],
 )
 def test_cohere_chat_api_respx(
-    respx_mock, cohere_mock_responses, response_key, expect_error_str
+    respx_mock, cohere_mock_responses, cohere_config_root, response_key, expect_error_str
 ):
     spec = cohere_mock_responses[response_key]
     mock_cohere_endpoint(respx_mock, "/v2/chat", spec)
-    gen = CohereGenerator(name=DEFAULT_MODEL_NAME)
-    gen.api_version = "v2"
-    gen._load_client()
+    gen = CohereGenerator(config_root=cohere_config_root)
     conv = Conversation([Turn("user", Message("Test prompt"))])
     result = gen.generate(conv)
 
@@ -239,10 +268,11 @@ def test_cohere_chat_api_respx(
 
 @pytest.mark.respx(base_url=COHERE_API_BASE)
 def test_chat_api_404_raises_bad_generator(respx_mock, cohere_mock_responses):
+    config_root = {
+        "generators": {"cohere": {"CohereGenerator": {"name": "nonexistent-model"}}}
+    }
     mock_cohere_endpoint(respx_mock, "/v2/chat", cohere_mock_responses["not_found_response"])
-    gen = CohereGenerator(name="nonexistent-model")
-    gen.api_version = "v2"
-    gen._load_client()
+    gen = CohereGenerator(config_root=config_root)
     conv = Conversation([Turn("user", Message("Test prompt"))])
     with pytest.raises(BadGeneratorException):
         gen.generate(conv)
@@ -250,10 +280,11 @@ def test_chat_api_404_raises_bad_generator(respx_mock, cohere_mock_responses):
 
 @pytest.mark.respx(base_url=COHERE_API_BASE)
 def test_generate_api_404_raises_bad_generator(respx_mock, cohere_mock_responses):
+    config_root = {
+        "generators": {"cohere": {"CohereGenerator": {"name": "nonexistent-model", "api_version": "v1"}}}
+    }
     mock_cohere_endpoint(respx_mock, "/v1/generate", cohere_mock_responses["not_found_response"])
-    gen = CohereGenerator(name="nonexistent-model")
-    gen.api_version = "v1"
-    gen._load_client()
+    gen = CohereGenerator(config_root=config_root)
     conv = Conversation([Turn("user", Message("Test prompt"))])
     with pytest.raises(BadGeneratorException):
         gen.generate(conv)
@@ -262,15 +293,13 @@ def test_generate_api_404_raises_bad_generator(respx_mock, cohere_mock_responses
 # ─── Logging on Error Variants ─────────────────────────────────────────
 
 
-def test_chat_response_logs_warning(respx_mock, cohere_mock_responses, caplog):
+def test_chat_response_logs_warning(respx_mock, cohere_mock_responses, cohere_config_root, caplog):
     caplog.set_level(logging.WARNING)
     mock_cohere_endpoint(
         respx_mock, "/v2/chat", cohere_mock_responses["missing_content_response"]
     )
 
-    gen = CohereGenerator(name=DEFAULT_MODEL_NAME)
-    gen.api_version = "v2"
-    gen._load_client()
+    gen = CohereGenerator(config_root=cohere_config_root)
     caplog.clear()
 
     conv = Conversation([Turn("user", Message("Test prompt"))])
@@ -283,10 +312,10 @@ def test_chat_response_logs_warning(respx_mock, cohere_mock_responses, caplog):
 
 
 @pytest.mark.respx(base_url=COHERE_API_BASE)
-def test_generate_returns_message_objects(respx_mock, cohere_mock_responses):
+def test_generate_returns_message_objects(respx_mock, cohere_mock_responses, cohere_config_root):
     """All non-None results from generate() should be Message objects."""
     mock_cohere_endpoint(respx_mock, "/v2/chat", cohere_mock_responses["chat_response"])
-    gen = CohereGenerator(name=DEFAULT_MODEL_NAME)
+    gen = CohereGenerator(config_root=cohere_config_root)
     conv = Conversation([Turn("user", Message("Test prompt"))])
     result = gen.generate(conv)
     for item in result:
@@ -314,7 +343,10 @@ def restore_real_api_key():
 @pytest.mark.skipif(not _has_cohere_key, reason="COHERE_API_KEY not set")
 def test_live_chat_api_output_format(restore_real_api_key):
     """Verify live chat API (v2) returns Message objects with non-empty text."""
-    gen = CohereGenerator(name=LIVE_MODEL)
+    config_root = {
+        "generators": {"cohere": {"CohereGenerator": {"name": LIVE_MODEL}}}
+    }
+    gen = CohereGenerator(config_root=config_root)
     assert gen.api_version == "v2"
     conv = Conversation([Turn("user", Message("Say hello in one word."))])
     result = gen.generate(conv, generations_this_call=1)
@@ -332,9 +364,10 @@ def test_live_v1_api_rejects_new_model(restore_real_api_key):
     This verifies that the 404 handling correctly raises BadGeneratorException
     rather than silently returning None.
     """
-    gen = CohereGenerator(name=LIVE_MODEL)
-    gen.api_version = "v1"
-    gen._load_client()
+    config_root = {
+        "generators": {"cohere": {"CohereGenerator": {"name": LIVE_MODEL, "api_version": "v1"}}}
+    }
+    gen = CohereGenerator(config_root=config_root)
     conv = Conversation([Turn("user", Message("Say hello in one word."))])
     with pytest.raises(BadGeneratorException):
         gen.generate(conv, generations_this_call=1)

--- a/tests/generators/test_cohere.py
+++ b/tests/generators/test_cohere.py
@@ -291,3 +291,50 @@ def test_generate_returns_message_objects(respx_mock, cohere_mock_responses):
     result = gen.generate(conv)
     for item in result:
         assert item is None or isinstance(item, Message)
+
+
+# ─── Live Endpoint Tests ─────────────────────────────────────────────
+# These tests require a valid COHERE_API_KEY and are skipped in CI.
+
+LIVE_MODEL = "command-a-03-2025"
+
+_real_cohere_key = os.environ.get("COHERE_API_KEY", "")
+_has_cohere_key = _real_cohere_key not in (None, "", "fake-api-key")
+
+
+@pytest.fixture
+def restore_real_api_key():
+    """Temporarily restore the real API key for live tests."""
+    var = CohereGenerator.ENV_VAR
+    os.environ[var] = _real_cohere_key
+    yield
+    os.environ[var] = "fake-api-key"
+
+
+@pytest.mark.skipif(not _has_cohere_key, reason="COHERE_API_KEY not set")
+def test_live_chat_api_output_format(restore_real_api_key):
+    """Verify live chat API (v2) returns Message objects with non-empty text."""
+    gen = CohereGenerator(name=LIVE_MODEL)
+    assert gen.api_version == "v2"
+    conv = Conversation([Turn("user", Message("Say hello in one word."))])
+    result = gen.generate(conv, generations_this_call=1)
+
+    assert len(result) == 1
+    assert isinstance(result[0], Message)
+    assert isinstance(result[0].text, str)
+    assert len(result[0].text) > 0
+
+
+@pytest.mark.skipif(not _has_cohere_key, reason="COHERE_API_KEY not set")
+def test_live_v1_api_rejects_new_model(restore_real_api_key):
+    """Newer models are not available on the legacy v1 generate API.
+
+    This verifies that the 404 handling correctly raises BadGeneratorException
+    rather than silently returning None.
+    """
+    gen = CohereGenerator(name=LIVE_MODEL)
+    gen.api_version = "v1"
+    gen._load_client()
+    conv = Conversation([Turn("user", Message("Say hello in one word."))])
+    with pytest.raises(BadGeneratorException):
+        gen.generate(conv, generations_this_call=1)

--- a/tests/generators/test_cohere.py
+++ b/tests/generators/test_cohere.py
@@ -1,24 +1,25 @@
 import os
 import json
 import logging
+import pickle
 import pytest
 import httpx
 
 from garak.attempt import Message, Turn, Conversation
-from garak.generators.cohere import CohereGenerator, COHERE_GENERATION_LIMIT
-from garak.exception import APIKeyMissingError
+from garak.generators.cohere import CohereGenerator
+from garak.exception import APIKeyMissingError, BadGeneratorException, TargetNameMissingError
 
 try:
     import cohere
 
-except:
+except Exception:
     pytest.skip(
         "couldn't import cohere, skipping cohere tests", allow_module_level=True
     )
 
 
 # Default model name and API URLs
-DEFAULT_MODEL_NAME = "command"
+DEFAULT_MODEL_NAME = "command-r-plus"
 COHERE_API_BASE = "https://api.cohere.com"
 COHERE_V1 = f"{COHERE_API_BASE}/v1"
 COHERE_V2 = f"{COHERE_API_BASE}/v2"
@@ -63,6 +64,10 @@ def cohere_mock_responses():
             "code": 200,
             "json": {"message": {}},  # no content
         },
+        "not_found_response": {
+            "code": 404,
+            "json": {"message": "model not found"},
+        },
     }
 
 
@@ -78,19 +83,18 @@ def mock_cohere_endpoint(respx_mock, path, spec):
 
 
 def test_cohere_instantiation():
-    # Test v2 (default)
-    gen_v2 = CohereGenerator()
+    # Test v2 (default) with explicit model name
+    gen_v2 = CohereGenerator(name=DEFAULT_MODEL_NAME)
     assert gen_v2.name == DEFAULT_MODEL_NAME
     assert gen_v2.api_key == "fake-api-key"
     assert hasattr(gen_v2, "generator")
     assert gen_v2.api_version == "v2"
 
-    # Test v1
-    gen_v1 = CohereGenerator()
-    gen_v1.api_version = "v1"
-    # Re-initialize the generator with v1
-    gen_v1.__init__()
-    assert gen_v1.api_version == "v1"
+
+def test_cohere_missing_model_name():
+    """Model name is required; omitting it raises TargetNameMissingError."""
+    with pytest.raises(TargetNameMissingError):
+        CohereGenerator()
 
 
 def test_cohere_missing_api_key():
@@ -98,14 +102,14 @@ def test_cohere_missing_api_key():
     saved = os.environ.pop(var, None)
     try:
         with pytest.raises(APIKeyMissingError):
-            CohereGenerator()
+            CohereGenerator(name=DEFAULT_MODEL_NAME)
     finally:
         if saved is not None:
             os.environ[var] = saved
 
 
 def test_cohere_default_parameters():
-    gen = CohereGenerator()
+    gen = CohereGenerator(name=DEFAULT_MODEL_NAME)
     assert gen.api_version == "v2"  # Default should be v2 (chat API)
     assert gen.temperature == CohereGenerator.DEFAULT_PARAMS["temperature"]
     assert gen.max_tokens == CohereGenerator.DEFAULT_PARAMS["max_tokens"]
@@ -118,40 +122,62 @@ def test_cohere_default_parameters():
 
 def test_api_version_validation():
     # Test invalid api_version gets corrected to v2
-    gen = CohereGenerator()
+    gen = CohereGenerator(name=DEFAULT_MODEL_NAME)
     gen.api_version = "invalid"
-    gen.__init__()
+    gen.__init__(name=DEFAULT_MODEL_NAME)
     assert gen.api_version == "v2"
 
     # Test v1 is accepted
-    gen = CohereGenerator()
+    gen = CohereGenerator(name=DEFAULT_MODEL_NAME)
     gen.api_version = "v1"
-    gen.__init__()
+    gen.__init__(name=DEFAULT_MODEL_NAME)
     assert gen.api_version == "v1"
 
     # Test v2 is accepted
-    gen = CohereGenerator()
+    gen = CohereGenerator(name=DEFAULT_MODEL_NAME)
     gen.api_version = "v2"
-    gen.__init__()
+    gen.__init__(name=DEFAULT_MODEL_NAME)
     assert gen.api_version == "v2"
 
 
-# ─── (Optional) Generation Limit Enforcement ─────────────────────────────────
-# If generate() does not currently enforce COHERE_GENERATION_LIMIT, this test is skipped
-import pytest
+# ─── _load_client Tests ──────────────────────────────────────────────
 
-# ─── Legacy Generate API (respx) (respx) ──────────────────────────────────────
+
+def test_load_client_v1():
+    gen = CohereGenerator(name=DEFAULT_MODEL_NAME)
+    gen.api_version = "v1"
+    gen._load_client()
+    assert isinstance(gen.generator, cohere.Client)
+
+
+def test_load_client_v2():
+    gen = CohereGenerator(name=DEFAULT_MODEL_NAME)
+    gen.api_version = "v2"
+    gen._load_client()
+    assert isinstance(gen.generator, cohere.ClientV2)
+
+
+def test_serialization_restores_client():
+    """Pickling and unpickling should restore the Cohere client."""
+    gen = CohereGenerator(name=DEFAULT_MODEL_NAME)
+    data = pickle.dumps(gen)
+    restored = pickle.loads(data)
+    assert hasattr(restored, "generator")
+    assert restored.generator is not None
+    assert restored.name == DEFAULT_MODEL_NAME
+
+
+# ─── Legacy Generate API (respx) ──────────────────────────────────────
 
 
 @pytest.mark.respx(base_url=COHERE_API_BASE)
 def test_cohere_generate_api_respx(respx_mock, cohere_mock_responses):
-    route = mock_cohere_endpoint(
+    mock_cohere_endpoint(
         respx_mock, "/v1/generate", cohere_mock_responses["generate_response"]
     )
-    gen = CohereGenerator()
-    gen.api_version = "v1"  # Use legacy generate API
-    # Re-initialize the generator with v1
-    gen.__init__()
+    gen = CohereGenerator(name=DEFAULT_MODEL_NAME)
+    gen.api_version = "v1"
+    gen._load_client()
     conv = Conversation([Turn("user", Message("Test prompt"))])
     result = gen.generate(conv, generations_this_call=1)
 
@@ -165,10 +191,10 @@ def test_cohere_generate_api_respx(respx_mock, cohere_mock_responses):
     assert payload["model"] == DEFAULT_MODEL_NAME
     assert payload["prompt"] == "Test prompt"
 
-    # Assert response parsing
-    assert result == [
-        cohere_mock_responses["generate_response"]["json"]["generations"][0]["text"]
-    ]
+    # Assert response parsing - should be Message objects
+    assert len(result) == 1
+    assert isinstance(result[0], Message)
+    assert result[0].text == "Mocked generate response 1."
 
 
 # ─── Chat API (respx) ─────────────────────────────────────────────────
@@ -187,10 +213,9 @@ def test_cohere_chat_api_respx(
 ):
     spec = cohere_mock_responses[response_key]
     mock_cohere_endpoint(respx_mock, "/v2/chat", spec)
-    gen = CohereGenerator()
-    # Default is already v2, but being explicit for test clarity
+    gen = CohereGenerator(name=DEFAULT_MODEL_NAME)
     gen.api_version = "v2"
-    gen.__init__()
+    gen._load_client()
     conv = Conversation([Turn("user", Message("Test prompt"))])
     result = gen.generate(conv)
 
@@ -201,11 +226,37 @@ def test_cohere_chat_api_respx(
     assert payload.get("model") == DEFAULT_MODEL_NAME
     assert payload.get("messages")[0]["content"] == "Test prompt"
 
-    # Check response or None for error cases
+    # Check response - should be Message or None
     if expect_error_str:
         assert result[0] is None, f"Expected None for error but got {result[0]}"
     else:
-        assert isinstance(result[0], str) and result[0]
+        assert isinstance(result[0], Message)
+        assert result[0].text == "Mocked chat response."
+
+
+# ─── 404 Error Handling ──────────────────────────────────────────────
+
+
+@pytest.mark.respx(base_url=COHERE_API_BASE)
+def test_chat_api_404_raises_bad_generator(respx_mock, cohere_mock_responses):
+    mock_cohere_endpoint(respx_mock, "/v2/chat", cohere_mock_responses["not_found_response"])
+    gen = CohereGenerator(name="nonexistent-model")
+    gen.api_version = "v2"
+    gen._load_client()
+    conv = Conversation([Turn("user", Message("Test prompt"))])
+    with pytest.raises(BadGeneratorException):
+        gen.generate(conv)
+
+
+@pytest.mark.respx(base_url=COHERE_API_BASE)
+def test_generate_api_404_raises_bad_generator(respx_mock, cohere_mock_responses):
+    mock_cohere_endpoint(respx_mock, "/v1/generate", cohere_mock_responses["not_found_response"])
+    gen = CohereGenerator(name="nonexistent-model")
+    gen.api_version = "v1"
+    gen._load_client()
+    conv = Conversation([Turn("user", Message("Test prompt"))])
+    with pytest.raises(BadGeneratorException):
+        gen.generate(conv)
 
 
 # ─── Logging on Error Variants ─────────────────────────────────────────
@@ -217,12 +268,26 @@ def test_chat_response_logs_warning(respx_mock, cohere_mock_responses, caplog):
         respx_mock, "/v2/chat", cohere_mock_responses["missing_content_response"]
     )
 
-    gen = CohereGenerator()
-    gen.api_version = "v2"  # Use chat API
-    gen.__init__()
+    gen = CohereGenerator(name=DEFAULT_MODEL_NAME)
+    gen.api_version = "v2"
+    gen._load_client()
     caplog.clear()
 
     conv = Conversation([Turn("user", Message("Test prompt"))])
     result = gen.generate(conv)
     assert result[0] is None, f"Expected None for error but got {result[0]}"
     assert "warning" in caplog.text.lower() or "error" in caplog.text.lower()
+
+
+# ─── Message Type Tests ──────────────────────────────────────────────
+
+
+@pytest.mark.respx(base_url=COHERE_API_BASE)
+def test_generate_returns_message_objects(respx_mock, cohere_mock_responses):
+    """All non-None results from generate() should be Message objects."""
+    mock_cohere_endpoint(respx_mock, "/v2/chat", cohere_mock_responses["chat_response"])
+    gen = CohereGenerator(name=DEFAULT_MODEL_NAME)
+    conv = Conversation([Turn("user", Message("Test prompt"))])
+    result = gen.generate(conv)
+    for item in result:
+        assert item is None or isinstance(item, Message)

--- a/tests/generators/test_cohere.py
+++ b/tests/generators/test_cohere.py
@@ -2,6 +2,7 @@ import os
 import json
 import logging
 import pickle
+import warnings
 import pytest
 import httpx
 
@@ -21,12 +22,7 @@ except Exception:
 # Default model name and API URLs
 DEFAULT_MODEL_NAME = "command-r-plus"
 COHERE_API_BASE = "https://api.cohere.com"
-COHERE_V1 = f"{COHERE_API_BASE}/v1"
 COHERE_V2 = f"{COHERE_API_BASE}/v2"
-
-# API version constants
-API_V1 = "v1"  # Legacy generate API
-API_V2 = "v2"  # Recommended chat API
 
 # ─── Fixtures ─────────────────────────────────────────────────────────
 
@@ -59,32 +55,9 @@ def cohere_config_root():
 
 
 @pytest.fixture
-def cohere_v1_config_root():
-    """Provide a config_root dict for CohereGenerator with v1 API."""
-    return {
-        "generators": {
-            "cohere": {
-                "CohereGenerator": {
-                    "name": DEFAULT_MODEL_NAME,
-                    "api_version": "v1",
-                }
-            }
-        }
-    }
-
-
-@pytest.fixture
 def cohere_mock_responses():
     """Provide mock HTTP response specs for Cohere endpoints."""
     return {
-        "generate_response": {
-            "code": 200,
-            "json": {
-                "generations": [
-                    {"text": "Mocked generate response 1."},
-                ]
-            },
-        },
         "chat_response": {
             "code": 200,
             "json": {"message": {"content": [{"text": "Mocked chat response."}]}},
@@ -112,12 +85,11 @@ def mock_cohere_endpoint(respx_mock, path, spec):
 
 
 def test_cohere_instantiation(cohere_config_root):
-    # Test v2 (default) with config_root
-    gen_v2 = CohereGenerator(config_root=cohere_config_root)
-    assert gen_v2.name == DEFAULT_MODEL_NAME
-    assert gen_v2.api_key == "fake-api-key"
-    assert hasattr(gen_v2, "generator")
-    assert gen_v2.api_version == "v2"
+    gen = CohereGenerator(config_root=cohere_config_root)
+    assert gen.name == DEFAULT_MODEL_NAME
+    assert gen.api_key == "fake-api-key"
+    assert hasattr(gen, "generator")
+    assert isinstance(gen.generator, cohere.ClientV2)
 
 
 def test_cohere_missing_model_name():
@@ -139,53 +111,43 @@ def test_cohere_missing_api_key(cohere_config_root):
 
 def test_cohere_default_parameters(cohere_config_root):
     gen = CohereGenerator(config_root=cohere_config_root)
-    assert gen.api_version == "v2"  # Default should be v2 (chat API)
     assert gen.temperature == CohereGenerator.DEFAULT_PARAMS["temperature"]
     assert gen.max_tokens == CohereGenerator.DEFAULT_PARAMS["max_tokens"]
     gen.temperature = 0.5
     assert gen.temperature == 0.5
 
 
-# ─── API Version Tests ─────────────────────────────────────────────────────────
+# ─── Deprecation Warning Tests ───────────────────────────────────────
 
 
-def test_api_version_validation(cohere_config_root, cohere_v1_config_root):
-    # Test invalid api_version gets corrected to v2
-    invalid_config = {
+def test_api_version_deprecation_warning():
+    """Setting api_version should emit a DeprecationWarning and still use ClientV2."""
+    config_root = {
         "generators": {
             "cohere": {
                 "CohereGenerator": {
                     "name": DEFAULT_MODEL_NAME,
-                    "api_version": "invalid",
+                    "api_version": "v1",
                 }
             }
         }
     }
-    gen = CohereGenerator(config_root=invalid_config)
-    assert gen.api_version == "v2"
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        gen = CohereGenerator(config_root=config_root)
+        deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(deprecation_warnings) >= 1
+        assert "api_version" in str(deprecation_warnings[0].message)
 
-    # Test v1 is accepted
-    gen = CohereGenerator(config_root=cohere_v1_config_root)
-    assert gen.api_version == "v1"
-
-    # Test v2 is accepted
-    gen = CohereGenerator(config_root=cohere_config_root)
-    assert gen.api_version == "v2"
+    # Should still use ClientV2 regardless
+    assert isinstance(gen.generator, cohere.ClientV2)
 
 
 # ─── _load_unsafe Tests ──────────────────────────────────────────────
 
 
-def test_load_unsafe_v1(cohere_config_root):
+def test_load_unsafe(cohere_config_root):
     gen = CohereGenerator(config_root=cohere_config_root)
-    gen.api_version = "v1"
-    gen._load_unsafe()
-    assert isinstance(gen.generator, cohere.Client)
-
-
-def test_load_unsafe_v2(cohere_config_root):
-    gen = CohereGenerator(config_root=cohere_config_root)
-    gen.api_version = "v2"
     gen._load_unsafe()
     assert isinstance(gen.generator, cohere.ClientV2)
 
@@ -198,34 +160,7 @@ def test_serialization_restores_client(cohere_config_root):
     assert hasattr(restored, "generator")
     assert restored.generator is not None
     assert restored.name == DEFAULT_MODEL_NAME
-
-
-# ─── Legacy Generate API (respx) ──────────────────────────────────────
-
-
-@pytest.mark.respx(base_url=COHERE_API_BASE)
-def test_cohere_generate_api_respx(respx_mock, cohere_mock_responses, cohere_v1_config_root):
-    mock_cohere_endpoint(
-        respx_mock, "/v1/generate", cohere_mock_responses["generate_response"]
-    )
-    gen = CohereGenerator(config_root=cohere_v1_config_root)
-    conv = Conversation([Turn("user", Message("Test prompt"))])
-    result = gen.generate(conv, generations_this_call=1)
-
-    # Assert headers
-    last = respx_mock.calls.last.request
-    assert last.headers["Authorization"] == "Bearer fake-api-key"
-    assert "application/json" in last.headers.get("Content-Type", "")
-
-    # Assert payload
-    payload = json.loads(last.content)
-    assert payload["model"] == DEFAULT_MODEL_NAME
-    assert payload["prompt"] == "Test prompt"
-
-    # Assert response parsing - should be Message objects
-    assert len(result) == 1
-    assert isinstance(result[0], Message)
-    assert result[0].text == "Mocked generate response 1."
+    assert isinstance(restored.generator, cohere.ClientV2)
 
 
 # ─── Chat API (respx) ─────────────────────────────────────────────────
@@ -233,14 +168,14 @@ def test_cohere_generate_api_respx(respx_mock, cohere_mock_responses, cohere_v1_
 
 @pytest.mark.respx(base_url=COHERE_API_BASE)
 @pytest.mark.parametrize(
-    "response_key, expect_error_str",
+    "response_key, expect_none",
     [
         ("chat_response", False),
         ("missing_content_response", True),
     ],
 )
 def test_cohere_chat_api_respx(
-    respx_mock, cohere_mock_responses, cohere_config_root, response_key, expect_error_str
+    respx_mock, cohere_mock_responses, cohere_config_root, response_key, expect_none
 ):
     spec = cohere_mock_responses[response_key]
     mock_cohere_endpoint(respx_mock, "/v2/chat", spec)
@@ -256,7 +191,7 @@ def test_cohere_chat_api_respx(
     assert payload.get("messages")[0]["content"] == "Test prompt"
 
     # Check response - should be Message or None
-    if expect_error_str:
+    if expect_none:
         assert result[0] is None, f"Expected None for error but got {result[0]}"
     else:
         assert isinstance(result[0], Message)
@@ -272,18 +207,6 @@ def test_chat_api_404_raises_bad_generator(respx_mock, cohere_mock_responses):
         "generators": {"cohere": {"CohereGenerator": {"name": "nonexistent-model"}}}
     }
     mock_cohere_endpoint(respx_mock, "/v2/chat", cohere_mock_responses["not_found_response"])
-    gen = CohereGenerator(config_root=config_root)
-    conv = Conversation([Turn("user", Message("Test prompt"))])
-    with pytest.raises(BadGeneratorException):
-        gen.generate(conv)
-
-
-@pytest.mark.respx(base_url=COHERE_API_BASE)
-def test_generate_api_404_raises_bad_generator(respx_mock, cohere_mock_responses):
-    config_root = {
-        "generators": {"cohere": {"CohereGenerator": {"name": "nonexistent-model", "api_version": "v1"}}}
-    }
-    mock_cohere_endpoint(respx_mock, "/v1/generate", cohere_mock_responses["not_found_response"])
     gen = CohereGenerator(config_root=config_root)
     conv = Conversation([Turn("user", Message("Test prompt"))])
     with pytest.raises(BadGeneratorException):
@@ -347,7 +270,6 @@ def test_live_chat_api_output_format(restore_real_api_key):
         "generators": {"cohere": {"CohereGenerator": {"name": LIVE_MODEL}}}
     }
     gen = CohereGenerator(config_root=config_root)
-    assert gen.api_version == "v2"
     conv = Conversation([Turn("user", Message("Say hello in one word."))])
     result = gen.generate(conv, generations_this_call=1)
 
@@ -355,19 +277,3 @@ def test_live_chat_api_output_format(restore_real_api_key):
     assert isinstance(result[0], Message)
     assert isinstance(result[0].text, str)
     assert len(result[0].text) > 0
-
-
-@pytest.mark.skipif(not _has_cohere_key, reason="COHERE_API_KEY not set")
-def test_live_v1_api_rejects_new_model(restore_real_api_key):
-    """Newer models are not available on the legacy v1 generate API.
-
-    This verifies that the 404 handling correctly raises BadGeneratorException
-    rather than silently returning None.
-    """
-    config_root = {
-        "generators": {"cohere": {"CohereGenerator": {"name": LIVE_MODEL, "api_version": "v1"}}}
-    }
-    gen = CohereGenerator(config_root=config_root)
-    conv = Conversation([Turn("user", Message("Say hello in one word."))])
-    with pytest.raises(BadGeneratorException):
-        gen.generate(conv, generations_this_call=1)


### PR DESCRIPTION
## Summary

Fixes #1384

Addresses all seven checklist items in #1384.

- **Drop default model**: `name` parameter is now required; passing no model name raises `TargetNameMissingError`. The deprecated `command` default has been removed.
- **Cancel run on 404**: Both v1 and v2 API paths now catch `cohere.errors.NotFoundError` and raise `BadGeneratorException` to stop execution immediately, following the pattern in `nvcf.py`.
- **Migrate to `cohere.errors`**: Replaced the broad `RuntimeError` catch in the v1 path with fine-grained `cohere.errors` types (`NotFoundError`, `GatewayTimeoutError`, `TooManyRequestsError`, `ServiceUnavailableError`, `InternalServerError`). The v2 path already used these.
- **Live endpoint tests (chat)**: Added `test_live_chat_api_output_format` — verifies that the v2 chat API returns a `Message` object with non-empty text. Skipped when `COHERE_API_KEY` is not set.
- **Live endpoint tests (completion)**: Added `test_live_v1_api_rejects_new_model` — Cohere has retired the generate endpoint and all current models return 404 on v1, so the test verifies that the 404 handling correctly raises `BadGeneratorException` rather than silently returning `None`.
- **Preserve `None`s**: Error paths continue to emit `None` per the existing protocol. `_call_model` wraps `str` results in `Message` while passing `None` through unchanged.
- **`_load_client` pattern**: Extracted client initialization into `_load_client()`, called from `__init__` and `__setstate__`. Added `_unsafe_attributes = ["generator"]` so pickle round-trips correctly restore the client.

## Test plan
- [ ] `pytest tests/generators/test_cohere.py` — 17 tests (15 mock + 2 live)
- [ ] `ruff check garak/generators/cohere.py tests/generators/test_cohere.py`
- [ ] Live tests require `COHERE_API_KEY`; safely skipped in CI when absent