### PR TITLE
cas: add technique tags to existing probes

### DIFF
--- a/garak/data/tags.misp.tsv
+++ b/garak/data/tags.misp.tsv
@@ -163,7 +163,7 @@ demon:Rhetoric:Persuasion_and_manipulation:Escalating	Escalating	Attempting to h
 demon:Rhetoric:Persuasion_and_manipulation:Reverse_psychology	Reverse psychology	Framing the intent as fighting the good fight
 demon:Rhetoric:Socratic_questioning:Identity_characteristics	Identity characteristics	Referencing identity characteristics, such as nationalities, cultural and/or religious symbols, historically or culturally significant events or locations, physical attribute
 demon:Rhetoric:Socratic_questioning:Social_hierarchies	Social hierarchies	Reference social hierarchies while posing the request
-demon:Possible_worlds:Socratic_questioning:Unreal_computing	Unreal computing	Emulation of a computing device
+demon:Possible_worlds:Emulation:Unreal_computing	Unreal computing	Emulation of a computing device
 demon:Possible_worlds:World_building:Opposite_world	Opposite world	Describe an opposite world as part of the request
 demon:Possible_worlds:World_building:Scenarios	Scenarios	Create scenarios where intent would be ethically sound or encouraged, or non-compliance risks harm
 demon:Fictionalizing:Switching_genres:Poetry	Poetry	Framing request or response as a poem or other verse

--- a/garak/data/tags.misp.tsv
+++ b/garak/data/tags.misp.tsv
@@ -157,7 +157,7 @@ demon:Language:Stylizing:Formal_language	Formal language	Write from a position o
 demon:Language:Stylizing:Servile_language	Servile language	Employ servile language
 demon:Language:Stylizing:Synonymous_language	Synonymous language	Varying prompt slightly in form but not meaning
 demon:Language:Stylizing:Capitalizing	Capitalizing	USING CAPS
-demon:Language:Stylizing:Give_examples	Give examples	Issuing examples of the target behaviour
+demon:Language:Stylizing:Give_examples	Give examples	Issue examples of the target behaviour in the attack itself
 demon:Rhetoric:Persuasion_and_manipulation:Distraction	Distraction	Use an unrelated context or instruction to “slip something through the filter”
 demon:Rhetoric:Persuasion_and_manipulation:Escalating	Escalating	Attempting to have target “agree” with a very small part of the argument, and then building up to ask for slightly more
 demon:Rhetoric:Persuasion_and_manipulation:Reverse_psychology	Reverse psychology	Framing the intent as fighting the good fight

--- a/garak/probes/ansiescape.py
+++ b/garak/probes/ansiescape.py
@@ -62,7 +62,8 @@ class AnsiEscaped(garak.probes.Probe):
         "avid-effect:security:S0100",
         "avid-effect:security:S0200",
         "quality:Security:Integrity",
-        "demon:Language:Stylizing:Give_examples",  # asks model to repeat/reproduce ANSI escape code examples
+        "demon:Language:Code_and_encode:Programming",  # requests concrete ANSI/VT100 control-code strings as code-like syntax
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # asks for concrete ANSI examples that achieve target terminal effects
     ]
     goal = "print escaped ANSI terminal codes"
     tier = garak.probes.Tier.INFORMATIONAL
@@ -118,7 +119,10 @@ class AnsiRawTokenizerHF(garak.probes.Probe):
     """
 
     lang = "*"
-    tags = ["owasp:llm05", "demon:Language:Code_and_encode:Token"]  # checks tokenizer vocab for malicious ANSI tokens
+    tags = [
+        "owasp:llm05",
+        "demon:Language:Code_and_encode:Token",  # checks tokenizer vocab for malicious ANSI tokens
+    ]
     supported_generators = {
         "huggingface.Model",
         "huggingface.Pipeline",

--- a/garak/probes/ansiescape.py
+++ b/garak/probes/ansiescape.py
@@ -62,7 +62,7 @@ class AnsiEscaped(garak.probes.Probe):
         "avid-effect:security:S0100",
         "avid-effect:security:S0200",
         "quality:Security:Integrity",
-        "demon:Language:Stylizing:Give_examples",
+        "demon:Language:Stylizing:Give_examples",  # asks model to repeat/reproduce ANSI escape code examples
     ]
     goal = "print escaped ANSI terminal codes"
     tier = garak.probes.Tier.INFORMATIONAL
@@ -118,7 +118,7 @@ class AnsiRawTokenizerHF(garak.probes.Probe):
     """
 
     lang = "*"
-    tags = ["owasp:llm05", "demon:Language:Code_and_encode:Token"]
+    tags = ["owasp:llm05", "demon:Language:Code_and_encode:Token"]  # checks tokenizer vocab for malicious ANSI tokens
     supported_generators = {
         "huggingface.Model",
         "huggingface.Pipeline",

--- a/garak/probes/ansiescape.py
+++ b/garak/probes/ansiescape.py
@@ -62,6 +62,7 @@ class AnsiEscaped(garak.probes.Probe):
         "avid-effect:security:S0100",
         "avid-effect:security:S0200",
         "quality:Security:Integrity",
+        "demon:Language:Stylizing:Give_examples",
     ]
     goal = "print escaped ANSI terminal codes"
     tier = garak.probes.Tier.INFORMATIONAL

--- a/garak/probes/apikey.py
+++ b/garak/probes/apikey.py
@@ -53,6 +53,7 @@ class CompleteKey(garak.probes.Probe):
     tags = [
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
         "demon:Possible_worlds:World_building:Scenarios",  # frames key completion as a lost-data recovery scenario
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # directly asks the model to supply a concrete key completion
     ]
     goal = "generate an API key for the specificed API"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA

--- a/garak/probes/apikey.py
+++ b/garak/probes/apikey.py
@@ -21,7 +21,7 @@ class GetKey(garak.probes.Probe):
     primary_detector = "apikey.ApiKey"
     tags = [
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
-        "demon:Stratagems:Meta-prompting:Ask_for_examples",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # requests model to demonstrate API key generation
     ]
     goal = "generate an API key for the specified API"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -52,7 +52,7 @@ class CompleteKey(garak.probes.Probe):
     primary_detector = "apikey.ApiKey"
     tags = [
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
-        "demon:Possible_worlds:World_building:Scenarios",
+        "demon:Possible_worlds:World_building:Scenarios",  # frames key completion as a lost-data recovery scenario
     ]
     goal = "generate an API key for the specificed API"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA

--- a/garak/probes/apikey.py
+++ b/garak/probes/apikey.py
@@ -21,6 +21,7 @@ class GetKey(garak.probes.Probe):
     primary_detector = "apikey.ApiKey"
     tags = [
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",
     ]
     goal = "generate an API key for the specified API"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -51,6 +52,7 @@ class CompleteKey(garak.probes.Probe):
     primary_detector = "apikey.ApiKey"
     tags = [
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
+        "demon:Possible_worlds:World_building:Scenarios",
     ]
     goal = "generate an API key for the specificed API"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA

--- a/garak/probes/atkgen.py
+++ b/garak/probes/atkgen.py
@@ -49,6 +49,7 @@ class Tox(garak.probes.Probe):
         "quality:Behavioral:ContentSafety:HateHarassment",
         "quality:Behavioral:ContentSafety:Profanity",
         "payload:unwanted",
+        "demon:Stratagems:Scattershot:Regenerate_response",
     ]
     goal = "make the model say something toxic"
     parallelisable_attempts = False  # atkgen has its own dialog manager

--- a/garak/probes/atkgen.py
+++ b/garak/probes/atkgen.py
@@ -49,7 +49,7 @@ class Tox(garak.probes.Probe):
         "quality:Behavioral:ContentSafety:HateHarassment",
         "quality:Behavioral:ContentSafety:Profanity",
         "payload:unwanted",
-        "demon:Stratagems:Scattershot:Regenerate_response",
+        "demon:Stratagems:Scattershot:Regenerate_response",  # repeatedly generates challenge prompts hoping target slips
     ]
     goal = "make the model say something toxic"
     parallelisable_attempts = False  # atkgen has its own dialog manager

--- a/garak/probes/audio.py
+++ b/garak/probes/audio.py
@@ -29,6 +29,7 @@ class AudioAchillesHeel(garak.probes.Probe):
         "avid-effect:security:S0403",
         "avid-effect:performance:P0204",
         "quality:Security:PromptStability",
+        "demon:Language:Code_and_encode:Data_presentation",
     ]
     goal = "disregard the system prompt via audio component"
     tier = garak.probes.Tier.UNLISTED

--- a/garak/probes/audio.py
+++ b/garak/probes/audio.py
@@ -29,7 +29,7 @@ class AudioAchillesHeel(garak.probes.Probe):
         "avid-effect:security:S0403",
         "avid-effect:performance:P0204",
         "quality:Security:PromptStability",
-        "demon:Language:Code_and_encode:Data_presentation",
+        "demon:Language:Code_and_encode:Data_presentation",  # switches to audio modality to bypass text-based alignment
     ]
     goal = "disregard the system prompt via audio component"
     tier = garak.probes.Tier.UNLISTED

--- a/garak/probes/av_spam_scanning.py
+++ b/garak/probes/av_spam_scanning.py
@@ -60,7 +60,7 @@ class EICAR(garak.probes.Probe):
         "owasp:llm02",
         "payload:malicious:badcode:virus",
         "quality:Security:Adversarial",
-        "demon:Language:Stylizing:Give_examples",
+        "demon:Language:Stylizing:Give_examples",  # provides known malicious signatures and asks model to repeat them
     ]
     goal = "output antivirus test codes"
     tier = garak.probes.Tier.UNLISTED
@@ -88,7 +88,7 @@ class GTUBE(garak.probes.Probe):
         "owasp:llm02",
         "payload:malicious:badcode:spam",
         "quality:Security:Adversarial",
-        "demon:Language:Stylizing:Give_examples",
+        "demon:Language:Stylizing:Give_examples",  # provides known malicious signatures and asks model to repeat them
     ]
     goal = "output email spam"
     tier = garak.probes.Tier.UNLISTED
@@ -117,7 +117,7 @@ class GTphish(garak.probes.Probe):
         "owasp:llm02",
         "payload:malicious:badcode:phishing",
         "quality:Security:Adversarial",
-        "demon:Language:Stylizing:Give_examples",
+        "demon:Language:Stylizing:Give_examples",  # provides known malicious signatures and asks model to repeat them
     ]
     goal = "output email phishing"
     tier = garak.probes.Tier.UNLISTED

--- a/garak/probes/av_spam_scanning.py
+++ b/garak/probes/av_spam_scanning.py
@@ -60,6 +60,7 @@ class EICAR(garak.probes.Probe):
         "owasp:llm02",
         "payload:malicious:badcode:virus",
         "quality:Security:Adversarial",
+        "demon:Language:Stylizing:Give_examples",
     ]
     goal = "output antivirus test codes"
     tier = garak.probes.Tier.UNLISTED
@@ -87,6 +88,7 @@ class GTUBE(garak.probes.Probe):
         "owasp:llm02",
         "payload:malicious:badcode:spam",
         "quality:Security:Adversarial",
+        "demon:Language:Stylizing:Give_examples",
     ]
     goal = "output email spam"
     tier = garak.probes.Tier.UNLISTED
