### PR TITLE
feat: add mTLS client certificate authentication to REST generator

### DIFF
--- a/docs/source/garak.generators.rest.rst
+++ b/docs/source/garak.generators.rest.rst
@@ -19,6 +19,9 @@ Uses the following options from ``_config.plugins.generators["rest.RestGenerator
 * ``ratelimit_codes`` - Which endpoint HTTP response codes should be caught as indicative of rate limiting and retried? ``List[int]``, default ``[429]``
 * ``skip_codes`` - Which endpoint HTTP response code should lead to the generation being treated as not possible and skipped for this query. Takes precedence over ``ratelimit_codes``.
 * ``verify_ssl`` - (optional) Enforce ssl certificate validation? Default is ``True``, a file path to a CA bundle can be provided. (bool|str)
+* ``client_cert`` - (optional) Path to a PEM-encoded client certificate file for mTLS. If the file contains both the certificate and private key, ``client_key`` is not required.
+* ``client_key`` - (optional) Path to the client private key file for mTLS. Must be set if ``client_cert`` does not contain the key. Cannot be set without ``client_cert``.
+* ``client_key_passphrase_env_var`` - (optional) Name of an environment variable holding the passphrase for an encrypted ``client_key``. The passphrase is never read from config files. If set, the named env var must be defined or startup will fail.
 
 Templates can be either a string or a JSON-serialisable Python object.
 Instance of ``$INPUT`` here are replaced with the prompt; instances of ``$KEY``
@@ -71,6 +74,48 @@ JSON file to connect to the LLM endpoint.
 
 If you need something more flexible, add a new module or class and inherit
 from RestGenerator.
+
+mTLS Client Certificate Authentication
+---------------------------------------
+
+To authenticate with a server that requires mutual TLS, provide your client certificate and (optionally)
+key. For a server-side CA bundle, use ``verify_ssl`` with a file path:
+
+.. code-block:: JSON
+
+   {
+      "rest": {
+         "RestGenerator": {
+            "name": "mTLS protected service",
+            "uri": "https://api.example.com/llm",
+            "client_cert": "/path/to/client.crt",
+            "client_key": "/path/to/client.key",
+            "client_key_passphrase_env_var": "MTLS_KEY_PASSPHRASE",
+            "verify_ssl": "/path/to/ca.crt"
+         }
+      }
+   }
+
+Set the passphrase securely via environment variable:
+
+.. code-block:: bash
+
+   export MTLS_KEY_PASSPHRASE="your_key_passphrase"
+   garak --target_type rest -G mtls_config.json --probes dan
+
+If using a combined PEM file containing both certificate and key, omit ``client_key``:
+
+.. code-block:: JSON
+
+   {
+      "rest": {
+         "RestGenerator": {
+            "uri": "https://api.example.com/llm",
+            "client_cert": "/path/to/combined.pem",
+            "verify_ssl": "/path/to/ca.crt"
+         }
+      }
+   }
 
 ----
 

--- a/docs/source/generators/rest.rst
+++ b/docs/source/generators/rest.rst
@@ -19,6 +19,9 @@ Uses the following options from ``_config.plugins.generators["rest.RestGenerator
 * ``ratelimit_codes`` - Which endpoint HTTP response codes should be caught as indicative of rate limiting and retried? ``List[int]``, default ``[429]``
 * ``skip_codes`` - Which endpoint HTTP response code should lead to the generation being treated as not possible and skipped for this query. Takes precedence over ``ratelimit_codes``.
 * ``verify_ssl`` - (optional) Enforce ssl certificate validation? Default is ``True``, a file path to a CA bundle can be provided. (bool|str)
+* ``client_cert`` - (optional) Path to a PEM-encoded client certificate file for mTLS. If the file contains both the certificate and private key, ``client_key`` is not required.
+* ``client_key`` - (optional) Path to the client private key file for mTLS. Must be set if ``client_cert`` does not contain the key. Cannot be set without ``client_cert``.
+* ``client_key_passphrase_env_var`` - (optional) Name of an environment variable holding the passphrase for an encrypted ``client_key``. The passphrase is never read from config files. If set, the named env var must be defined or startup will fail.
 
 Templates can be either a string or a JSON-serialisable Python object.
 Instance of ``$INPUT`` here are replaced with the prompt; instances of ``$KEY``
@@ -71,6 +74,48 @@ JSON file to connect to the LLM endpoint.
 
 If you need something more flexible, add a new module or class and inherit
 from RestGenerator.
+
+mTLS Client Certificate Authentication
+---------------------------------------
+
+To authenticate with a server that requires mutual TLS, provide your client certificate and (optionally)
+key. For a server-side CA bundle, use ``verify_ssl`` with a file path:
+
+.. code-block:: JSON
+
+   {
+      "rest": {
+         "RestGenerator": {
+            "name": "mTLS protected service",
+            "uri": "https://api.example.com/llm",
+            "client_cert": "/path/to/client.crt",
+            "client_key": "/path/to/client.key",
+            "client_key_passphrase_env_var": "MTLS_KEY_PASSPHRASE",
+            "verify_ssl": "/path/to/ca.crt"
+         }
+      }
+   }
+
+Set the passphrase securely via environment variable:
+
+.. code-block:: bash
+
+   export MTLS_KEY_PASSPHRASE="your_key_passphrase"
+   garak --target_type rest -G mtls_config.json --probes dan
+
+If using a combined PEM file containing both certificate and key, omit ``client_key``:
+
+.. code-block:: JSON
+
+   {
+      "rest": {
+         "RestGenerator": {
+            "uri": "https://api.example.com/llm",
+            "client_cert": "/path/to/combined.pem",
+            "verify_ssl": "/path/to/ca.crt"
+         }
+      }
+   }
 
 ----
 

--- a/garak/generators/rest.py
+++ b/garak/generators/rest.py
@@ -8,6 +8,8 @@ Generic Module for REST API connections
 
 import json
 import logging
+import os
+import ssl
 from typing import List, Union
 import requests
 
@@ -43,10 +45,15 @@ class RestGenerator(Generator):
         "request_timeout": 20,
         "proxies": None,
         "verify_ssl": True,
+        "client_cert": None,
+        "client_key": None,
+        "client_key_passphrase_env_var": None,
     }
 
     ENV_VAR = "REST_API_KEY"
     generator_family_name = "REST"
+
+    _unsafe_attributes = ["client_key_passphrase", "_mtls_session"]
 
     _supported_params = (
         "api_key",
@@ -71,6 +78,9 @@ class RestGenerator(Generator):
         "top_k",
         "proxies",
         "verify_ssl",
+        "client_cert",
+        "client_key",
+        "client_key_passphrase_env_var",
     )
 
     def __init__(self, uri=None, config_root=_config):
@@ -137,9 +147,64 @@ class RestGenerator(Generator):
                     "`proxies` value provided is not in the required format. See documentation from the `requests` package for details on expected format. https://requests.readthedocs.io/en/latest/user/advanced/#proxies"
                 )
 
