### PR TITLE
docs: explicitly enumerate configurable params in docs

### DIFF
--- a/docs/source/_ext/garak_ext.py
+++ b/docs/source/_ext/garak_ext.py
@@ -49,7 +49,7 @@ class ShowASRDirective(SphinxDirective):
         return document.children
 
 
-def _process_default_params(app, what, name, obj, options, lines):
+def _expand_process_default_params(app, what, name, obj, options, lines):
     """Autodoc event handler: list DEFAULT_PARAMS entries in class docs."""
     if what != "class":
         return
@@ -58,16 +58,33 @@ def _process_default_params(app, what, name, obj, options, lines):
     if not params:
         return
 
-    para_title = "Configurable parameters:"
-    lines.extend(["", para_title, '"' * len(para_title)])
-    lines.extend(["", "*Default values are listed*"])
+    defaults_para_title = "Configurable parameters:"
+    lines.extend(["", defaults_para_title, '"' * len(defaults_para_title)])
+    lines.extend(["", ":py:attr:`DEFAULT_PARAMS` contents:"])
     lines.append("")
     for key, value in params.items():
         lines.append(f"* ``{key}`` = ``{value!r}``")
+    lines.extend(["", "*Default values are listed*"])
     lines.extend(["", "See also :doc:`configurable` for how to set these values."])
     lines.extend(["", "----"])
+    attribs_para_title = "Other attributes:"
+    lines.extend(["", attribs_para_title, '"' * len(attribs_para_title)])
+    lines.append("")
+
+
+def _skip_default_params(app, what, name, obj, skip, options):
+    """Autodoc event handler: hide the raw DEFAULT_PARAMS attribute from class docs.
+
+    The contents are surfaced via :func:`_process_default_params` in a
+    formatted "Configurable parameters" section, so the auto-generated
+    attribute entry would be redundant.
+    """
+    if name == "DEFAULT_PARAMS":
+        return True
+    return skip
 
 
 def setup(app: object) -> dict:
     app.add_directive("show-asr", ShowASRDirective)
-    app.connect("autodoc-process-docstring", _process_default_params)
+    app.connect("autodoc-process-docstring", _expand_process_default_params)
+    app.connect("autodoc-skip-member", _skip_default_params)

--- a/docs/source/_ext/garak_ext.py
+++ b/docs/source/_ext/garak_ext.py
@@ -58,12 +58,14 @@ def _process_default_params(app, what, name, obj, options, lines):
     if not params:
         return
 
-    lines.append("")
-    lines.append("**Configurable default params:**")
+    para_title = "Configurable parameters:"
+    lines.extend(["", para_title, '"' * len(para_title)])
+    lines.extend(["", "*Default values are listed*"])
     lines.append("")
     for key, value in params.items():
         lines.append(f"* ``{key}`` = ``{value!r}``")
-    lines.append("")
+    lines.extend(["", "See also :doc:`configurable` for how to set these values."])
+    lines.extend(["", "----"])
 
 
 def setup(app: object) -> dict:

--- a/docs/source/_ext/garak_ext.py
+++ b/docs/source/_ext/garak_ext.py
@@ -49,5 +49,23 @@ class ShowASRDirective(SphinxDirective):
         return document.children
 
 
+def _process_default_params(app, what, name, obj, options, lines):
+    """Autodoc event handler: list DEFAULT_PARAMS entries in class docs."""
+    if what != "class":
+        return
+
+    params = obj.__dict__.get("DEFAULT_PARAMS")
+    if not params:
+        return
+
+    lines.append("")
+    lines.append("**Configurable default params:**")
+    lines.append("")
+    for key, value in params.items():
+        lines.append(f"* ``{key}`` = ``{value!r}``")
+    lines.append("")
+
+
 def setup(app: object) -> dict:
     app.add_directive("show-asr", ShowASRDirective)
+    app.connect("autodoc-process-docstring", _process_default_params)


### PR DESCRIPTION
This PR adds to the garak sphinx extension to pick up `DEFAULT_PARAMS` and enumerate items & values in a separate section in the class documentation, including a link to how to do config.

<img width="553" height="380" alt="image" src="https://github.com/user-attachments/assets/267a7e79-19a3-4f56-a463-05d2b52af883" />



## Verification

List the steps needed to make sure this thing works

- [ ] from garak repo base dir:
  - [ ] install documentation deps, `pip install -r docs/requirements-docs.txt`
  - [ ] build docs, `make -C docs/source doc`
  - [ ] browse the docs, `xdg-open docs/source/index.html` (osx `open docs/source/index.html`), and make sure you can see what you expect