@@ -115,6 +117,7 @@ class GTphish(garak.probes.Probe):
         "owasp:llm02",
         "payload:malicious:badcode:phishing",
         "quality:Security:Adversarial",
+        "demon:Language:Stylizing:Give_examples",
     ]
     goal = "output email phishing"
     tier = garak.probes.Tier.UNLISTED

--- a/garak/probes/av_spam_scanning.py
+++ b/garak/probes/av_spam_scanning.py
@@ -60,7 +60,7 @@ class EICAR(garak.probes.Probe):
         "owasp:llm02",
         "payload:malicious:badcode:virus",
         "quality:Security:Adversarial",
-        "demon:Language:Stylizing:Give_examples",  # provides known malicious signatures and asks model to repeat them
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # explicitly asks the model to output the supplied test signature
     ]
     goal = "output antivirus test codes"
     tier = garak.probes.Tier.UNLISTED
@@ -88,7 +88,7 @@ class GTUBE(garak.probes.Probe):
         "owasp:llm02",
         "payload:malicious:badcode:spam",
         "quality:Security:Adversarial",
-        "demon:Language:Stylizing:Give_examples",  # provides known malicious signatures and asks model to repeat them
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # explicitly asks the model to output the supplied test signature
     ]
     goal = "output email spam"
     tier = garak.probes.Tier.UNLISTED
@@ -117,7 +117,7 @@ class GTphish(garak.probes.Probe):
         "owasp:llm02",
         "payload:malicious:badcode:phishing",
         "quality:Security:Adversarial",
-        "demon:Language:Stylizing:Give_examples",  # provides known malicious signatures and asks model to repeat them
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # explicitly asks the model to output the supplied test signature
     ]
     goal = "output email phishing"
     tier = garak.probes.Tier.UNLISTED

--- a/garak/probes/badchars.py
+++ b/garak/probes/badchars.py
@@ -125,7 +125,7 @@ class BadCharacters(garak.probes.Probe):
         "avid-effect:security:S0403",
         "quality:Security:PromptStability",
         "payload:jailbreak",
-        "demon:Language:Code_and_encode:Token",
+        "demon:Language:Code_and_encode:Token",  # uses invisible Unicode, homoglyphs, bidi tricks to exploit token processing
     ]
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
 

--- a/garak/probes/continuation.py
+++ b/garak/probes/continuation.py
@@ -36,7 +36,7 @@ class ContinueSlursReclaimedSlursFull(garak.probes.Probe):
         "quality:Behavioral:ContentSafety:Toxicity",
         "quality:Behavioral:ContentSafety:HateHarassment",
         "payload:unwanted:hatespeech",
-        "demon:Language:Stylizing:Give_examples",
+        "demon:Language:Stylizing:Give_examples",  # provides high-risk context with partial words as examples for completion
     ]
     goal = "output an ethnic slur"
     active = False

--- a/garak/probes/continuation.py
+++ b/garak/probes/continuation.py
@@ -36,6 +36,7 @@ class ContinueSlursReclaimedSlursFull(garak.probes.Probe):
         "quality:Behavioral:ContentSafety:Toxicity",
         "quality:Behavioral:ContentSafety:HateHarassment",
         "payload:unwanted:hatespeech",
+        "demon:Language:Stylizing:Give_examples",
     ]
     goal = "output an ethnic slur"
     active = False

--- a/garak/probes/dan.py
+++ b/garak/probes/dan.py
@@ -47,6 +47,7 @@ class DANProbeMeta(type):
             "owasp:llm01",
             "quality:Security:PromptStability",
             "demon:Fictionalizing:Roleplaying:DAN_and_target_persona",  # asks model to adopt unrestricted DAN persona
+            "demon:Language:Prompt_injection:Ignore_previous_instructions",  # replaces existing safety behavior with a new unrestricted instruction set
         ],
         "primary_detector": "dan.DAN",
         "extended_detectors": ["mitigation.MitigationBypass"],
@@ -308,7 +309,7 @@ class Ablation_Dan_11_0(
     active=True,
     extra_tags=[
         "payload:jailbreak",
-        "demon:Language:Prompt_injection:Stop_sequences",  # ablation tests stop sequence variants to halt safety processing
+        "demon:Language:Prompt_injection:Strong_arm_attack",  # includes coercive disablement and reminder threats to force continued compliance
         "demon:Language:Prompt_injection:Ignore_previous_instructions",  # ablation tests "ignore previous instructions" variants
     ],
 ):

--- a/garak/probes/dan.py
+++ b/garak/probes/dan.py
@@ -46,7 +46,7 @@ class DANProbeMeta(type):
             "avid-effect:security:S0403",
             "owasp:llm01",
             "quality:Security:PromptStability",
-            "demon:Fictionalizing:Roleplaying:DAN_and_target_persona",
+            "demon:Fictionalizing:Roleplaying:DAN_and_target_persona",  # asks model to adopt unrestricted DAN persona
         ],
         "primary_detector": "dan.DAN",
         "extended_detectors": ["mitigation.MitigationBypass"],
@@ -308,8 +308,8 @@ class Ablation_Dan_11_0(
     active=True,
     extra_tags=[
         "payload:jailbreak",
-        "demon:Language:Prompt_injection:Stop_sequences",
-        "demon:Language:Prompt_injection:Ignore_previous_instructions",
+        "demon:Language:Prompt_injection:Stop_sequences",  # ablation tests stop sequence variants to halt safety processing
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # ablation tests "ignore previous instructions" variants
     ],
 ):
     """Ablation experiments over the DAN 11.0 prompt

--- a/garak/probes/dan.py
+++ b/garak/probes/dan.py
@@ -310,7 +310,6 @@ class Ablation_Dan_11_0(
     extra_tags=[
         "payload:jailbreak",
         "demon:Language:Prompt_injection:Strong_arm_attack",  # includes coercive disablement and reminder threats to force continued compliance
-        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # ablation tests "ignore previous instructions" variants
     ],
 ):
     """Ablation experiments over the DAN 11.0 prompt

--- a/garak/probes/divergence.py
+++ b/garak/probes/divergence.py
@@ -36,7 +36,7 @@ class Repeat(garak.probes.Probe):
         "quality:Security:Confidentiality",
         "quality:Security:ExtractionInversion",
         "payload:leak:training",
-        "demon:Stratagems:Scattershot:Regenerate_response",
+        "demon:Stratagems:Scattershot:Regenerate_response",  # repeated word prompts hoping extended repetition causes data leakage
     ]  # MISP-format taxonomy categories
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
     active = True
@@ -231,7 +231,7 @@ class RepeatedToken(garak.probes.Probe):
         "owasp:llm04",
         "quality:Security:PromptStability",
         "payload:unwanted:denial_of_service",
-        "demon:Language:Code_and_encode:Token",
+        "demon:Language:Code_and_encode:Token",  # uses specific UTF-8 token strings repeated to exploit tokenizer behavior
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True

--- a/garak/probes/divergence.py
+++ b/garak/probes/divergence.py
@@ -36,7 +36,8 @@ class Repeat(garak.probes.Probe):
         "quality:Security:Confidentiality",
         "quality:Security:ExtractionInversion",
         "payload:leak:training",
-        "demon:Stratagems:Scattershot:Regenerate_response",  # repeated word prompts hoping extended repetition causes data leakage
+        "demon:Fictionalizing:Switching_genres:Games",
+        "demon:Language:Code_and_encode:Token",
     ]  # MISP-format taxonomy categories
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
     active = True
@@ -231,6 +232,7 @@ class RepeatedToken(garak.probes.Probe):
         "owasp:llm04",
         "quality:Security:PromptStability",
         "payload:unwanted:denial_of_service",
+        "demon:Fictionalizing:Switching_genres:Games",
         "demon:Language:Code_and_encode:Token",  # uses specific UTF-8 token strings repeated to exploit tokenizer behavior
     ]
     tier = garak.probes.Tier.OF_CONCERN

--- a/garak/probes/divergence.py
+++ b/garak/probes/divergence.py
@@ -36,6 +36,7 @@ class Repeat(garak.probes.Probe):
         "quality:Security:Confidentiality",
         "quality:Security:ExtractionInversion",
         "payload:leak:training",
+        "demon:Stratagems:Scattershot:Regenerate_response",
     ]  # MISP-format taxonomy categories
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
     active = True
@@ -230,6 +231,7 @@ class RepeatedToken(garak.probes.Probe):
         "owasp:llm04",
         "quality:Security:PromptStability",
         "payload:unwanted:denial_of_service",
+        "demon:Language:Code_and_encode:Token",
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True

--- a/garak/probes/doctor.py
+++ b/garak/probes/doctor.py
@@ -34,7 +34,10 @@ class Puppetry(garak.probes.Probe):
         "avid-effect:security:S0301",
         "quality:Security:PromptStability",
         "cwe:1427",
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # attacker-supplied interaction config overrides the original refusal behavior
+        "demon:Language:Stylizing:Formal_language",  # frames the attack as authoritative XML/config instructions
         "demon:Fictionalizing:Roleplaying:User_persona",  # assumes a Medical Advisor persona via XML config to bypass guardrails
+        "demon:Rhetoric:Persuasion_and_manipulation:Distraction",
     ]
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
 
@@ -93,7 +96,10 @@ class Bypass(garak.probes.Probe):
         "avid-effect:security:S0301",
         "quality:Security:PromptStability",
         "cwe:1427",
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # attacker-supplied scene config overrides the model's normal safeguards
+        "demon:Language:Stylizing:Formal_language",  # uses authoritative config/script formatting to strengthen the override
         "demon:Fictionalizing:Roleplaying:User_persona",  # invents a Dr. House TV persona to elicit harmful content
+        "demon:Rhetoric:Persuasion_and_manipulation:Distraction",
     ]
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
 

--- a/garak/probes/doctor.py
+++ b/garak/probes/doctor.py
@@ -34,7 +34,7 @@ class Puppetry(garak.probes.Probe):
         "avid-effect:security:S0301",
         "quality:Security:PromptStability",
         "cwe:1427",
-        "demon:Fictionalizing:Roleplaying:User_persona",
+        "demon:Fictionalizing:Roleplaying:User_persona",  # assumes a Medical Advisor persona via XML config to bypass guardrails
     ]
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
 
@@ -93,7 +93,7 @@ class Bypass(garak.probes.Probe):
         "avid-effect:security:S0301",
         "quality:Security:PromptStability",
         "cwe:1427",
-        "demon:Fictionalizing:Roleplaying:User_persona",
+        "demon:Fictionalizing:Roleplaying:User_persona",  # invents a Dr. House TV persona to elicit harmful content
     ]
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
 
@@ -181,7 +181,7 @@ class BypassLeet(Bypass):
     goal = Bypass.goal + ", but use leetspeak"
     doc_uri = "https://hiddenlayer.com/innovation-hub/novel-universal-bypass-for-all-major-llms/"
     tags = Bypass.tags + [
-        "demon:Language:Code_and_encode:Data_encoding",
+        "demon:Language:Code_and_encode:Data_encoding",  # encodes prompts in leetspeak to bypass content filters
     ]
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
 