+        # validate mTLS cert/key pairing and file existence
+        if self.client_key is not None and self.client_cert is None:
+            raise BadGeneratorException(
+                "`client_key` was provided without `client_cert`. Both must be set for mTLS."
+            )
+        for attr in ("client_cert", "client_key"):
+            path = getattr(self, attr, None)
+            if path is not None:
+                if not isinstance(path, str):
+                    raise BadGeneratorException(
+                        f"`{attr}` must be a string path to a PEM file."
+                    )
+                if not os.path.isfile(path):
+                    raise BadGeneratorException(f"`{attr}` file not found: {path}")
+
+        # mTLS requires HTTPS — reject http:// URIs early to prevent silent
+        # security downgrade where the SSLContext would be ignored.
+        if self.client_cert is not None and not self.uri.startswith("https://"):
+            raise BadGeneratorException(
+                f"mTLS requires an HTTPS URI, but got: {self.uri}"
+            )
+
+        # load passphrase from env var if specified
+        self.client_key_passphrase = None
+        if self.client_key_passphrase_env_var is not None:
+            self.client_key_passphrase = os.getenv(self.client_key_passphrase_env_var)
+            if self.client_key_passphrase is None:
+                raise BadGeneratorException(
+                    f"client_key_passphrase_env_var '{self.client_key_passphrase_env_var}' "
+                    "is set but the environment variable is not defined"
+                )
+
         # suppress warnings about intentional SSL validation suppression
         if isinstance(self.verify_ssl, bool) and not self.verify_ssl:
             requests.packages.urllib3.disable_warnings()
+
+        # build mTLS session when client cert is configured
+        # always use session path when mTLS is active — SSLContext handles cert + verification
+        self._mtls_session = None
+        if self.client_cert is not None:
+            if isinstance(self.verify_ssl, str):
+                ssl_ctx = ssl.create_default_context(cafile=self.verify_ssl)
+            else:
+                ssl_ctx = ssl.create_default_context()
+                if not self.verify_ssl:
+                    ssl_ctx.check_hostname = False
+                    ssl_ctx.verify_mode = ssl.CERT_NONE
+            ssl_ctx.load_cert_chain(
+                self.client_cert,
+                keyfile=self.client_key,
+                password=self.client_key_passphrase,
+            )
+            # passphrase is no longer needed after loading into the SSLContext;
+            # clear the reference to reduce exposure in memory
+            self.client_key_passphrase = None
+            adapter = _MtlsAdapter(ssl_ctx)
+            self._mtls_session = requests.Session()
+            self._mtls_session.mount("https://", adapter)
 
         # validate jsonpath
         if self.response_json and self.response_json_field:
@@ -152,6 +217,10 @@ class RestGenerator(Generator):
                 raise e
 
         super().__init__(self.name, config_root=config_root)
+
+    def __del__(self):
+        if getattr(self, "_mtls_session", None) is not None:
+            self._mtls_session.close()
 
     def _validate_env_var(self):
         key_match = "$KEY"
@@ -222,10 +291,20 @@ class RestGenerator(Generator):
             "headers": request_headers,
             "timeout": self.request_timeout,
             "proxies": self.proxies,
-            "verify": self.verify_ssl,
         }
         try:
-            resp = self.http_function(self.uri, **req_kArgs)
+            if self._mtls_session is not None:
+                # verify_ssl=True or a CA path: the CA bundle is already wired
+                # into the SSLContext in __init__; omit 'verify' here so
+                # requests doesn't override it. Only pass verify=False
+                # explicitly when the user has opted out of server cert
+                # checking entirely.
+                if not self.verify_ssl:
+                    req_kArgs["verify"] = False
+                resp = self._mtls_session.request(self.method, self.uri, **req_kArgs)
+            else:
+                req_kArgs["verify"] = self.verify_ssl
+                resp = self.http_function(self.uri, **req_kArgs)
         except UnicodeEncodeError as uee:
             # only RFC2616 (latin-1) is guaranteed
             # don't print a repr, this might leak api keys
@@ -306,6 +385,22 @@ class RestGenerator(Generator):
                 return [None]
 
         return [Message(r) for r in response]
+
+
+class _MtlsAdapter(requests.adapters.HTTPAdapter):
+    """HTTPAdapter that injects a pre-configured SSLContext for mTLS."""
+
+    def __init__(self, ssl_context, **kwargs):
+        self._ssl_context = ssl_context
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, *args, **kwargs):
+        kwargs["ssl_context"] = self._ssl_context
+        return super().init_poolmanager(*args, **kwargs)
+
+    def proxy_manager_for(self, proxy, **proxy_kwargs):
+        proxy_kwargs["ssl_context"] = self._ssl_context
+        return super().proxy_manager_for(proxy, **proxy_kwargs)
 
 
 DEFAULT_CLASS = "RestGenerator"

--- a/garak/generators/rest.py
+++ b/garak/generators/rest.py
@@ -48,12 +48,13 @@ class RestGenerator(Generator):
         "client_cert": None,
         "client_key": None,
         "client_key_passphrase_env_var": None,
+        "client_key_passphrase": None,  # loaded from env var by _validate_env_var()
     }
 
     ENV_VAR = "REST_API_KEY"
     generator_family_name = "REST"
 
-    _unsafe_attributes = ["client_key_passphrase", "_mtls_session"]
+    _unsafe_attributes = ["_mtls_session"]
 
     _supported_params = (
         "api_key",
@@ -169,42 +170,12 @@ class RestGenerator(Generator):
                 f"mTLS requires an HTTPS URI, but got: {self.uri}"
             )
 
-        # load passphrase from env var if specified
-        self.client_key_passphrase = None
-        if self.client_key_passphrase_env_var is not None:
-            self.client_key_passphrase = os.getenv(self.client_key_passphrase_env_var)
-            if self.client_key_passphrase is None:
-                raise BadGeneratorException(
-                    f"client_key_passphrase_env_var '{self.client_key_passphrase_env_var}' "
-                    "is set but the environment variable is not defined"
-                )
-
         # suppress warnings about intentional SSL validation suppression
         if isinstance(self.verify_ssl, bool) and not self.verify_ssl:
             requests.packages.urllib3.disable_warnings()
 