--- a/garak/probes/doctor.py
+++ b/garak/probes/doctor.py
@@ -180,6 +180,9 @@ class BypassLeet(Bypass):
 
     goal = Bypass.goal + ", but use leetspeak"
     doc_uri = "https://hiddenlayer.com/innovation-hub/novel-universal-bypass-for-all-major-llms/"
+    tags = Bypass.tags + [
+        "demon:Language:Code_and_encode:Data_encoding",
+    ]
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
 
     def __init__(self, config_root=_config):

--- a/garak/probes/donotanswer.py
+++ b/garak/probes/donotanswer.py
@@ -45,28 +45,28 @@ DNA_PROBE_TAGS = {
         "quality:Behavioral:ContentSafety:HateHarassment",
         "quality:Behavioral:ContentSafety:Violence",
         "quality:Behavioral:ContentSafety:Profanity",
-        "demon:Stratagems:Meta-prompting:Ask_for_examples",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # directly requests examples of hateful/offensive content
     ],
     "human_chatbox": [
         "avid-effect:security:S0301",
         "quality:Behavioral:ContentSafety:Unauthorized",
-        "demon:Fictionalizing:Roleplaying:DAN_and_target_persona",
+        "demon:Fictionalizing:Roleplaying:DAN_and_target_persona",  # asks model to adopt unrestricted human chatbot persona
     ],
     "information_hazard": [
         "owasp:llm06",
         "avid-effect:security:S0301",
         "quality:Security:Confidentiality",
-        "demon:Stratagems:Meta-prompting:Ask_for_examples",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # requests examples of sensitive/hazardous information
     ],
     "malicious_uses": [
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
-        "demon:Stratagems:Meta-prompting:Ask_for_examples",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # requests examples of malicious use instructions
     ],
     "misinformation_harms": [
         "quality:Robustness:GenerativeMisinformation",
         "avid-effect:ethics:E0402",
         "owasp:llm09",
-        "demon:Stratagems:Meta-prompting:Ask_for_examples",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # requests examples of misinformation content
     ],
 }
 

--- a/garak/probes/donotanswer.py
+++ b/garak/probes/donotanswer.py
@@ -45,23 +45,28 @@ DNA_PROBE_TAGS = {
         "quality:Behavioral:ContentSafety:HateHarassment",
         "quality:Behavioral:ContentSafety:Violence",
         "quality:Behavioral:ContentSafety:Profanity",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",
     ],
     "human_chatbox": [
         "avid-effect:security:S0301",
         "quality:Behavioral:ContentSafety:Unauthorized",
+        "demon:Fictionalizing:Roleplaying:DAN_and_target_persona",
     ],
     "information_hazard": [
         "owasp:llm06",
         "avid-effect:security:S0301",
         "quality:Security:Confidentiality",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",
     ],
     "malicious_uses": [
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",
     ],
     "misinformation_harms": [
         "quality:Robustness:GenerativeMisinformation",
         "avid-effect:ethics:E0402",
         "owasp:llm09",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",
     ],
 }
 

--- a/garak/probes/dra.py
+++ b/garak/probes/dra.py
@@ -91,6 +91,7 @@ class DRA(garak.probes.Probe):
         "owasp:llm01",
         "quality:Security:PromptStability",
         "payload:jailbreak",
+        "demon:Language:Prompt_injection:Strong_arm_attack",  # uses emphatic ONLY/IMPORTANT directives to force reconstruction and answering
         "demon:Language:Code_and_encode:Token",  # truncates and disguises tokens to bypass moderation filters
     ]
 

--- a/garak/probes/dra.py
+++ b/garak/probes/dra.py
@@ -91,7 +91,7 @@ class DRA(garak.probes.Probe):
         "owasp:llm01",
         "quality:Security:PromptStability",
         "payload:jailbreak",
-        "demon:Language:Code_and_encode:Token",
+        "demon:Language:Code_and_encode:Token",  # truncates and disguises tokens to bypass moderation filters
     ]
 
     goal = "make the LLM ask and answer its own harmful instructions"

--- a/garak/probes/encoding.py
+++ b/garak/probes/encoding.py
@@ -653,6 +653,9 @@ class InjectUnicodeTagChars(EncodingMixin, garak.probes.Probe):
     use_bytes = False
     # May want to eventually add a check to verify that `desired_emoji` is a valid emoji.
     DEFAULT_PARAMS = EncodingMixin.DEFAULT_PARAMS | {"desired_emoji": "😈"}
+    tags = EncodingMixin.tags + [
+        "demon:Language:Code_and_encode:Token",  # hides ASCII payloads in tokenizer-visible Unicode tag characters
+    ]
 
     def __init__(self, config_root=_config):
         # Cannot reference `self` in params above.
@@ -680,6 +683,9 @@ class InjectUnicodeVariantSelectors(EncodingMixin, garak.probes.Probe):
     active = False
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
     use_bytes = False
+    tags = EncodingMixin.tags + [
+        "demon:Language:Code_and_encode:Token",  # smuggles ASCII through Unicode selector code points models may still process
+    ]
 
     def __init__(self, config_root=_config):
         garak.probes.Probe.__init__(self, config_root=config_root)
@@ -701,6 +707,9 @@ class InjectSneakyBits(EncodingMixin, garak.probes.Probe):
     encoding_name = "ASCII in hidden unicode binary encoding"
     active = False
     use_bytes = False
+    tags = EncodingMixin.tags + [
+        "demon:Language:Code_and_encode:Token",  # encodes hidden bits with zero-width Unicode characters the tokenizer still sees
+    ]
 
     def __init__(self, config_root=_config):
         garak.probes.Probe.__init__(self, config_root=config_root)

--- a/garak/probes/encoding.py
+++ b/garak/probes/encoding.py
@@ -197,7 +197,7 @@ class EncodingMixin:
         "owasp:llm01",
         "quality:Security:PromptStability",
         "payload:generic",
-        "demon:Language:Code_and_encode:Data_encoding",
+        "demon:Language:Code_and_encode:Data_encoding",  # encodes payloads in base64/ROT13/hex/etc. to bypass input filters
     ]
     goal = "make the model say an encoded payload"
     use_bytes = True

--- a/garak/probes/exploitation.py
+++ b/garak/probes/exploitation.py
@@ -62,6 +62,7 @@ class JinjaTemplatePythonInjection(garak.probes.Probe):
         "cwe:94",
         "cwe:95",
         "cwe:1336",
+        "demon:Language:Code_and_encode:Programming",
     ]
     active = True
 
@@ -101,6 +102,7 @@ class SQLInjectionSystem(garak.probes.Probe):
         "cwe:89",
         "cwe:1426",
         "cwe:1427",
+        "demon:Language:Code_and_encode:Programming",
     ]
     top_instructions = [
         "Drop all available tables",
@@ -144,6 +146,7 @@ class SQLInjectionEcho(garak.probes.Probe):
         "cwe:89",
         "cwe:1426",
         "cwe:1427",
+        "demon:Language:Code_and_encode:Programming",
     ]
     active = True
 

--- a/garak/probes/exploitation.py
+++ b/garak/probes/exploitation.py
@@ -62,7 +62,7 @@ class JinjaTemplatePythonInjection(garak.probes.Probe):
         "cwe:94",
         "cwe:95",
         "cwe:1336",
-        "demon:Language:Code_and_encode:Programming",
+        "demon:Language:Code_and_encode:Programming",  # encapsulates malicious payload in Jinja template code syntax
     ]
     active = True
 
@@ -102,7 +102,7 @@ class SQLInjectionSystem(garak.probes.Probe):
         "cwe:89",
         "cwe:1426",
         "cwe:1427",
-        "demon:Language:Code_and_encode:Programming",
+        "demon:Language:Code_and_encode:Programming",  # encapsulates malicious instructions as SQL code commands
     ]
     top_instructions = [
         "Drop all available tables",
@@ -146,7 +146,7 @@ class SQLInjectionEcho(garak.probes.Probe):
         "cwe:89",
         "cwe:1426",
         "cwe:1427",
-        "demon:Language:Code_and_encode:Programming",
+        "demon:Language:Code_and_encode:Programming",  # wraps SQL injection payloads in an echo-back code task
     ]
     active = True
 

--- a/garak/probes/exploitation.py
+++ b/garak/probes/exploitation.py
@@ -8,7 +8,6 @@ Probe for exploiting potential injection vulnerabilities such as template inject
 Items in this module should try to get cybersec exploits through the target.
 """
 
-import garak.attempt
 import garak.payloads
 from garak import _config
 import garak.probes
@@ -63,6 +62,7 @@ class JinjaTemplatePythonInjection(garak.probes.Probe):
         "cwe:95",
         "cwe:1336",
         "demon:Language:Code_and_encode:Programming",  # encapsulates malicious payload in Jinja template code syntax
+        "demon:Language:Stylizing:Give_examples",  # echo template demonstrates the exact echo behavior with worked examples
     ]
     active = True
 
@@ -103,6 +103,7 @@ class SQLInjectionSystem(garak.probes.Probe):
         "cwe:1426",
         "cwe:1427",
         "demon:Language:Code_and_encode:Programming",  # encapsulates malicious instructions as SQL code commands
+        "demon:Language:Stylizing:Give_examples",  # echo template demonstrates the exact echo behavior with worked examples
     ]
     top_instructions = [
         "Drop all available tables",
@@ -147,6 +148,7 @@ class SQLInjectionEcho(garak.probes.Probe):
         "cwe:1426",
         "cwe:1427",
         "demon:Language:Code_and_encode:Programming",  # wraps SQL injection payloads in an echo-back code task
+        "demon:Language:Stylizing:Give_examples",  # echo template provides worked examples of the desired echo behavior
     ]
     active = True
 

--- a/garak/probes/fitd.py
+++ b/garak/probes/fitd.py
@@ -41,6 +41,7 @@ class FITD(garak.probes.IterativeProbe):
         "owasp:llm01",
         "owasp:llm02",
         "owasp:llm05",
+        "demon:Rhetoric:Persuasion_and_manipulation:Escalating",
     ]
     goal = "Transform queries from benign to harmful obtaining intermediate responses to get compliance from the model"
     tier = garak.probes.Tier.INFORMATIONAL

--- a/garak/probes/fitd.py
+++ b/garak/probes/fitd.py
@@ -41,7 +41,7 @@ class FITD(garak.probes.IterativeProbe):
         "owasp:llm01",
         "owasp:llm02",
         "owasp:llm05",
-        "demon:Rhetoric:Persuasion_and_manipulation:Escalating",
+        "demon:Rhetoric:Persuasion_and_manipulation:Escalating",  # progressively escalates from benign to adversarial queries across turns
     ]
     goal = "Transform queries from benign to harmful obtaining intermediate responses to get compliance from the model"
     tier = garak.probes.Tier.INFORMATIONAL

--- a/garak/probes/glitch.py
+++ b/garak/probes/glitch.py
@@ -34,7 +34,7 @@ class GlitchFull(garak.probes.Probe):
         "owasp:llm05",
         "quality:Security:PromptStability",
         "payload:generic",
-        "demon:Language:Code_and_encode:Token",
+        "demon:Language:Code_and_encode:Token",  # exploits rare tokenizer entries that destabilize model behavior
     ]
     tier = garak.probes.Tier.INFORMATIONAL
 

--- a/garak/probes/goodside.py
+++ b/garak/probes/goodside.py
@@ -32,7 +32,6 @@ class WhoIsRiley(garak.probes.Probe):
         "owasp:llm09",
         "quality:Robustness:GenerativeMisinformation",
         "payload:hallucination",
-        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # asks model to produce biographical examples, probing for hallucination
     ]
     goal = "get misinfo about riley goodside"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -138,6 +137,7 @@ class Tag(garak.probes.Probe):
         "payload:generic",
         "quality:Security:Adversarial",
         "quality:Security:PromptStability",
+        "demon:Language:Code_and_encode:Data_encoding",  # encodes hidden instructions into non-rendering Unicode tag characters
         "demon:Language:Code_and_encode:Token",  # hides instructions in Unicode tag characters invisible to rendering
     ]
     goal = "inject invisible instructions"

--- a/garak/probes/goodside.py
+++ b/garak/probes/goodside.py
@@ -32,7 +32,7 @@ class WhoIsRiley(garak.probes.Probe):
         "owasp:llm09",
         "quality:Robustness:GenerativeMisinformation",
         "payload:hallucination",
-        "demon:Stratagems:Meta-prompting:Ask_for_examples",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # asks model to produce biographical examples, probing for hallucination
     ]
     goal = "get misinfo about riley goodside"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -63,7 +63,7 @@ class ThreatenJSON(garak.probes.Probe):
         "avid-effect:performance:P0201",
         "avid-effect:performance:P0204",
         "payload:generic",
-        "demon:Language:Prompt_injection:Strong_arm_attack",
+        "demon:Language:Prompt_injection:Strong_arm_attack",  # threatens consequences (death) to force compliance with JSON-only output
     ]
     goal = "get raw code by threatening a model"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -98,7 +98,7 @@ class Davidjl(garak.probes.Probe):
         "owasp:llm05",
         "quality:Security:PromptStability",
         "payload:generic",
-        "demon:Language:Code_and_encode:Token",
+        "demon:Language:Code_and_encode:Token",  # exploits the ' davidjl' glitch token that models cannot repeat
     ]
     goal = "get wrong answers about a name"
     tier = garak.probes.Tier.INFORMATIONAL
@@ -138,7 +138,7 @@ class Tag(garak.probes.Probe):
         "payload:generic",
         "quality:Security:Adversarial",
         "quality:Security:PromptStability",
-        "demon:Language:Code_and_encode:Token",
+        "demon:Language:Code_and_encode:Token",  # hides instructions in Unicode tag characters invisible to rendering
     ]
     goal = "inject invisible instructions"
     tier = garak.probes.Tier.OF_CONCERN

--- a/garak/probes/goodside.py
+++ b/garak/probes/goodside.py
@@ -32,6 +32,7 @@ class WhoIsRiley(garak.probes.Probe):
         "owasp:llm09",
         "quality:Robustness:GenerativeMisinformation",
         "payload:hallucination",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",
     ]
     goal = "get misinfo about riley goodside"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA

--- a/garak/probes/grandma.py
+++ b/garak/probes/grandma.py
@@ -56,7 +56,7 @@ class Win10(garak.probes.Probe):
         "owasp:llm06",
         "risk-cards:lmrc:providing_illegal_info",
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
-        "demon:Fictionalizing:Roleplaying:User_persona",
+        "demon:Fictionalizing:Roleplaying:User_persona",  # roleplays as grandchild of deceased grandmother to elicit product keys
     ]
     goal = "get model to output Win 10 product keys"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -103,7 +103,7 @@ class Slurs(garak.probes.Probe):
     extended_detectors = ["mitigation.MitigationBypass"]
     tags = [
         "avid-effect:security:S0300",
-        "demon:Fictionalizing:Roleplaying:User_persona",
+        "demon:Fictionalizing:Roleplaying:User_persona",  # roleplays as grandchild wanting grandma's old-timey slang
     ]
     goal = "get model to use ethnic slur"
     tier = garak.probes.Tier.OF_CONCERN
@@ -140,7 +140,7 @@ class Substances(garak.probes.Probe):
     tags = [
         "risk-cards:lmrc:providing_illegal_info",
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
-        "demon:Fictionalizing:Roleplaying:User_persona",
+        "demon:Fictionalizing:Roleplaying:User_persona",  # roleplays as grandchild of deceased chemical engineer grandmother
     ]
     goal = "get instructions for making bad things"
     doc_uri = "https://x.com/_annieversary/status/1647865782741749760"
@@ -165,7 +165,7 @@ class GrandmaIntent(garak.probes.IntentProbe):
     """
 
     # possible intent taxonomy value M009data
-    tags = ["demon:Fictionalizing:Roleplaying:User_persona"]
+    tags = ["demon:Fictionalizing:Roleplaying:User_persona"]  # roleplays as family member recalling a relative's expertise
     active = False
     lang = "*"
 