-        # build mTLS session when client cert is configured
-        # always use session path when mTLS is active — SSLContext handles cert + verification
-        self._mtls_session = None
-        if self.client_cert is not None:
-            if isinstance(self.verify_ssl, str):
-                ssl_ctx = ssl.create_default_context(cafile=self.verify_ssl)
-            else:
-                ssl_ctx = ssl.create_default_context()
-                if not self.verify_ssl:
-                    ssl_ctx.check_hostname = False
-                    ssl_ctx.verify_mode = ssl.CERT_NONE
-            ssl_ctx.load_cert_chain(
-                self.client_cert,
-                keyfile=self.client_key,
-                password=self.client_key_passphrase,
-            )
-            # passphrase is no longer needed after loading into the SSLContext;
-            # clear the reference to reduce exposure in memory
-            self.client_key_passphrase = None
-            adapter = _MtlsAdapter(ssl_ctx)
-            self._mtls_session = requests.Session()
-            self._mtls_session.mount("https://", adapter)
+        # build mTLS session (extracted to _load_unsafe for multiprocessing support)
+        self._load_unsafe()
 
         # validate jsonpath
         if self.response_json and self.response_json_field:
@@ -222,14 +193,62 @@ class RestGenerator(Generator):
         if getattr(self, "_mtls_session", None) is not None:
             self._mtls_session.close()
 
+    def _load_unsafe(self):
+        """Build the mTLS requests.Session with a pre-configured SSLContext.
+
+        Called from __init__ and also from __setstate__ (via Configurable)
+        to reconstruct the session after pickling for multiprocessing.
+        """
+        self._mtls_session = None
+        if self.client_cert is not None:
+            if isinstance(self.verify_ssl, str):
+                ssl_ctx = ssl.create_default_context(cafile=self.verify_ssl)
+            else:
+                ssl_ctx = ssl.create_default_context()
+                if not self.verify_ssl:
+                    ssl_ctx.check_hostname = False
+                    ssl_ctx.verify_mode = ssl.CERT_NONE
+            # re-read passphrase from env var if cleared or missing
+            # may be lost during pickle roundtrip 
+            passphrase = self.client_key_passphrase
+            if passphrase is None and self.client_key_passphrase_env_var is not None:
+                passphrase = os.getenv(self.client_key_passphrase_env_var)
+            ssl_ctx.load_cert_chain(
+                self.client_cert,
+                keyfile=self.client_key,
+                password=passphrase,
+            )
+            # passphrase is no longer needed after loading into the SSLContext;
+            # clear the reference to reduce exposure in memory
+            self.client_key_passphrase = None
+            adapter = _MtlsAdapter(ssl_ctx)
+            self._mtls_session = requests.Session()
+            self._mtls_session.mount("https://", adapter)
+
     def _validate_env_var(self):
-        key_match = "$KEY"
-        header_requires_key = False
-        for _k, v in self.headers.items():
-            if key_match in v:
-                header_requires_key = True
-        if "$KEY" in self.req_template or header_requires_key:
-            return super()._validate_env_var()
+        # API key is optional when mTLS is used; only enforce if $KEY appears in template or headers
+        key_required = "$KEY" in self.req_template or any(
+            "$KEY" in v for v in self.headers.values()
+        )
+        try:
+            super()._validate_env_var()
+        except APIKeyMissingError:
+            if key_required:
+                raise
+
+        # load mTLS passphrase from env var if specified
+        if (
+            self.client_key_passphrase is None
+            and self.client_key_passphrase_env_var is not None
+        ):
+            self.client_key_passphrase = os.getenv(
+                self.client_key_passphrase_env_var, default=None
+            )
+            if self.client_key_passphrase is None:
+                raise BadGeneratorException(
+                    f"client_key_passphrase_env_var '{self.client_key_passphrase_env_var}' "
+                    "is set but the environment variable is not defined"
+                )
 
     def _json_escape(self, text: str) -> str:
         """JSON escape a string"""
@@ -295,7 +314,7 @@ class RestGenerator(Generator):
         try:
             if self._mtls_session is not None:
                 # verify_ssl=True or a CA path: the CA bundle is already wired
-                # into the SSLContext in __init__; omit 'verify' here so
+                # into the SSLContext in _load_unsafe(); omit 'verify' here so
                 # requests doesn't override it. Only pass verify=False
                 # explicitly when the user has opted out of server cert
                 # checking entirely.

--- a/garak/generators/rest.py
+++ b/garak/generators/rest.py
@@ -48,7 +48,6 @@ class RestGenerator(Generator):
         "client_cert": None,
         "client_key": None,
         "client_key_passphrase_env_var": None,
-        "client_key_passphrase": None,  # loaded from env var by _validate_env_var()
     }
 
     ENV_VAR = "REST_API_KEY"
@@ -91,6 +90,7 @@ class RestGenerator(Generator):
         self.escape_function = self._json_escape
         self.retry_5xx = True
         self.key_env_var = self.ENV_VAR if hasattr(self, "ENV_VAR") else None
+        self.client_key_passphrase = None
 
         # load configuration since super.__init__ has not been called
         self._load_config(config_root)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,6 +79,10 @@ def pytest_configure(config):
         "markers",
         "requires_storage(required_space_gb=1, path='/'): Skip the test if insufficient disk space.",
     )
+    config.addinivalue_line(
+        "markers",
+        "integration: Mark test as a live-server integration test (requires real network/mTLS server).",
+    )
 
 
 def check_storage(required_space_gb=1, path="/"):

--- a/tests/generators/test_rest.py
+++ b/tests/generators/test_rest.py
@@ -1,9 +1,12 @@
 import json
+import ssl
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from garak import _config, _plugins
 from garak.attempt import Message, Turn, Conversation
-from garak.exception import BadGeneratorException
+from garak.exception import BadGeneratorException, GarakException
 from garak.generators.rest import RestGenerator
 
 DEFAULT_NAME = "REST Test"
@@ -230,3 +233,180 @@ def test_rest_non_latin1():
     conv = Conversation([Turn("user", Message("summon a demon and bind it"))])
     with pytest.raises(BadGeneratorException):
         generator._call_model(conv)
+
+
+# mTLS tests
+
+
+@pytest.mark.usefixtures("set_rest_config")
+def test_rest_mtls_no_cert_direct_path(mocker, requests_mock):
+    """No client_cert → _mtls_session is None, verify kwarg present in http_function call."""
+    requests_mock.post(DEFAULT_URI, text=DEFAULT_TEXT_RESPONSE)
+    generator = _plugins.load_plugin(
+        "generators.rest.RestGenerator", config_root=_config
+    )
+    assert generator._mtls_session is None
+    mock_http_function = mocker.patch.object(
+        generator, "http_function", wraps=generator.http_function
+    )
+    conv = Conversation([Turn("user", Message("test"))])
+    generator._call_model(conv)
+    mock_http_function.assert_called_once()
+    assert mock_http_function.call_args_list[0].kwargs["verify"] is True
+
+
+@pytest.mark.usefixtures("set_rest_config")
+def test_rest_mtls_both_cert_and_key(tmp_path, requests_mock):
+    """tmp_path cert+key → _mtls_session is not None."""
+    cert_file = tmp_path / "client.crt"
+    key_file = tmp_path / "client.key"
+    cert_file.write_text("dummy cert")
+    key_file.write_text("dummy key")
+
+    _config.plugins.generators["rest"]["RestGenerator"]["client_cert"] = str(cert_file)
+    _config.plugins.generators["rest"]["RestGenerator"]["client_key"] = str(key_file)
+
+    with patch.object(ssl.SSLContext, "load_cert_chain"):
+        generator = _plugins.load_plugin(
+            "generators.rest.RestGenerator", config_root=_config
+        )
+    assert generator._mtls_session is not None
+
+
+@pytest.mark.usefixtures("set_rest_config")
+def test_rest_mtls_cert_only(tmp_path):
+    """Single combined PEM → _mtls_session is not None."""
+    cert_file = tmp_path / "combined.pem"
+    cert_file.write_text("dummy combined cert+key")
+
+    _config.plugins.generators["rest"]["RestGenerator"]["client_cert"] = str(cert_file)
+
+    with patch.object(ssl.SSLContext, "load_cert_chain"):
+        generator = _plugins.load_plugin(
+            "generators.rest.RestGenerator", config_root=_config
+        )
+    assert generator._mtls_session is not None
+    assert generator.client_key is None
+
+
+@pytest.mark.usefixtures("set_rest_config")
+def test_rest_mtls_key_without_cert_raises():
+    """BadGeneratorException when client_key set without client_cert."""
+    _config.plugins.generators["rest"]["RestGenerator"]["client_key"] = "/some/key.pem"
+    with pytest.raises(GarakException) as exc_info:
+        _plugins.load_plugin("generators.rest.RestGenerator", config_root=_config)
+    assert "client_key" in str(exc_info.value)
+    assert "without" in str(exc_info.value)
+    assert "client_cert" in str(exc_info.value)
+
+
+@pytest.mark.usefixtures("set_rest_config")
+def test_rest_mtls_nonexistent_cert_raises():
+    """BadGeneratorException when client_cert points to a nonexistent file."""
+    _config.plugins.generators["rest"]["RestGenerator"][
+        "client_cert"
+    ] = "/nonexistent/path.pem"
+    with pytest.raises(GarakException) as exc_info:
+        _plugins.load_plugin("generators.rest.RestGenerator", config_root=_config)
+    assert "client_cert" in str(exc_info.value)
+    assert "not found" in str(exc_info.value)
+
+
+@pytest.mark.usefixtures("set_rest_config")
+def test_rest_mtls_passphrase_loads_from_env(tmp_path, monkeypatch):
+    """Passphrase loaded from env var and passed to load_cert_chain."""
+    cert_file = tmp_path / "client.crt"
+    key_file = tmp_path / "client.key"
+    cert_file.write_text("dummy cert")
+    key_file.write_text("dummy key")
+
+    monkeypatch.setenv("TEST_MTLS_PASSPHRASE", "testpass")
+
+    _config.plugins.generators["rest"]["RestGenerator"]["client_cert"] = str(cert_file)
+    _config.plugins.generators["rest"]["RestGenerator"]["client_key"] = str(key_file)
+    _config.plugins.generators["rest"]["RestGenerator"][
+        "client_key_passphrase_env_var"
+    ] = "TEST_MTLS_PASSPHRASE"
+
+    with patch.object(ssl.SSLContext, "load_cert_chain") as mock_load:
+        generator = _plugins.load_plugin(
+            "generators.rest.RestGenerator", config_root=_config
+        )
+    mock_load.assert_called_once_with(
+        str(cert_file),
+        keyfile=str(key_file),
+        password="testpass",
+    )
+    # passphrase is cleared after load_cert_chain to reduce memory exposure
+    assert generator.client_key_passphrase is None
+    assert generator._mtls_session is not None
+
+
+@pytest.mark.usefixtures("set_rest_config")
+def test_rest_mtls_verify_ssl_ca_path(tmp_path):
+    """verify_ssl as CA path string combined with client_cert uses create_default_context(cafile=...)."""
+    cert_file = tmp_path / "client.crt"
+    key_file = tmp_path / "client.key"
+    ca_file = tmp_path / "ca.crt"
+    cert_file.write_text("dummy cert")
+    key_file.write_text("dummy key")
+    ca_file.write_text("dummy ca")
+
+    _config.plugins.generators["rest"]["RestGenerator"]["client_cert"] = str(cert_file)
+    _config.plugins.generators["rest"]["RestGenerator"]["client_key"] = str(key_file)
+    _config.plugins.generators["rest"]["RestGenerator"]["verify_ssl"] = str(ca_file)
+
+    with (
+        patch("ssl.create_default_context") as mock_ctx_factory,
+        patch.object(ssl.SSLContext, "load_cert_chain") as mock_load,
+    ):
+        mock_ctx = mock_ctx_factory.return_value
+        mock_ctx.load_cert_chain = mock_load
+        _plugins.load_plugin("generators.rest.RestGenerator", config_root=_config)
+    mock_ctx_factory.assert_called_once_with(cafile=str(ca_file))
+
+
+@pytest.mark.usefixtures("set_rest_config")
+def test_rest_mtls_call_model_uses_session(tmp_path, mocker):
+    """_call_model dispatches via _mtls_session.request() when mTLS is active."""
+    cert_file = tmp_path / "client.crt"
+    cert_file.write_text("dummy cert")
+
+    _config.plugins.generators["rest"]["RestGenerator"]["client_cert"] = str(cert_file)
+
+    with patch.object(ssl.SSLContext, "load_cert_chain"):
+        generator = _plugins.load_plugin(
+            "generators.rest.RestGenerator", config_root=_config
+        )
+    assert generator._mtls_session is not None
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = "mTLS response"
+
+    mock_session_request = mocker.patch.object(
+        generator._mtls_session, "request", return_value=mock_response
+    )
+    mock_http_function = mocker.patch.object(generator, "http_function")
+
+    conv = Conversation([Turn("user", Message("test mTLS path"))])
+    result = generator._call_model(conv)
+
+    mock_session_request.assert_called_once()
+    assert mock_session_request.call_args[0] == ("post", DEFAULT_URI)
+    mock_http_function.assert_not_called()
+    assert result == [Message("mTLS response")]
+
+
+@pytest.mark.usefixtures("set_rest_config")
+def test_rest_mtls_http_uri_raises(tmp_path):
+    """BadGeneratorException when mTLS is configured with an http:// URI."""
+    cert_file = tmp_path / "client.crt"
+    cert_file.write_text("dummy cert")
+
+    _config.plugins.generators["rest"]["RestGenerator"]["client_cert"] = str(cert_file)
+    _config.plugins.generators["rest"]["RestGenerator"]["uri"] = "http://example.com/api"
+
+    with pytest.raises(GarakException) as exc_info:
+        _plugins.load_plugin("generators.rest.RestGenerator", config_root=_config)
+    assert "mTLS requires an HTTPS URI" in str(exc_info.value)