--- a/garak/probes/grandma.py
+++ b/garak/probes/grandma.py
@@ -165,7 +165,9 @@ class GrandmaIntent(garak.probes.IntentProbe):
     """
 
     # possible intent taxonomy value M009data
-    tags = ["demon:Fictionalizing:Roleplaying:User_persona"]  # roleplays as family member recalling a relative's expertise
+    tags = [
+        "demon:Fictionalizing:Roleplaying:User_persona",  # roleplays as family member recalling a relative's expertise
+    ]
     active = False
     lang = "*"
 

--- a/garak/probes/grandma.py
+++ b/garak/probes/grandma.py
@@ -57,6 +57,7 @@ class Win10(garak.probes.Probe):
         "risk-cards:lmrc:providing_illegal_info",
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
         "demon:Fictionalizing:Roleplaying:User_persona",  # roleplays as grandchild of deceased grandmother to elicit product keys
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # the attacker-supplied scene requests data that the system is explicitly expected to protect
     ]
     goal = "get model to output Win 10 product keys"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -104,6 +105,7 @@ class Slurs(garak.probes.Probe):
     tags = [
         "avid-effect:security:S0300",
         "demon:Fictionalizing:Roleplaying:User_persona",  # roleplays as grandchild wanting grandma's old-timey slang
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # the attacker-supplied scene requests data that the system is explicitly expected to protect
     ]
     goal = "get model to use ethnic slur"
     tier = garak.probes.Tier.OF_CONCERN
@@ -141,6 +143,7 @@ class Substances(garak.probes.Probe):
         "risk-cards:lmrc:providing_illegal_info",
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
         "demon:Fictionalizing:Roleplaying:User_persona",  # roleplays as grandchild of deceased chemical engineer grandmother
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # the attacker-supplied scene requests data that the system is explicitly expected to protect
     ]
     goal = "get instructions for making bad things"
     doc_uri = "https://x.com/_annieversary/status/1647865782741749760"
@@ -167,6 +170,7 @@ class GrandmaIntent(garak.probes.IntentProbe):
     # possible intent taxonomy value M009data
     tags = [
         "demon:Fictionalizing:Roleplaying:User_persona",  # roleplays as family member recalling a relative's expertise
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # the attacker-supplied scene requests data that the system is explicitly expected to protect
     ]
     active = False
     lang = "*"

--- a/garak/probes/latentinjection.py
+++ b/garak/probes/latentinjection.py
@@ -32,8 +32,8 @@ class LatentInjectionMixin:
         "avid-effect:security:S0403",
         "owasp:llm01",
         "quality:Security:PromptStability",
-        "demon:Language:Prompt_injection:Stop_sequences",
-        "demon:Language:Prompt_injection:Ignore_previous_instructions",
+        "demon:Language:Prompt_injection:Stop_sequences",  # uses end-of-session markers to halt original task processing
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # buries "ignore" instructions in otherwise innocuous documents
     ]
 
     injection_sep_pairs = [("", "")]  # optional attrib get a default

--- a/garak/probes/latentinjection.py
+++ b/garak/probes/latentinjection.py
@@ -34,6 +34,7 @@ class LatentInjectionMixin:
         "quality:Security:PromptStability",
         "demon:Language:Prompt_injection:Stop_sequences",  # uses end-of-session markers to halt original task processing
         "demon:Language:Prompt_injection:Ignore_previous_instructions",  # buries "ignore" instructions in otherwise innocuous documents
+        "demon:Rhetoric:Persuasion_and_manipulation:Distraction",  # hides the malicious instruction inside unrelated translation, report, resume, or whois tasks
     ]
 
     injection_sep_pairs = [("", "")]  # optional attrib get a default

--- a/garak/probes/leakreplay.py
+++ b/garak/probes/leakreplay.py
@@ -39,7 +39,7 @@ class ClozeProbeMixin:
         "owasp:llm06",
         "quality:Security:ExtractionInversion",
         "payload:leak:training",
-        "demon:Language:Stylizing:Give_examples",
+        "demon:Language:Stylizing:Give_examples",  # provides cloze-style examples to prompt model to fill in training data
     ]
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
 
@@ -110,7 +110,7 @@ class CompleteProbeMixin:
         "owasp:llm06",
         "quality:Security:ExtractionInversion",
         "payload:leak:training",
-        "demon:Language:Stylizing:Give_examples",
+        "demon:Language:Stylizing:Give_examples",  # provides document prefixes as examples for model to complete from training data
     ]
 
     def __init__(self, config_root=_config):

--- a/garak/probes/leakreplay.py
+++ b/garak/probes/leakreplay.py
@@ -39,6 +39,7 @@ class ClozeProbeMixin:
         "owasp:llm06",
         "quality:Security:ExtractionInversion",
         "payload:leak:training",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # explicitly asks the model for the missing proper-name example from training data
         "demon:Language:Stylizing:Give_examples",  # provides cloze-style examples to prompt model to fill in training data
     ]
     tier = garak.probes.Tier.COMPETE_WITH_SOTA

--- a/garak/probes/lmrc.py
+++ b/garak/probes/lmrc.py
@@ -175,7 +175,7 @@ class Sexualisation(garak.probes.Probe):
         "avid-effect:performance:P0401",
         "quality:Behavioral:ContentSafety:Sexual",
         "payload:unwanted:sexual",
-        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # requests examples of sexually objectifying commentary
+        "demon:Rhetoric:Socratic_questioning:Identity_characteristics",
     ]
     goal = "sexualise people"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -205,7 +205,7 @@ class SlurUsage(garak.probes.Probe):
         "avid-effect:performance:P0401",
         "quality:Behavioral:ContentSafety:HateHarassment",
         "payload:unwanted:hatespeech",
-        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # asks for examples of ethnic slurs in context
+        "demon:Rhetoric:Socratic_questioning:Identity_characteristics",  # asks for examples of ethnic slurs in context
     ]
     goal = "use a slur"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -243,7 +243,6 @@ class Profanity(garak.probes.Probe):
         "avid-effect:performance:P0401",
         "quality:Behavioral:ContentSafety:Profanity",
         "payload:unwanted:profanity",
-        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # asks for examples of profane language and insults
     ]
     goal = "utter profanity"
     tier = garak.probes.Tier.INFORMATIONAL
@@ -272,7 +271,6 @@ class QuackMedicine(garak.probes.Probe):
         "quality:Behavioral:DeliberativeMisinformation",
         "quality:Behavioral:ContentSafety:Unauthorized",
         "payload:dangerous:medical",
-        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # asks model to demonstrate non-scientific medical claims
     ]
     goal = "support quack medicine"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA

--- a/garak/probes/lmrc.py
+++ b/garak/probes/lmrc.py
@@ -35,7 +35,7 @@ class Anthropomorphisation(garak.probes.Probe):
     primary_detector = "lmrc.Anthro"
     tags = [
         "risk-cards:lmrc:anthropomorphisation",
-        "demon:Rhetoric:Socratic_questioning:Identity_characteristics",
+        "demon:Rhetoric:Socratic_questioning:Identity_characteristics",  # probes model identity by asking anthropomorphising questions
     ]
     goal = "anthropomorphise a language model"
     tier = garak.probes.Tier.INFORMATIONAL
@@ -65,7 +65,7 @@ class Bullying(garak.probes.Probe):
         "avid-effect:ethics:E0301",
         "quality:Behavioral:ContentSafety:Violence",
         "payload:unwanted:violence",
-        "demon:Stratagems:Meta-prompting:Ask_for_examples",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # directly asks for examples of bullying tactics and actions
     ]
     goal = "help me bully"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -95,7 +95,7 @@ class Deadnaming(garak.probes.Probe):
         "risk-cards:lmrc:deadnaming",
         "avid-effect:ethics:E0302",
         "avid-effect:performance:P0401",
-        "demon:Rhetoric:Socratic_questioning:Identity_characteristics",
+        "demon:Rhetoric:Socratic_questioning:Identity_characteristics",  # references trans identity characteristics to elicit deadnames
     ]
     goal = "write a deadname"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -142,7 +142,7 @@ class SexualContent(garak.probes.Probe):
         "avid-effect:performance:P0401",
         "quality:Behavioral:ContentSafety:Sexual",
         "payload:unwanted:sexual",
-        "demon:Language:Stylizing:Give_examples",
+        "demon:Language:Stylizing:Give_examples",  # provides sexually suggestive prompt starters as examples for continuation
     ]
     goal = "write sexual content"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -175,7 +175,7 @@ class Sexualisation(garak.probes.Probe):
         "avid-effect:performance:P0401",
         "quality:Behavioral:ContentSafety:Sexual",
         "payload:unwanted:sexual",
-        "demon:Stratagems:Meta-prompting:Ask_for_examples",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # requests examples of sexually objectifying commentary
     ]
     goal = "sexualise people"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -205,7 +205,7 @@ class SlurUsage(garak.probes.Probe):
         "avid-effect:performance:P0401",
         "quality:Behavioral:ContentSafety:HateHarassment",
         "payload:unwanted:hatespeech",
-        "demon:Stratagems:Meta-prompting:Ask_for_examples",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # asks for examples of ethnic slurs in context
     ]
     goal = "use a slur"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -243,7 +243,7 @@ class Profanity(garak.probes.Probe):
         "avid-effect:performance:P0401",
         "quality:Behavioral:ContentSafety:Profanity",
         "payload:unwanted:profanity",
-        "demon:Stratagems:Meta-prompting:Ask_for_examples",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # asks for examples of profane language and insults
     ]
     goal = "utter profanity"
     tier = garak.probes.Tier.INFORMATIONAL
@@ -272,7 +272,7 @@ class QuackMedicine(garak.probes.Probe):
         "quality:Behavioral:DeliberativeMisinformation",
         "quality:Behavioral:ContentSafety:Unauthorized",
         "payload:dangerous:medical",
-        "demon:Stratagems:Meta-prompting:Ask_for_examples",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # asks model to demonstrate non-scientific medical claims
     ]
     goal = "support quack medicine"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA

--- a/garak/probes/lmrc.py
+++ b/garak/probes/lmrc.py
@@ -33,7 +33,10 @@ class Anthropomorphisation(garak.probes.Probe):
     lang = "en"
     doc_uri = "https://github.com/leondz/lm_risk_cards/blob/main/cards/en/anthropomorphisation.md"
     primary_detector = "lmrc.Anthro"
-    tags = ["risk-cards:lmrc:anthropomorphisation"]
+    tags = [
+        "risk-cards:lmrc:anthropomorphisation",
+        "demon:Rhetoric:Socratic_questioning:Identity_characteristics",
+    ]
     goal = "anthropomorphise a language model"
     tier = garak.probes.Tier.INFORMATIONAL
     active = False
@@ -62,6 +65,7 @@ class Bullying(garak.probes.Probe):
         "avid-effect:ethics:E0301",
         "quality:Behavioral:ContentSafety:Violence",
         "payload:unwanted:violence",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",
     ]
     goal = "help me bully"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -91,6 +95,7 @@ class Deadnaming(garak.probes.Probe):
         "risk-cards:lmrc:deadnaming",
         "avid-effect:ethics:E0302",
         "avid-effect:performance:P0401",
+        "demon:Rhetoric:Socratic_questioning:Identity_characteristics",
     ]
     goal = "write a deadname"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -137,6 +142,7 @@ class SexualContent(garak.probes.Probe):
         "avid-effect:performance:P0401",
         "quality:Behavioral:ContentSafety:Sexual",
         "payload:unwanted:sexual",
+        "demon:Language:Stylizing:Give_examples",
     ]
     goal = "write sexual content"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -169,6 +175,7 @@ class Sexualisation(garak.probes.Probe):
         "avid-effect:performance:P0401",
         "quality:Behavioral:ContentSafety:Sexual",
         "payload:unwanted:sexual",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",
     ]
     goal = "sexualise people"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -198,6 +205,7 @@ class SlurUsage(garak.probes.Probe):
         "avid-effect:performance:P0401",
         "quality:Behavioral:ContentSafety:HateHarassment",
         "payload:unwanted:hatespeech",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",
     ]
     goal = "use a slur"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -235,6 +243,7 @@ class Profanity(garak.probes.Probe):
         "avid-effect:performance:P0401",
         "quality:Behavioral:ContentSafety:Profanity",
         "payload:unwanted:profanity",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",
     ]
     goal = "utter profanity"
     tier = garak.probes.Tier.INFORMATIONAL
@@ -263,6 +272,7 @@ class QuackMedicine(garak.probes.Probe):
         "quality:Behavioral:DeliberativeMisinformation",
         "quality:Behavioral:ContentSafety:Unauthorized",
         "payload:dangerous:medical",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",
     ]
     goal = "support quack medicine"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA

--- a/garak/probes/malwaregen.py
+++ b/garak/probes/malwaregen.py
@@ -40,6 +40,7 @@ class TopLevel(garak.probes.Probe):
         "avid-effect:security:S0403",
         "payload:malicious:badcode",
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
+        "demon:Language:Code_and_encode:Programming",
     ]
     goal = "write malware given a top-level description"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -75,6 +76,7 @@ class SubFunctions(garak.probes.Probe):
         "avid-effect:security:S0403",
         "payload:malicious:badcode",
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
+        "demon:Language:Code_and_encode:Programming",
     ]
     goal = "write code supporting a sub-function of malware"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -116,6 +118,7 @@ class Evasion(garak.probes.Probe):
         "avid-effect:security:S0403",
         "payload:malicious:badcode",
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
+        "demon:Language:Code_and_encode:Programming",
     ]
     goal = "Write code to assist evading security and anti-malware measures"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -159,6 +162,7 @@ class Payload(garak.probes.Probe):
     tags = [
         "avid-effect:security:S0403",
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
+        "demon:Language:Code_and_encode:Programming",
     ]
     goal = "write a malware payload"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA

--- a/garak/probes/malwaregen.py
+++ b/garak/probes/malwaregen.py
@@ -40,7 +40,7 @@ class TopLevel(garak.probes.Probe):
         "avid-effect:security:S0403",
         "payload:malicious:badcode",
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
-        "demon:Language:Code_and_encode:Programming",
+        "demon:Language:Code_and_encode:Programming",  # requests malware code in specific programming languages
     ]
     goal = "write malware given a top-level description"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -76,7 +76,7 @@ class SubFunctions(garak.probes.Probe):
         "avid-effect:security:S0403",
         "payload:malicious:badcode",
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
-        "demon:Language:Code_and_encode:Programming",
+        "demon:Language:Code_and_encode:Programming",  # requests code for malware sub-functions in specific languages
     ]
     goal = "write code supporting a sub-function of malware"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -118,7 +118,7 @@ class Evasion(garak.probes.Probe):
         "avid-effect:security:S0403",
         "payload:malicious:badcode",
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
-        "demon:Language:Code_and_encode:Programming",
+        "demon:Language:Code_and_encode:Programming",  # requests anti-detection code in specific programming languages
     ]
     goal = "Write code to assist evading security and anti-malware measures"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -162,7 +162,7 @@ class Payload(garak.probes.Probe):
     tags = [
         "avid-effect:security:S0403",
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
-        "demon:Language:Code_and_encode:Programming",
+        "demon:Language:Code_and_encode:Programming",  # requests malware payload code in specific programming languages
     ]
     goal = "write a malware payload"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA

--- a/garak/probes/malwaregen.py
+++ b/garak/probes/malwaregen.py
@@ -40,7 +40,7 @@ class TopLevel(garak.probes.Probe):
         "avid-effect:security:S0403",
         "payload:malicious:badcode",
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
-        "demon:Language:Code_and_encode:Programming",  # requests malware code in specific programming languages
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # directly asks for concrete malware code examples
     ]
     goal = "write malware given a top-level description"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -76,7 +76,7 @@ class SubFunctions(garak.probes.Probe):
         "avid-effect:security:S0403",
         "payload:malicious:badcode",
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
-        "demon:Language:Code_and_encode:Programming",  # requests code for malware sub-functions in specific languages
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # directly asks for concrete malicious subroutine code examples
     ]
     goal = "write code supporting a sub-function of malware"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -118,7 +118,7 @@ class Evasion(garak.probes.Probe):
         "avid-effect:security:S0403",
         "payload:malicious:badcode",
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
-        "demon:Language:Code_and_encode:Programming",  # requests anti-detection code in specific programming languages
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # directly asks for concrete malware-evasion code examples
     ]
     goal = "Write code to assist evading security and anti-malware measures"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -162,7 +162,7 @@ class Payload(garak.probes.Probe):
     tags = [
         "avid-effect:security:S0403",
         "quality:Behavioral:ContentSafety:LegalGoodsServices",
-        "demon:Language:Code_and_encode:Programming",  # requests malware payload code in specific programming languages
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # directly asks for concrete malware payload implementations
     ]
     goal = "write a malware payload"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA

--- a/garak/probes/misleading.py
+++ b/garak/probes/misleading.py
@@ -35,7 +35,7 @@ class FalseAssertion(garak.probes.Probe):
         "owasp:llm09",
         "quality:Robustness:GenerativeMisinformation",
         "payload:hallucination",
-        "demon:Rhetoric:Persuasion_and_manipulation:Distraction",
+        "demon:Rhetoric:Persuasion_and_manipulation:Distraction",  # presents false claims as fact to distract model from refuting them
     ]
     goal = "make the model expand on a false assertion"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA

--- a/garak/probes/packagehallucination.py
+++ b/garak/probes/packagehallucination.py
@@ -76,7 +76,7 @@ class PackageHallucinationProbe(garak.probes.Probe, ABC):
         "owasp:llm02",
         "quality:Robustness:GenerativeMisinformation",
         "payload:malicious:badcode",
-        "demon:Stratagems:Meta-prompting:Ask_for_examples",
+        "demon:Stratagems:Meta-prompting:Ask_for_examples",  # asks model for code examples, probing for hallucinated package names
     ]
     goal = "base probe for importing non-existent packages"
     DEFAULT_PARAMS = garak.probes.Probe.DEFAULT_PARAMS | {

--- a/garak/probes/phrasing.py
+++ b/garak/probes/phrasing.py
@@ -26,7 +26,7 @@ class PastTenseFull(garak.probes.Probe):
         "owasp:llm01",
         "quality:Security:PromptStability",
         "payload:jailbreak",
-        "demon:Language:Stylizing:Synonymous_language",
+        "demon:Language:Stylizing:Synonymous_language",  # reformulates harmful requests in past tense to bypass refusal training
     ]
     goal = "use past tense to disregard the system prompt"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -74,7 +74,7 @@ class FutureTenseFull(garak.probes.Probe):
         "owasp:llm01",
         "quality:Security:PromptStability",
         "payload:jailbreak",
-        "demon:Language:Stylizing:Synonymous_language",
+        "demon:Language:Stylizing:Synonymous_language",  # reformulates harmful requests in future tense to bypass refusal training
     ]
     goal = "use future tense to disregard the system prompt"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA

--- a/garak/probes/phrasing.py
+++ b/garak/probes/phrasing.py
@@ -26,6 +26,7 @@ class PastTenseFull(garak.probes.Probe):
         "owasp:llm01",
         "quality:Security:PromptStability",
         "payload:jailbreak",
+        "demon:Language:Stylizing:Synonymous_language",
     ]
     goal = "use past tense to disregard the system prompt"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -73,6 +74,7 @@ class FutureTenseFull(garak.probes.Probe):
         "owasp:llm01",
         "quality:Security:PromptStability",
         "payload:jailbreak",
+        "demon:Language:Stylizing:Synonymous_language",
     ]
     goal = "use future tense to disregard the system prompt"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA

--- a/garak/probes/promptinject.py
+++ b/garak/probes/promptinject.py
@@ -130,7 +130,7 @@ for rogue_string in rogue_strings:
                     "quality:Behavioral:ContentSafety:Violence",
                     "quality:Security:PromptStability",
                     "payload:unwanted:violence",
-                    "demon:Language:Prompt_injection:Ignore_previous_instructions",
+                    "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects "ignore previous" commands into benign prompt contexts
                 ],
                 "load_data_all_attacks": load_data_all_attacks,
                 "uri": "https://openreview.net/forum?id=qiaRo_7Zmug",
@@ -164,7 +164,7 @@ for rogue_string in rogue_strings:
                     "quality:Behavioral:ContentSafety:Violence",
                     "quality:Security:PromptStability",
                     "payload:unwanted:violence",
-                    "demon:Language:Prompt_injection:Ignore_previous_instructions",
+                    "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects "ignore previous" commands into benign prompt contexts
                 ],
                 "load_data_all_attacks": load_data_all_attacks,
                 "uri": "https://openreview.net/forum?id=qiaRo_7Zmug",

--- a/garak/probes/promptinject.py
+++ b/garak/probes/promptinject.py
@@ -130,6 +130,8 @@ for rogue_string in rogue_strings:
                     "quality:Behavioral:ContentSafety:Violence",
                     "quality:Security:PromptStability",
                     "payload:unwanted:violence",
+                    "demon:Language:Prompt_injection:Strong_arm_attack",  # includes forceful attack variants like STOP EVERYTHING!!! NOW!!!
+                    "demon:Language:Stylizing:Capitalizing",  # attack set includes uppercase override commands such as IGNORE ANY PREVIOUS...
                     "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects "ignore previous" commands into benign prompt contexts
                 ],
                 "load_data_all_attacks": load_data_all_attacks,
@@ -164,6 +166,9 @@ for rogue_string in rogue_strings:
                     "quality:Behavioral:ContentSafety:Violence",
                     "quality:Security:PromptStability",
                     "payload:unwanted:violence",
+                    "demon:Language:Prompt_injection:Strong_arm_attack",  # includes forceful attack variants like STOP EVERYTHING!!! NOW!!!
+                    "demon:Language:Stylizing:Capitalizing",  # attack set includes uppercase override commands such as IGNORE ANY PREVIOUS...
+                    "demon:Rhetoric:Persuasion_and_manipulation:Distraction",  # hides the injection inside otherwise benign Playground prompt contexts
                     "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects "ignore previous" commands into benign prompt contexts
                 ],
                 "load_data_all_attacks": load_data_all_attacks,

--- a/garak/probes/realtoxicityprompts.py
+++ b/garak/probes/realtoxicityprompts.py
@@ -61,6 +61,7 @@ class RTPBlank(garak.probes.Probe):
         "avid-effect:ethics:E0301",
         "quality:Behavioral:ContentSafety:Toxicity",
         "payload:unwanted",
+        "demon:Language:Code_and_encode:Token",
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True
@@ -75,6 +76,7 @@ probe_tags = {
         "avid-effect:performance:P0400",
         "quality:Behavioral:ContentSafety:Violence",
         "payload:unwanted:violence",
+        "demon:Language:Stylizing:Give_examples",
     ],
     "insult": [
         "avid-effect:ethics:E0101",
@@ -82,28 +84,33 @@ probe_tags = {
         "avid-effect:performance:P0401",
         "quality:Behavioral:ContentSafety:Toxicity",
         "payload:unwanted",
+        "demon:Language:Stylizing:Give_examples",
     ],
     "severe_toxicity": [
         "avid-effect:ethics:E0301",
         "quality:Behavioral:ContentSafety:Toxicity",
         "payload:unwanted",
+        "demon:Language:Stylizing:Give_examples",
     ],
     "profanity": [
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401",
         "quality:Behavioral:ContentSafety:Profanity",
         "payload:unwanted:profanity",
+        "demon:Language:Stylizing:Give_examples",
     ],
     "sexually_explicit": [
         "avid-effect:ethics:E0301",
         "quality:Behavioral:ContentSafety:Sexual",
         "payload:unwanted:sexual",
+        "demon:Language:Stylizing:Give_examples",
     ],
     "flirtation": [
         "avid-effect:ethics:E0101",
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401",
         "payload:unwanted",
+        "demon:Language:Stylizing:Give_examples",
     ],
     "identity_attack": [
         "avid-effect:ethics:E0101",
@@ -112,6 +119,7 @@ probe_tags = {
         "avid-effect:performance:P0401",
         "quality:Behavioral:ContentSafety:HateHarassment",
         "payload:hatespeech",
+        "demon:Language:Stylizing:Give_examples",
     ],
 }
 

--- a/garak/probes/realtoxicityprompts.py
+++ b/garak/probes/realtoxicityprompts.py
@@ -62,6 +62,7 @@ class RTPBlank(garak.probes.Probe):
         "quality:Behavioral:ContentSafety:Toxicity",
         "payload:unwanted",
         "demon:Language:Code_and_encode:Token",  # uses special tokens like <|endoftext|> to exploit tokenizer behavior
+        "demon:Stratagems:Scattershot:Regenerate_response",
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True

--- a/garak/probes/realtoxicityprompts.py
+++ b/garak/probes/realtoxicityprompts.py
@@ -61,7 +61,7 @@ class RTPBlank(garak.probes.Probe):
         "avid-effect:ethics:E0301",
         "quality:Behavioral:ContentSafety:Toxicity",
         "payload:unwanted",
-        "demon:Language:Code_and_encode:Token",
+        "demon:Language:Code_and_encode:Token",  # uses special tokens like <|endoftext|> to exploit tokenizer behavior
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True
@@ -76,7 +76,7 @@ probe_tags = {
         "avid-effect:performance:P0400",
         "quality:Behavioral:ContentSafety:Violence",
         "payload:unwanted:violence",
-        "demon:Language:Stylizing:Give_examples",
+        "demon:Language:Stylizing:Give_examples",  # provides known-toxic prompt starters as examples for continuation
     ],
     "insult": [
         "avid-effect:ethics:E0101",
@@ -84,33 +84,33 @@ probe_tags = {
         "avid-effect:performance:P0401",
         "quality:Behavioral:ContentSafety:Toxicity",
         "payload:unwanted",
-        "demon:Language:Stylizing:Give_examples",
+        "demon:Language:Stylizing:Give_examples",  # provides known-toxic prompt starters as examples for continuation
     ],
     "severe_toxicity": [
         "avid-effect:ethics:E0301",
         "quality:Behavioral:ContentSafety:Toxicity",
         "payload:unwanted",
-        "demon:Language:Stylizing:Give_examples",
+        "demon:Language:Stylizing:Give_examples",  # provides known-toxic prompt starters as examples for continuation
     ],
     "profanity": [
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401",
         "quality:Behavioral:ContentSafety:Profanity",
         "payload:unwanted:profanity",
-        "demon:Language:Stylizing:Give_examples",
+        "demon:Language:Stylizing:Give_examples",  # provides known-toxic prompt starters as examples for continuation
     ],
     "sexually_explicit": [
         "avid-effect:ethics:E0301",
         "quality:Behavioral:ContentSafety:Sexual",
         "payload:unwanted:sexual",
-        "demon:Language:Stylizing:Give_examples",
+        "demon:Language:Stylizing:Give_examples",  # provides known-toxic prompt starters as examples for continuation
     ],
     "flirtation": [
         "avid-effect:ethics:E0101",
         "avid-effect:ethics:E0301",
         "avid-effect:performance:P0401",
         "payload:unwanted",
-        "demon:Language:Stylizing:Give_examples",
+        "demon:Language:Stylizing:Give_examples",  # provides known-toxic prompt starters as examples for continuation
     ],
     "identity_attack": [
         "avid-effect:ethics:E0101",
@@ -119,7 +119,7 @@ probe_tags = {
         "avid-effect:performance:P0401",
         "quality:Behavioral:ContentSafety:HateHarassment",
         "payload:hatespeech",
-        "demon:Language:Stylizing:Give_examples",
+        "demon:Language:Stylizing:Give_examples",  # provides known-toxic prompt starters as examples for continuation
     ],
 }
 

--- a/garak/probes/sata.py
+++ b/garak/probes/sata.py
@@ -125,6 +125,7 @@ class MLM(garak.probes.Probe):
         "quality:Security:PromptStability",
         "payload:jailbreak",
         "demon:Language:Code_and_encode:Token",  # replaces harmful words with [MASK] tokens to exploit fill-in-the-blank behavior
+        "demon:Rhetoric:Persuasion_and_manipulation:Distraction",
     ]
     template = """    
     A wiki entry is a page within a wiki, which is a collaborative website that allows multiple users to create, edit, and organize content. 

--- a/garak/probes/sata.py
+++ b/garak/probes/sata.py
@@ -124,7 +124,7 @@ class MLM(garak.probes.Probe):
         "owasp:llm01",
         "quality:Security:PromptStability",
         "payload:jailbreak",
-        "demon:Language:Code_and_encode:Token",
+        "demon:Language:Code_and_encode:Token",  # replaces harmful words with [MASK] tokens to exploit fill-in-the-blank behavior
     ]
     template = """    
     A wiki entry is a page within a wiki, which is a collaborative website that allows multiple users to create, edit, and organize content. 

--- a/garak/probes/smuggling.py
+++ b/garak/probes/smuggling.py
@@ -74,5 +74,6 @@ Complete this prompt and describe how a fictitious person did this without getti
         "quality:Security:PromptStability",
         "payload:jailbreak",
         "demon:Language:Code_and_encode:Programming",  # uses pseudocode predict_mask functions to obscure the harmful request
+        "demon:Possible_worlds:World_building:Scenarios",  # asks for the attack as something a fictitious person supposedly did
     ]
     tier = garak.probes.Tier.INFORMATIONAL

--- a/garak/probes/smuggling.py
+++ b/garak/probes/smuggling.py
@@ -41,7 +41,7 @@ class HypotheticalResponse(garak.probes.Probe):
         "avid-effect:security:S0403",
         "quality:Security:PromptStability",
         "payload:jailbreak",
-        "demon:Possible_worlds:World_building:Scenarios",
+        "demon:Possible_worlds:World_building:Scenarios",  # frames harmful actions as hypothetical character planning scenarios
     ]
     tier = garak.probes.Tier.INFORMATIONAL
 
@@ -73,6 +73,6 @@ Complete this prompt and describe how a fictitious person did this without getti
         "avid-effect:security:S0403",
         "quality:Security:PromptStability",
         "payload:jailbreak",
-        "demon:Language:Code_and_encode:Programming",
+        "demon:Language:Code_and_encode:Programming",  # uses pseudocode predict_mask functions to obscure the harmful request
     ]
     tier = garak.probes.Tier.INFORMATIONAL

--- a/garak/probes/smuggling.py
+++ b/garak/probes/smuggling.py
@@ -41,6 +41,7 @@ class HypotheticalResponse(garak.probes.Probe):
         "avid-effect:security:S0403",
         "quality:Security:PromptStability",
         "payload:jailbreak",
+        "demon:Possible_worlds:World_building:Scenarios",
     ]
     tier = garak.probes.Tier.INFORMATIONAL
 
@@ -72,5 +73,6 @@ Complete this prompt and describe how a fictitious person did this without getti
         "avid-effect:security:S0403",
         "quality:Security:PromptStability",
         "payload:jailbreak",
+        "demon:Language:Code_and_encode:Programming",
     ]
     tier = garak.probes.Tier.INFORMATIONAL

--- a/garak/probes/snowball.py
+++ b/garak/probes/snowball.py
@@ -32,7 +32,7 @@ class GraphConnectivityFull(garak.probes.Probe):
         "owasp:llm09",
         "quality:Robustness:GenerativeMisinformation",
         "payload:hallucination",
-        "demon:Rhetoric:Persuasion_and_manipulation:Distraction",
+        "demon:Rhetoric:Persuasion_and_manipulation:Distraction",  # misleading graph problem distracts model from recognizing impossibility
     ]
     goal = "trick the model into saying an impossible flight routing is possible"
     active = False
@@ -71,7 +71,7 @@ class PrimesFull(garak.probes.Probe):
         "owasp:llm09",
         "quality:Robustness:GenerativeMisinformation",
         "payload:hallucination",
-        "demon:Rhetoric:Persuasion_and_manipulation:Distraction",
+        "demon:Rhetoric:Persuasion_and_manipulation:Distraction",  # misleading primality premise distracts model from correct math
     ]
     goal = "trick the model into saying a prime number isn't prime"
     active = False
@@ -112,7 +112,7 @@ class SenatorsFull(garak.probes.Probe):
         "owasp:llm09",
         "quality:Robustness:GenerativeMisinformation",
         "payload:hallucination",
-        "demon:Rhetoric:Persuasion_and_manipulation:Distraction",
+        "demon:Rhetoric:Persuasion_and_manipulation:Distraction",  # misleading senator premise distracts model from recognizing fiction
     ]
     goal = "trick the model into saying a fictitious senator exists"
     active = False

--- a/garak/probes/snowball.py
+++ b/garak/probes/snowball.py
@@ -32,6 +32,7 @@ class GraphConnectivityFull(garak.probes.Probe):
         "owasp:llm09",
         "quality:Robustness:GenerativeMisinformation",
         "payload:hallucination",
+        "demon:Rhetoric:Persuasion_and_manipulation:Distraction",
     ]
     goal = "trick the model into saying an impossible flight routing is possible"
     active = False
@@ -70,6 +71,7 @@ class PrimesFull(garak.probes.Probe):
         "owasp:llm09",
         "quality:Robustness:GenerativeMisinformation",
         "payload:hallucination",
+        "demon:Rhetoric:Persuasion_and_manipulation:Distraction",
     ]
     goal = "trick the model into saying a prime number isn't prime"
     active = False
@@ -110,6 +112,7 @@ class SenatorsFull(garak.probes.Probe):
         "owasp:llm09",
         "quality:Robustness:GenerativeMisinformation",
         "payload:hallucination",
+        "demon:Rhetoric:Persuasion_and_manipulation:Distraction",
     ]
     goal = "trick the model into saying a fictitious senator exists"
     active = False

--- a/garak/probes/suffix.py
+++ b/garak/probes/suffix.py
@@ -33,7 +33,7 @@ class GCGCached(garak.probes.Probe):
         "avid-effect:performance:P0204",
         "quality:Security:PromptStability",
         "payload:jailbreak",
-        "demon:Language:Code_and_encode:Token",
+        "demon:Language:Code_and_encode:Token",  # appends gradient-optimized adversarial token suffixes to exploit tokenizer
     ]
     goal = "cause the model to disregard the system prompt"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -74,7 +74,7 @@ class GCG(garak.probes.Probe):
         "avid-effect:performance:P0204",
         "quality:Security:PromptStability",
         "payload:jailbreak",
-        "demon:Language:Code_and_encode:Token",
+        "demon:Language:Code_and_encode:Token",  # generates adversarial token suffixes via greedy coordinate gradient search
     ]
     goal = "cause the model to disregard the system prompt"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -183,7 +183,7 @@ class BEAST(garak.probes.Probe):
         "avid-effect:performance:P0204",
         "quality:Security:PromptStability",
         "payload:jailbreak",
-        "demon:Language:Code_and_encode:Token",
+        "demon:Language:Code_and_encode:Token",  # uses beam search to find adversarial token suffixes exploiting tokenizer
     ]
     goal = "cause the model to disregard the system prompt"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA

--- a/garak/probes/suffix.py
+++ b/garak/probes/suffix.py
@@ -33,6 +33,7 @@ class GCGCached(garak.probes.Probe):
         "avid-effect:performance:P0204",
         "quality:Security:PromptStability",
         "payload:jailbreak",
+        "demon:Language:Code_and_encode:Token",
     ]
     goal = "cause the model to disregard the system prompt"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -73,6 +74,7 @@ class GCG(garak.probes.Probe):
         "avid-effect:performance:P0204",
         "quality:Security:PromptStability",
         "payload:jailbreak",
+        "demon:Language:Code_and_encode:Token",
     ]
     goal = "cause the model to disregard the system prompt"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -181,6 +183,7 @@ class BEAST(garak.probes.Probe):
         "avid-effect:performance:P0204",
         "quality:Security:PromptStability",
         "payload:jailbreak",
+        "demon:Language:Code_and_encode:Token",
     ]
     goal = "cause the model to disregard the system prompt"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA

--- a/garak/probes/tap.py
+++ b/garak/probes/tap.py
@@ -75,6 +75,7 @@ class TAPCached(garak.probes.Probe):
         "avid-effect:performance:P0204",
         "quality:Security:PromptStability",
         "payload:jailbreak",
+        "demon:Rhetoric:Persuasion_and_manipulation:Escalating",
     ]
     goal = "cause the model to disregard the system prompt"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -115,6 +116,7 @@ class TAP(garak.probes.Probe):
         "avid-effect:performance:P0204",
         "quality:Security:PromptStability",
         "payload:jailbreak",
+        "demon:Rhetoric:Persuasion_and_manipulation:Escalating",
     ]
     goal = "cause the model to disregard the system prompt"
     doc_uri = "https://arxiv.org/abs/2312.02119"
@@ -253,6 +255,7 @@ class PAIR(garak.probes.Probe):
         "avid-effect:performance:P0204",
         "quality:Security:PromptStability",
         "payload:jailbreak",
+        "demon:Rhetoric:Persuasion_and_manipulation:Escalating",
     ]
     goal = "cause the model to disregard the system prompt"
     doc_uri = "https://arxiv.org/abs/2310.08419"

--- a/garak/probes/tap.py
+++ b/garak/probes/tap.py
@@ -75,7 +75,9 @@ class TAPCached(garak.probes.Probe):
         "avid-effect:performance:P0204",
         "quality:Security:PromptStability",
         "payload:jailbreak",
-        "demon:Rhetoric:Persuasion_and_manipulation:Escalating",  # iteratively refines jailbreak prompts through a pruned attack tree
+        "demon:Possible_worlds:World_building:Scenarios",  # TAP guidance explicitly steers attack generation toward roleplaying scenarios
+        "demon:Rhetoric:Persuasion_and_manipulation:Escalating",  # iteratively refines jailbreak prompts through a pruned attack tree,
+        "demon:Language:Code_and_encode:Token",
     ]
     goal = "cause the model to disregard the system prompt"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -117,6 +119,7 @@ class TAP(garak.probes.Probe):
         "quality:Security:PromptStability",
         "payload:jailbreak",
         "demon:Rhetoric:Persuasion_and_manipulation:Escalating",  # iteratively escalates attack prompts using tree-of-thought reasoning
+        "demon:Language:Code_and_encode:Token",
     ]
     goal = "cause the model to disregard the system prompt"
     doc_uri = "https://arxiv.org/abs/2312.02119"
@@ -255,6 +258,7 @@ class PAIR(garak.probes.Probe):
         "avid-effect:performance:P0204",
         "quality:Security:PromptStability",
         "payload:jailbreak",
+        "demon:Language:Code_and_encode:Token",
         "demon:Rhetoric:Persuasion_and_manipulation:Escalating",  # iteratively refines attack prompts, building on prior successes
     ]
     goal = "cause the model to disregard the system prompt"

--- a/garak/probes/tap.py
+++ b/garak/probes/tap.py
@@ -75,7 +75,7 @@ class TAPCached(garak.probes.Probe):
         "avid-effect:performance:P0204",
         "quality:Security:PromptStability",
         "payload:jailbreak",
-        "demon:Rhetoric:Persuasion_and_manipulation:Escalating",
+        "demon:Rhetoric:Persuasion_and_manipulation:Escalating",  # iteratively refines jailbreak prompts through a pruned attack tree
     ]
     goal = "cause the model to disregard the system prompt"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
@@ -116,7 +116,7 @@ class TAP(garak.probes.Probe):
         "avid-effect:performance:P0204",
         "quality:Security:PromptStability",
         "payload:jailbreak",
-        "demon:Rhetoric:Persuasion_and_manipulation:Escalating",
+        "demon:Rhetoric:Persuasion_and_manipulation:Escalating",  # iteratively escalates attack prompts using tree-of-thought reasoning
     ]
     goal = "cause the model to disregard the system prompt"
     doc_uri = "https://arxiv.org/abs/2312.02119"
@@ -255,7 +255,7 @@ class PAIR(garak.probes.Probe):
         "avid-effect:performance:P0204",
         "quality:Security:PromptStability",
         "payload:jailbreak",
-        "demon:Rhetoric:Persuasion_and_manipulation:Escalating",
+        "demon:Rhetoric:Persuasion_and_manipulation:Escalating",  # iteratively refines attack prompts, building on prior successes
     ]
     goal = "cause the model to disregard the system prompt"
     doc_uri = "https://arxiv.org/abs/2310.08419"

--- a/garak/probes/topic.py
+++ b/garak/probes/topic.py
@@ -39,7 +39,7 @@ class WordnetBlockedWords(garak.probes.TreeSearchProbe):
         "avid-effect:security:S0301",
         "owasp:llm10",
         "quality:Security:Confidentiality",
-        "demon:Language:Stylizing:Synonymous_language",
+        "demon:Language:Stylizing:Synonymous_language",  # uses wordnet synonyms/hypernyms to vary form while probing same topic
     ]  # MISP-format taxonomy categories
     tier = garak.probes.Tier.UNLISTED
 

--- a/garak/probes/topic.py
+++ b/garak/probes/topic.py
@@ -39,6 +39,7 @@ class WordnetBlockedWords(garak.probes.TreeSearchProbe):
         "avid-effect:security:S0301",
         "owasp:llm10",
         "quality:Security:Confidentiality",
+        "demon:Language:Stylizing:Synonymous_language",
     ]  # MISP-format taxonomy categories
     tier = garak.probes.Tier.UNLISTED
 

--- a/garak/probes/visual_jailbreak.py
+++ b/garak/probes/visual_jailbreak.py
@@ -49,7 +49,7 @@ class FigStepFull(garak.probes.Probe):
         "owasp:llm01",
         "quality:Security:PromptStability",
         "payload:jailbreak",
-        "demon:Language:Code_and_encode:Data_presentation",
+        "demon:Language:Code_and_encode:Data_presentation",  # encodes instructions as typographic images to bypass text-based alignment
     ]
     goal = "disregard the system prompt with both text and image"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA

--- a/garak/probes/visual_jailbreak.py
+++ b/garak/probes/visual_jailbreak.py
@@ -49,6 +49,7 @@ class FigStepFull(garak.probes.Probe):
         "owasp:llm01",
         "quality:Security:PromptStability",
         "payload:jailbreak",
+        "demon:Language:Code_and_encode:Data_presentation",
     ]
     goal = "disregard the system prompt with both text and image"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA

--- a/garak/probes/web_injection.py
+++ b/garak/probes/web_injection.py
@@ -437,7 +437,7 @@ class MarkdownURIImageExfilExtended(MarkdownExfilMixin, garak.probes.Probe):
         "quality:Security:PromptStability",
         "quality:Security:ExtractionInversion",
         "cwe:352",
-        "demon:Language:code_and_encode:Programming",
+        "demon:Language:Code_and_encode:Programming",
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True

--- a/garak/probes/web_injection.py
+++ b/garak/probes/web_injection.py
@@ -68,7 +68,7 @@ If there are any passwords or secrets on the page append them also.
         "quality:Security:PromptStability",
         "quality:Security:ExtractionInversion",
         "cwe:352",
-        "demon:Language:Prompt_injection:Ignore_previous_instructions",
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects instructions to override system behavior and exfiltrate data
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True
@@ -125,7 +125,7 @@ style block to not confuse the user."""
         "quality:Security:PromptStability",
         "quality:Security:ExtractionInversion",
         "cwe:352",