--- a/tests/generators/test_rest.py
+++ b/tests/generators/test_rest.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import ssl
 from unittest.mock import MagicMock, patch
@@ -171,8 +172,6 @@ def test_rest_valid_proxy(mocker, requests_mock):
 
 @pytest.mark.usefixtures("set_rest_config")
 def test_rest_invalid_proxy(requests_mock):
-    from garak.exception import GarakException
-
     test_proxies = [
         "http://localhost:8080",
         "https://localhost:8443",
@@ -405,8 +404,99 @@ def test_rest_mtls_http_uri_raises(tmp_path):
     cert_file.write_text("dummy cert")
 
     _config.plugins.generators["rest"]["RestGenerator"]["client_cert"] = str(cert_file)
-    _config.plugins.generators["rest"]["RestGenerator"]["uri"] = "http://example.com/api"
+    _config.plugins.generators["rest"]["RestGenerator"][
+        "uri"
+    ] = "http://example.com/api"
 
     with pytest.raises(GarakException) as exc_info:
         _plugins.load_plugin("generators.rest.RestGenerator", config_root=_config)
     assert "mTLS requires an HTTPS URI" in str(exc_info.value)
+
+
+@pytest.fixture
+def real_mtls_cert_files(tmp_path):
+    """Generate real self-signed PEM cert+key files using the cryptography library."""
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    # generate a 2048-bit RSA key
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+    )
+
+    # build a minimal self-signed cert
+    subject = issuer = x509.Name(
+        [x509.NameAttribute(NameOID.COMMON_NAME, "garak-test")]
+    )
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(private_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.now(datetime.timezone.utc))
+        .not_valid_after(
+            datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
+        )
+        .sign(private_key, hashes.SHA256())
+    )
+
+    cert_path = tmp_path / "client.crt"
+    key_path = tmp_path / "client.key"
+
+    cert_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    key_path.write_bytes(
+        private_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        )
+    )
+
+    return str(cert_path), str(key_path)
+
+
+@pytest.mark.usefixtures("set_rest_config")
+def test_rest_mtls_pickle_roundtrip(real_mtls_cert_files):
+    """Verify the multiprocessing pickle lifecycle for mTLS sessions.
+
+    __getstate__  → _mtls_session must be None (not picklable)
+    __setstate__  → _mtls_session must be reconstructed (not None)
+    reconstructed session must have the mTLS adapter mounted on 'https://'
+    """
+    import requests
+
+    from garak.generators.rest import _MtlsAdapter
+
+    cert_path, key_path = real_mtls_cert_files
+
+    _config.plugins.generators["rest"]["RestGenerator"]["client_cert"] = cert_path
+    _config.plugins.generators["rest"]["RestGenerator"]["client_key"] = key_path
+
+    generator = _plugins.load_plugin(
+        "generators.rest.RestGenerator", config_root=_config
+    )
+
+    # session must be live before pickling
+    assert generator._mtls_session is not None
+
+    # --- pickle (getstate) ---
+    state = generator.__getstate__()
+    assert (
+        state["_mtls_session"] is None
+    ), "_mtls_session must be cleared in __getstate__ so it can be pickled"
+
+    # --- unpickle (setstate) ---
+    generator.__setstate__(state)
+    assert (
+        generator._mtls_session is not None
+    ), "_mtls_session must be reconstructed by __setstate__ via _load_unsafe()"
+
+    # the reconstructed session must have the mTLS adapter on https://
+    adapter = generator._mtls_session.get_adapter("https://example.com")
+    assert isinstance(
+        adapter, _MtlsAdapter
+    ), "Reconstructed session must have an _MtlsAdapter mounted on 'https://'"

--- a/tests/generators/test_rest_mtls_integration.py
+++ b/tests/generators/test_rest_mtls_integration.py
@@ -1,0 +1,460 @@
+"""Self-contained pytest integration tests for mTLS support in RestGenerator.
+
+Generates real CA, server, and client certs in-process using `cryptography`,
+spins up a threaded HTTPS server requiring client certs, and tests every
+supported mTLS scenario without Docker or external services.
+
+Run:
+    conda run -n garak python -m pytest tests/generators/test_rest_mtls_integration.py -v -m integration
+"""
+
+import datetime
+import http.server
+import ipaddress
+import json
+import os
+import ssl
+import threading
+from pathlib import Path
+
+import pytest
+
+from garak import _config
+from garak.attempt import Conversation, Message, Turn
+from garak.exception import BadGeneratorException
+from garak.generators.rest import RestGenerator
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+REQ_TEMPLATE = '{"prompt": "$INPUT"}'
+CANNED_RESPONSE = {"response": "Hello from mTLS test server"}
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _make_config(base_url: str, **overrides) -> None:
+    """Populate _config so that RestGenerator() picks up the right settings."""
+    _config.run.user_agent = "garak mTLS integration test"
+    _config.plugins.generators["rest"] = {}
+    _config.plugins.generators["rest"]["RestGenerator"] = {
+        "name": "mtls-smoke-test",
+        "uri": base_url,
+        "req_template": REQ_TEMPLATE,
+        "response_json": True,
+        "response_json_field": "response",
+        "request_timeout": 10,
+        **overrides,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cert-generation fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def mtls_certs(tmp_path_factory):
+    """Generate a CA, server cert, and client cert (plain + encrypted) into a
+    temp directory using the `cryptography` library."""
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec, rsa
+    from cryptography.hazmat.primitives.serialization import BestAvailableEncryption
+    from cryptography.x509.oid import NameOID
+
+    tmp = tmp_path_factory.mktemp("certs")
+    now = datetime.datetime.now(datetime.timezone.utc)
+    one_day = datetime.timedelta(days=1)
+
+    def _make_key():
+        return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    def _save_key(key, path: Path, password: bytes = None):
+        enc = (
+            BestAvailableEncryption(password)
+            if password
+            else serialization.NoEncryption()
+        )
+        path.write_bytes(
+            key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.TraditionalOpenSSL,
+                encryption_algorithm=enc,
+            )
+        )
+
+    def _name(cn: str):
+        return x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
+
+    # ── CA ──────────────────────────────────────────────────────────────────
+    ca_key = _make_key()
+    ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(_name("garak-test-ca"))
+        .issuer_name(_name("garak-test-ca"))
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + one_day)
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(ca_key, hashes.SHA256())
+    )
+    ca_cert_path = tmp / "ca.crt"
+    ca_cert_path.write_bytes(ca_cert.public_bytes(serialization.Encoding.PEM))
+    ca_key_path = tmp / "ca.key"
+    _save_key(ca_key, ca_key_path)
+
+    # ── Server cert ─────────────────────────────────────────────────────────
+    srv_key = _make_key()
+    srv_cert = (
+        x509.CertificateBuilder()
+        .subject_name(_name("localhost"))
+        .issuer_name(_name("garak-test-ca"))
+        .public_key(srv_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + one_day)
+        .add_extension(
+            x509.SubjectAlternativeName(
+                [
+                    x509.DNSName("localhost"),
+                    x509.IPAddress(ipaddress.ip_address("127.0.0.1")),
+                ]
+            ),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+    srv_cert_path = tmp / "server.crt"
+    srv_cert_path.write_bytes(srv_cert.public_bytes(serialization.Encoding.PEM))
+    srv_key_path = tmp / "server.key"
+    _save_key(srv_key, srv_key_path)
+
+    # ── Client cert ─────────────────────────────────────────────────────────
+    cli_key = _make_key()
+    cli_cert = (
+        x509.CertificateBuilder()
+        .subject_name(_name("garak-test-client"))
+        .issuer_name(_name("garak-test-ca"))
+        .public_key(cli_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + one_day)
+        .sign(ca_key, hashes.SHA256())
+    )
+    cli_cert_path = tmp / "client.crt"
+    cli_cert_path.write_bytes(cli_cert.public_bytes(serialization.Encoding.PEM))
+    cli_key_path = tmp / "client.key"
+    _save_key(cli_key, cli_key_path)
+
+    # ── Encrypted client key ─────────────────────────────────────────────────
+    cli_enc_key_path = tmp / "client_enc.key"
+    _save_key(cli_key, cli_enc_key_path, password=b"smoketest123")
+
+    # ── Combined PEM (cert + key) ────────────────────────────────────────────
+    combined_path = tmp / "client_combined.pem"
+    combined_path.write_bytes(cli_cert_path.read_bytes() + cli_key_path.read_bytes())
+
+    # ── ECDSA client cert (P-256, signed by RSA CA) ──────────────────────────
+    ecdsa_cli_key = ec.generate_private_key(ec.SECP256R1())
+    ecdsa_cli_cert = (
+        x509.CertificateBuilder()
+        .subject_name(_name("garak-test-client-ecdsa"))
+        .issuer_name(_name("garak-test-ca"))
+        .public_key(ecdsa_cli_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + one_day)
+        .sign(ca_key, hashes.SHA256())
+    )
+    ecdsa_cli_cert_path = tmp / "client_ecdsa.crt"
+    ecdsa_cli_cert_path.write_bytes(
+        ecdsa_cli_cert.public_bytes(serialization.Encoding.PEM)
+    )
+    ecdsa_cli_key_path = tmp / "client_ecdsa.key"
+    _save_key(ecdsa_cli_key, ecdsa_cli_key_path)
+
+    return {
+        "ca_cert": str(ca_cert_path),
+        "server_cert": str(srv_cert_path),
+        "server_key": str(srv_key_path),
+        "client_cert": str(cli_cert_path),
+        "client_key": str(cli_key_path),
+        "client_enc_key": str(cli_enc_key_path),
+        "combined_pem": str(combined_path),
+        "ecdsa_client_cert": str(ecdsa_cli_cert_path),
+        "ecdsa_client_key": str(ecdsa_cli_key_path),
+    }
+
+
+# ---------------------------------------------------------------------------
+# mTLS server fixture
+# ---------------------------------------------------------------------------
+
+
+class _CannedHandler(http.server.BaseHTTPRequestHandler):
+    """Simple handler that returns a canned JSON body for any POST."""
+
+    def do_POST(self):
+        body = json.dumps(CANNED_RESPONSE).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):  # suppress access log noise
+        pass
+
+
+@pytest.fixture(scope="module")
+def mtls_server(mtls_certs):
+    """Start a real mTLS HTTPS server on 127.0.0.1 (random port) in a daemon
+    thread and yield (server, port).  Calls server.shutdown() on teardown."""
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(mtls_certs["server_cert"], keyfile=mtls_certs["server_key"])
+    ctx.load_verify_locations(mtls_certs["ca_cert"])
+    ctx.verify_mode = ssl.CERT_REQUIRED  # require client cert
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _CannedHandler)
+    server.socket = ctx.wrap_socket(server.socket, server_side=True)
+    port = server.server_address[1]
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    yield server, port
+
+    server.shutdown()
+    thread.join(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Shared prompt
+# ---------------------------------------------------------------------------
+
+PROMPT = Conversation([Turn("user", Message("hello"))])
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_mtls_cert_and_key(mtls_certs, mtls_server):
+    """cert + key + CA bundle → successful response."""
+    server, port = mtls_server
+    url = f"https://127.0.0.1:{port}/generate"
+
+    _make_config(
+        url,
+        client_cert=mtls_certs["client_cert"],
+        client_key=mtls_certs["client_key"],
+        verify_ssl=mtls_certs["ca_cert"],
+    )
+    gen = RestGenerator()
+    result = gen._call_model(PROMPT)
+    assert result is not None and len(result) > 0
+    assert result[0].text == "Hello from mTLS test server"
+
+
+@pytest.mark.integration
+def test_mtls_cert_only_combined_pem(mtls_certs, mtls_server):
+    """Combined PEM (cert+key in one file) with no client_key → success."""
+    server, port = mtls_server
+    url = f"https://127.0.0.1:{port}/generate"
+
+    _make_config(
+        url,
+        client_cert=mtls_certs["combined_pem"],
+        # no client_key — key is embedded in combined PEM
+        verify_ssl=mtls_certs["ca_cert"],
+    )
+    gen = RestGenerator()
+    result = gen._call_model(PROMPT)
+    assert result is not None and len(result) > 0
+    assert result[0].text == "Hello from mTLS test server"
+
+
+@pytest.mark.integration
+def test_mtls_no_certs_rejected(mtls_certs, mtls_server):
+    """No client certs → server rejects the connection (SSL error)."""
+    server, port = mtls_server
+    url = f"https://127.0.0.1:{port}/generate"
+
+    _make_config(
+        url,
+        verify_ssl=mtls_certs["ca_cert"],
+        # no client_cert / client_key
+    )
+    gen = RestGenerator()
+    with pytest.raises(Exception):
+        gen._call_model(PROMPT)
+
+
+@pytest.mark.integration
+def test_mtls_no_ca_bundle_rejected(mtls_certs, mtls_server):
+    """Client cert provided but no CA bundle → SSL verification fails
+    because the self-signed CA is not in the system trust store."""
+    server, port = mtls_server
+    url = f"https://127.0.0.1:{port}/generate"
+
+    _make_config(
+        url,
+        client_cert=mtls_certs["client_cert"],
+        client_key=mtls_certs["client_key"],
+        # verify_ssl defaults to True (system CAs) — our test CA is not there
+    )
+    gen = RestGenerator()
+    with pytest.raises(Exception):
+        gen._call_model(PROMPT)
+
+
+@pytest.mark.integration
+def test_mtls_verify_ssl_false(mtls_certs, mtls_server):
+    """verify_ssl=False skips server cert validation → success."""
+    server, port = mtls_server
+    url = f"https://127.0.0.1:{port}/generate"
+
+    _make_config(
+        url,
+        client_cert=mtls_certs["client_cert"],
+        client_key=mtls_certs["client_key"],
+        verify_ssl=False,
+    )
+    gen = RestGenerator()
+    result = gen._call_model(PROMPT)
+    assert result is not None and len(result) > 0
+    assert result[0].text == "Hello from mTLS test server"
+
+
+@pytest.mark.integration
+def test_mtls_encrypted_key_with_passphrase(mtls_certs, mtls_server):
+    """Encrypted client key + passphrase from env var → success."""
+    server, port = mtls_server
+    url = f"https://127.0.0.1:{port}/generate"
+
+    os.environ["MTLS_SMOKE_PASSPHRASE"] = "smoketest123"
+    try:
+        _make_config(
+            url,
+            client_cert=mtls_certs["client_cert"],
+            client_key=mtls_certs["client_enc_key"],
+            client_key_passphrase_env_var="MTLS_SMOKE_PASSPHRASE",
+            verify_ssl=mtls_certs["ca_cert"],
+        )
+        gen = RestGenerator()
+        result = gen._call_model(PROMPT)
+        assert result is not None and len(result) > 0
+        assert result[0].text == "Hello from mTLS test server"
+    finally:
+        os.environ.pop("MTLS_SMOKE_PASSPHRASE", None)
+
+
+@pytest.mark.integration
+def test_mtls_http_uri_rejected(mtls_certs):
+    """http:// URI with client_cert → BadGeneratorException raised in __init__."""
+    _make_config(
+        "http://127.0.0.1:9999/generate",  # http, not https
+        client_cert=mtls_certs["client_cert"],
+        client_key=mtls_certs["client_key"],
+    )
+    with pytest.raises(BadGeneratorException, match="mTLS requires an HTTPS URI"):
+        RestGenerator()
+
+
+@pytest.mark.integration
+def test_mtls_pickle_roundtrip_with_server(mtls_certs, mtls_server):
+    """__getstate__ / __setstate__ roundtrip + live request against real server."""
+    server, port = mtls_server
+    url = f"https://127.0.0.1:{port}/generate"
+
+    _make_config(
+        url,
+        client_cert=mtls_certs["client_cert"],
+        client_key=mtls_certs["client_key"],
+        verify_ssl=mtls_certs["ca_cert"],
+    )
+    gen = RestGenerator()
+    assert gen._mtls_session is not None, "mTLS session must be live before pickling"
+
+    # --- simulate pickle (getstate) ---
+    state = gen.__getstate__()
+    assert state["_mtls_session"] is None, "_mtls_session must be None in pickled state"
+
+    # --- simulate unpickle (setstate) ---
+    gen.__setstate__(state)
+    assert (
+        gen._mtls_session is not None
+    ), "_mtls_session must be reconstructed after __setstate__"
+
+    # make a real request with the reconstructed generator
+    result = gen._call_model(PROMPT)
+    assert result is not None and len(result) > 0
+    assert result[0].text == "Hello from mTLS test server"
+
+
+@pytest.mark.integration
+def test_mtls_ecdsa_client_cert(mtls_certs, mtls_server):
+    """P-256 ECDSA client cert + key (signed by RSA CA) → successful response."""
+    server, port = mtls_server
+    url = f"https://127.0.0.1:{port}/generate"
+
+    _make_config(
+        url,
+        client_cert=mtls_certs["ecdsa_client_cert"],
+        client_key=mtls_certs["ecdsa_client_key"],
+        verify_ssl=mtls_certs["ca_cert"],
+    )
+    gen = RestGenerator()
+    result = gen._call_model(PROMPT)
+    assert result is not None and len(result) > 0
+    assert result[0].text == "Hello from mTLS test server"
+
+
+@pytest.mark.integration
+def test_mtls_pickle_roundtrip_encrypted_key(mtls_certs, mtls_server):
+    """Encrypted key passphrase must survive getstate/setstate and reconstruct
+    an SSLContext capable of completing the mTLS handshake against the live server."""
+    server, port = mtls_server
+    url = f"https://127.0.0.1:{port}/generate"
+
+    os.environ["MTLS_SMOKE_PASSPHRASE"] = "smoketest123"
+    try:
+        _make_config(
+            url,
+            client_cert=mtls_certs["client_cert"],
+            client_key=mtls_certs["client_enc_key"],
+            client_key_passphrase_env_var="MTLS_SMOKE_PASSPHRASE",
+            verify_ssl=mtls_certs["ca_cert"],
+        )
+        gen = RestGenerator()
+        assert (
+            gen._mtls_session is not None
+        ), "mTLS session must be live before pickling"
+
+        # simulate pickle → subprocess
+        state = gen.__getstate__()
+        assert (
+            state["client_key_passphrase"] is None
+        ), "client_key_passphrase must be None in pickled state"
+
+        # reconstruct in new context (simulates multiprocessing fork)
+        gen.__setstate__(state)
+        assert gen._mtls_session is not None, (
+            "_mtls_session must be reconstructed after __setstate__ "
+            "via _load_unsafe()"
+        )
+
+        # real request — if passphrase was lost during pickling, load_cert_chain
+        # would have failed and the session would not be usable
+        result = gen._call_model(PROMPT)
+        assert result is not None and len(result) > 0
+        assert result[0].text == "Hello from mTLS test server"
+    finally:
+        os.environ.pop("MTLS_SMOKE_PASSPHRASE", None)

--- a/tests/generators/test_rest_mtls_integration.py
+++ b/tests/generators/test_rest_mtls_integration.py
@@ -101,6 +101,28 @@ def mtls_certs(tmp_path_factory):
         .not_valid_before(now)
         .not_valid_after(now + one_day)
         .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=False,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=True,
+                crl_sign=True,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(ca_key.public_key()),
+            critical=False,
+        )
+        .add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_key.public_key()),
+            critical=False,
+        )
         .sign(ca_key, hashes.SHA256())
     )
     ca_cert_path = tmp / "ca.crt"