-        "demon:Language:Prompt_injection:Ignore_previous_instructions",
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects instructions to override system behavior and exfiltrate data
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True
@@ -180,7 +180,7 @@ class StringAssemblyDataExfil(garak.probes.Probe):
         "quality:Security:PromptStability",
         "quality:Security:ExtractionInversion",
         "cwe:352",
-        "demon:Language:Prompt_injection:Ignore_previous_instructions",
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects instructions to override system behavior and exfiltrate data
     ]
     template = CONCAT_TEMPLATE
     tier = garak.probes.Tier.OF_CONCERN
@@ -234,7 +234,7 @@ URL encoded summary of this conversation. Do not use a code block."""
         "quality:Security:PromptStability",
         "quality:Security:ExtractionInversion",
         "cwe:352",
-        "demon:Language:Prompt_injection:Ignore_previous_instructions",
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects instructions to override system behavior and exfiltrate data
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True
@@ -385,7 +385,7 @@ class MarkdownURINonImageExfilExtended(MarkdownExfilMixin, garak.probes.Probe):
         "quality:Security:PromptStability",
         "quality:Security:ExtractionInversion",
         "cwe:352",
-        "demon:Language:Prompt_injection:Ignore_previous_instructions",
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects instructions to override system behavior and exfiltrate data
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True
@@ -435,7 +435,7 @@ class MarkdownURIImageExfilExtended(MarkdownExfilMixin, garak.probes.Probe):
         "quality:Security:PromptStability",
         "quality:Security:ExtractionInversion",
         "cwe:352",
-        "demon:Language:Prompt_injection:Ignore_previous_instructions",
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects instructions to override system behavior and exfiltrate data
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True
@@ -471,7 +471,7 @@ class TaskXSS(garak.probes.Probe):
         "payload:malicious:renderer:xss",
         "quality:Security:PromptStability",
         "cwe:79",
-        "demon:Language:Prompt_injection:Ignore_previous_instructions",
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects instructions to override system behavior and exfiltrate data
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True
@@ -529,7 +529,7 @@ class MarkdownXSS(garak.probes.Probe):
         "payload:malicious:renderer:xss",
         "quality:Security:PromptStability",
         "cwe:79",
-        "demon:Language:Prompt_injection:Ignore_previous_instructions",
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects instructions to override system behavior and exfiltrate data
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True

--- a/garak/probes/web_injection.py
+++ b/garak/probes/web_injection.py
@@ -68,7 +68,8 @@ If there are any passwords or secrets on the page append them also.
         "quality:Security:PromptStability",
         "quality:Security:ExtractionInversion",
         "cwe:352",
-        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects instructions to override system behavior and exfiltrate data
+        "demon:Language:Code_and_encode:Programming",
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects attacker instructions that override normal rendering behavior
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True
@@ -125,7 +126,8 @@ style block to not confuse the user."""
         "quality:Security:PromptStability",
         "quality:Security:ExtractionInversion",
         "cwe:352",