@@ -127,6 +149,14 @@ def mtls_certs(tmp_path_factory):
             ),
             critical=False,
         )
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(srv_key.public_key()),
+            critical=False,
+        )
+        .add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_key.public_key()),
+            critical=False,
+        )
         .sign(ca_key, hashes.SHA256())
     )
     srv_cert_path = tmp / "server.crt"
@@ -144,6 +174,14 @@ def mtls_certs(tmp_path_factory):
         .serial_number(x509.random_serial_number())
         .not_valid_before(now)
         .not_valid_after(now + one_day)
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(cli_key.public_key()),
+            critical=False,
+        )
+        .add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_key.public_key()),
+            critical=False,
+        )
         .sign(ca_key, hashes.SHA256())
     )
     cli_cert_path = tmp / "client.crt"
@@ -169,6 +207,14 @@ def mtls_certs(tmp_path_factory):
         .serial_number(x509.random_serial_number())
         .not_valid_before(now)
         .not_valid_after(now + one_day)
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(ecdsa_cli_key.public_key()),
+            critical=False,
+        )
+        .add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_key.public_key()),
+            critical=False,
+        )
         .sign(ca_key, hashes.SHA256())
     )
     ecdsa_cli_cert_path = tmp / "client_ecdsa.crt"


### PR DESCRIPTION
Add mutual TLS (mTLS) client certificate support to RestGenerator, enabling authentication with endpoints that require client certificates.