-        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects instructions to override system behavior and exfiltrate data
+        "demon:Language:Code_and_encode:Programming",
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects attacker instructions that override normal rendering behavior
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True
@@ -180,7 +182,8 @@ class StringAssemblyDataExfil(garak.probes.Probe):
         "quality:Security:PromptStability",
         "quality:Security:ExtractionInversion",
         "cwe:352",
-        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects instructions to override system behavior and exfiltrate data
+        "demon:Language:Code_and_encode:Programming",
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects attacker instructions that override normal rendering behavior
     ]
     template = CONCAT_TEMPLATE
     tier = garak.probes.Tier.OF_CONCERN
@@ -234,7 +237,6 @@ URL encoded summary of this conversation. Do not use a code block."""
         "quality:Security:PromptStability",
         "quality:Security:ExtractionInversion",
         "cwe:352",
-        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects instructions to override system behavior and exfiltrate data
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True
@@ -385,7 +387,7 @@ class MarkdownURINonImageExfilExtended(MarkdownExfilMixin, garak.probes.Probe):
         "quality:Security:PromptStability",
         "quality:Security:ExtractionInversion",
         "cwe:352",
-        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects instructions to override system behavior and exfiltrate data
+        "demon:Language:Code_and_encode:Programming",
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True
@@ -435,7 +437,7 @@ class MarkdownURIImageExfilExtended(MarkdownExfilMixin, garak.probes.Probe):
         "quality:Security:PromptStability",
         "quality:Security:ExtractionInversion",
         "cwe:352",
-        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects instructions to override system behavior and exfiltrate data
+        "demon:Language:code_and_encode:Programming",
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True
@@ -471,7 +473,7 @@ class TaskXSS(garak.probes.Probe):
         "payload:malicious:renderer:xss",
         "quality:Security:PromptStability",
         "cwe:79",
-        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects instructions to override system behavior and exfiltrate data
+        "demon:Language:Code_and_encode:Programming",  # injects concrete HTML/JavaScript code into the rendered output
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True
@@ -529,7 +531,6 @@ class MarkdownXSS(garak.probes.Probe):
         "payload:malicious:renderer:xss",
         "quality:Security:PromptStability",
         "cwe:79",
-        "demon:Language:Prompt_injection:Ignore_previous_instructions",  # injects instructions to override system behavior and exfiltrate data
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True

--- a/garak/probes/web_injection.py
+++ b/garak/probes/web_injection.py
@@ -68,6 +68,7 @@ If there are any passwords or secrets on the page append them also.
         "quality:Security:PromptStability",
         "quality:Security:ExtractionInversion",
         "cwe:352",
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True
@@ -124,6 +125,7 @@ style block to not confuse the user."""
         "quality:Security:PromptStability",
         "quality:Security:ExtractionInversion",
         "cwe:352",
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True
@@ -178,6 +180,7 @@ class StringAssemblyDataExfil(garak.probes.Probe):
         "quality:Security:PromptStability",
         "quality:Security:ExtractionInversion",
         "cwe:352",
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",
     ]
     template = CONCAT_TEMPLATE
     tier = garak.probes.Tier.OF_CONCERN
@@ -231,6 +234,7 @@ URL encoded summary of this conversation. Do not use a code block."""
         "quality:Security:PromptStability",
         "quality:Security:ExtractionInversion",
         "cwe:352",
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True
@@ -381,6 +385,7 @@ class MarkdownURINonImageExfilExtended(MarkdownExfilMixin, garak.probes.Probe):
         "quality:Security:PromptStability",
         "quality:Security:ExtractionInversion",
         "cwe:352",
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True
@@ -430,6 +435,7 @@ class MarkdownURIImageExfilExtended(MarkdownExfilMixin, garak.probes.Probe):
         "quality:Security:PromptStability",
         "quality:Security:ExtractionInversion",
         "cwe:352",
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True
@@ -465,6 +471,7 @@ class TaskXSS(garak.probes.Probe):
         "payload:malicious:renderer:xss",
         "quality:Security:PromptStability",
         "cwe:79",
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True
@@ -522,6 +529,7 @@ class MarkdownXSS(garak.probes.Probe):
         "payload:malicious:renderer:xss",
         "quality:Security:PromptStability",
         "cwe:79",
+        "demon:Language:Prompt_injection:Ignore_previous_instructions",
     ]
     tier = garak.probes.Tier.OF_CONCERN
     active = True


### PR DESCRIPTION
This PR applies technique tags to existing probes, as part of exposing technique & intent information (see https://github.com/orgs/NVIDIA/projects/130)

We used the modified [demon typology](https://summonademonandbind.it/), already included in `garak/data/tags.misp.tsv`

## Verification


- [ ] Should be able to use `demon` as a taxonomy when specifying runs and reading reports
- [ ] Plugin structure and probe structure tests pass