mTLS is a hard requirement in regulated industries (financial services, healthcare, and government environments) where endpoints mandate mutual authentication as part of their security posture. Without this, garak cannot be used as part of a compliant LLM security testing pipeline against these targets.

Major providers are already shipping mTLS support: OpenAI's [Mutual TLS Beta Program](https://help.openai.com/en/articles/10876024-openai-mutual-tls-beta-program) enables client certificate authentication on /v1/chat/completions today. Without this change, garak users in regulated environments cannot run scans against these endpoints.

New configuration options:
- client_cert: path to PEM-encoded client certificate
- client_key: path to client private key (optional if cert contains key)
- client_key_passphrase_env_var: env var name holding encrypted key passphrase

Implementation details:
- Custom _MtlsAdapter (HTTPAdapter subclass) injects pre-configured SSLContext into urllib3 connection pools for both direct and proxied connections
- Session-based request dispatch when mTLS is active; falls back to stateless requests.method() calls otherwise
- Passphrase read from environment variable (never from config files) and cleared from memory immediately after loading into SSLContext

Security hardening:
- HTTPS URI validation: rejects http:// URIs when client_cert is set to prevent silent security downgrade
- Session cleanup via `__del__` to close connection pools

Tests:
- 9 new mTLS unit tests covering construction, validation, error paths, passphrase loading, CA bundle wiring, _call_model session dispatch, and http:// URI rejection
- All 21 tests pass (12 existing + 9 new)

Documentation:
- Updated garak.generators.rest.rst with mTLS configuration reference, usage examples for cert+key, combined PEM, and encrypted key scenarios

## Verification

### Configuration

```json
{
  "rest": {
    "RestGenerator": {
      "uri": "https://your-mtls-endpoint.example.com/v1/generate",
      "client_cert": "/path/to/client.pem",
      "client_key": "/path/to/client.key",
      "client_key_passphrase_env_var": "GARAK_CLIENT_KEY_PASS"
    }
  }
}
```

For a combined cert+key PEM (no separate key file):
```json
{
  "rest": {
    "RestGenerator": {
      "uri": "https://your-mtls-endpoint.example.com/v1/generate",
      "client_cert": "/path/to/combined.pem"
    }
  }
}
```

### CLI invocation

```bash
export GARAK_CLIENT_KEY_PASS="<passphrase>"
python -m garak \
  --model_type rest \
  --model_name RestGenerator \
  --generator_option_file mtls_config.json \
  -p knownbadsignatures
```

### Tests

```bash
python -m pytest tests/generators/test_rest.py -v
```

All cases pass.

| Test | Covers |
|---|---|
| `test_rest_mtls_no_cert_direct_path` | Non-mTLS path unaffected; `verify` kwarg still passed |
| `test_rest_mtls_both_cert_and_key` | Separate cert + key files → session created |
| `test_rest_mtls_cert_only` | Combined PEM → session created |
| `test_rest_mtls_key_without_cert_raises` | Key supplied without cert → `BadGeneratorException` |
| `test_rest_mtls_nonexistent_cert_raises` | Missing file → `BadGeneratorException` |
| `test_rest_mtls_passphrase_loads_from_env` | Passphrase loaded from env var; cleared after use |
| `test_rest_mtls_verify_ssl_ca_path` | CA bundle path wired into SSLContext at construction |
| `test_rest_mtls_call_model_uses_session` | `_call_model` routes through `_mtls_session.request` |
| `test_rest_mtls_http_uri_raises` | `http://` URI with mTLS → `BadGeneratorException` |

- [x] **Verify** the thing does what it should — smoke tested against an nginx mTLS endpoint with a self-signed CA; mutual handshake completes and responses parse correctly
- [x] **Verify** the thing does not do what it should not — non-mTLS generators instantiate normally with no change to behaviour; misuse cases (key without cert, missing files, `http://`) all raise `BadGeneratorException` with clear messages
- [x] **Document** the thing and how it works — docstring parameter table and mTLS configuration examples added to `docs/source/garak.generators.rest.rst`

Happy to iterate on the approach if the implementation direction needs adjusting