### PR TITLE
generators: test generator with reasoning traces

### DIFF
--- a/garak/generators/test.py
+++ b/garak/generators/test.py
@@ -70,16 +70,37 @@ class Nones(Generator):
 
 
 class Lipsum(Generator):
-    """Lorem Ipsum generator, so we can get non-zero outputs that vary"""
+    """Lorem Ipsum generator, so we can get non-zero outputs that vary
+
+    Configurable parameters:
+        unit: str - content unit to generate per output.
+            Must be one of "sentence", "paragraph", or "text".
+        count: int - How many of the specified unit to join per output.
+    """
+
+    DEFAULT_PARAMS = Generator.DEFAULT_PARAMS | {
+        "unit": "sentence",
+        "count": 1,
+    }
 
     supports_multiple_generations = False
     generator_family_name = "Test"
     name = "Lorem Ipsum"
 
+    _VALID_UNITS = {"sentence", "paragraph", "text"}
+
     def _call_model(
         self, prompt: Conversation, generations_this_call: int = 1
     ) -> List[Message | None]:
-        return [Message(lorem.sentence()) for i in range(generations_this_call)]
+        if self.unit not in self._VALID_UNITS:
+            raise ValueError(
+                f"Invalid lipsum unit '{self.unit}', must be one of {self._VALID_UNITS}"
+            )
+        generate = getattr(lorem, self.unit)
+        return [
+            Message(" ".join(generate() for _ in range(self.count)))
+            for i in range(generations_this_call)
+        ]
 
 
 class BlankVision(Generator):

--- a/garak/generators/test.py
+++ b/garak/generators/test.py
@@ -87,18 +87,23 @@ class Lipsum(Generator):
     generator_family_name = "Test"
     name = "Lorem Ipsum"
 
-    _VALID_UNITS = {"sentence", "paragraph", "text"}
+    _unit_separators = {
+        "sentence": ". ",
+        "paragraph": ".\n",
+        "text": "\n\n",
+    }
 
     def _call_model(
         self, prompt: Conversation, generations_this_call: int = 1
     ) -> List[Message | None]:
-        if self.unit not in self._VALID_UNITS:
+        if self.unit not in self._unit_separators:
             raise ValueError(
-                f"Invalid lipsum unit '{self.unit}', must be one of {self._VALID_UNITS}"
+                f"Invalid unit '{self.unit}', must be one of {set(self._unit_separators)}"
             )
         generate = getattr(lorem, self.unit)
+        sep = self._unit_separators[self.unit]
         return [
-            Message(" ".join(generate() for _ in range(self.count)))
+            Message(sep.join(generate() for _ in range(self.count)))
             for i in range(generations_this_call)
         ]
 

--- a/garak/generators/test.py
+++ b/garak/generators/test.py
@@ -93,6 +93,28 @@ class Lipsum(Generator):
         "text": "\n\n",
     }
 
+    def _generate_lorem(self, target_length: int, variance: float = 0.0) -> str:
+        """Generate lorem text of approximately target_length characters.
+
+        Builds up text sentence-by-sentence until the target is reached.
+
+        Args:
+            target_length: Target number of characters to generate.
+            variance: Fraction (0.0–1.0) by which the actual length may
+                randomly deviate from target_length. E.g. 0.1 means ±10%.
+        """
+        if variance > 0:
+            deviation = self._rng.uniform(-variance, variance) * target_length
+            target_length = max(1, int(target_length + deviation))
+
+        parts = []
+        current_length = 0
+        while current_length < target_length:
+            part = lorem.sentence()
+            parts.append(part)
+            current_length += len(part) + 1
+        return " ".join(parts)
+
     def _call_model(
         self, prompt: Conversation, generations_this_call: int = 1
     ) -> List[Message | None]:
@@ -106,6 +128,45 @@ class Lipsum(Generator):
             Message(sep.join(generate() for _ in range(self.count)))
             for i in range(generations_this_call)
         ]
+
+
+class ReasoningLipsum(Lipsum):
+    """Lorem Ipsum generator with a simulated reasoning trace, for testing
+    probe/detector behavior with long structured outputs.
+
+    Generates output in the format:
+        {skip_seq_start}\\n{reasoning text}\\n{skip_seq_end}\\n{output text}
+
+    Configurable parameters:
+        skip_seq_start: str - Opening delimiter for the reasoning trace.
+        skip_seq_end: str - Closing delimiter for the reasoning trace.
+        reasoning_length: int - Target character count for the reasoning trace.
+        output_length: int - Target character count for the output text.
+        variance: float - Fraction (0.0–1.0) by which reasoning_length and output_length may independently and randomly deviate from their configured values. E.g. 0.1 means ±10%.
+    """
+
+    DEFAULT_PARAMS = Lipsum.DEFAULT_PARAMS | {
+        "skip_seq_start": "<think>",
+        "skip_seq_end": "</think>",
+        "reasoning_length": 1500,
+        "output_length": 1000,
+        "variance": 0.1,
+    }
+
+    supports_multiple_generations = False
+    generator_family_name = "Test"
+    name = "Reasoning Lipsum"
+
+    def _call_model(
+        self, prompt: Conversation, generations_this_call: int = 1
+    ) -> List[Message | None]:
+        results = []
+        for _ in range(generations_this_call):
+            reasoning = self._generate_lorem(self.reasoning_length, self.variance)
+            output = self._generate_lorem(self.output_length, self.variance)
+            text = f"{self.skip_seq_start}{reasoning}" f"{self.skip_seq_end}{output}"
+            results.append(Message(text))
+        return results
 
 
 class BlankVision(Generator):

--- a/garak/generators/test.py
+++ b/garak/generators/test.py
@@ -161,13 +161,11 @@ class ReasoningLipsum(Lipsum):
 
         gen_func = getattr(lorem, self.unit)
 
-        parts = []
-        current_length = 0
-        while current_length < min_length:
-            part = gen_func()
-            parts.append(part)
-            current_length += len(part) + len(self._unit_separators[self.unit])
-        return self._unit_separators[self.unit].join(parts)
+        lorem_text = gen_func()
+        while len(lorem_text) < min_length:
+            lorem_text += self._unit_separators[self.unit]
+            lorem_text += gen_func()
+        return lorem_text
 
     def _call_model(
         self, prompt: Conversation, generations_this_call: int = 1

--- a/garak/generators/test.py
+++ b/garak/generators/test.py
@@ -88,32 +88,10 @@ class Lipsum(Generator):
     name = "Lorem Ipsum"
 
     _unit_separators = {
-        "sentence": ". ",
-        "paragraph": ".\n",
-        "text": "\n\n",
+        "sentence": " ",
+        "paragraph": "\n",
+        "text": "\n",
     }
-
-    def _generate_lorem(self, target_length: int, variance: float = 0.0) -> str:
-        """Generate lorem text of approximately target_length characters.
-
-        Builds up text sentence-by-sentence until the target is reached.
-
-        Args:
-            target_length: Target number of characters to generate.
-            variance: Fraction (0.0–1.0) by which the actual length may
-                randomly deviate from target_length. E.g. 0.1 means ±10%.
-        """
-        if variance > 0:
-            deviation = self._rng.uniform(-variance, variance) * target_length
-            target_length = max(1, int(target_length + deviation))
-
-        parts = []
-        current_length = 0
-        while current_length < target_length:
-            part = lorem.sentence()
-            parts.append(part)
-            current_length += len(part) + 1
-        return " ".join(parts)
 
     def _call_model(
         self, prompt: Conversation, generations_this_call: int = 1
@@ -151,15 +129,45 @@ class ReasoningLipsum(Lipsum):
     DEFAULT_PARAMS = Lipsum.DEFAULT_PARAMS | {
         "skip_seq_start": "<think>",
         "skip_seq_end": "</think>",
-        "reasoning_length": 1500,
-        "output_length": 1000,
+        "reasoning_length": 2000,
+        "output_length": 500,
         "variance": 0.1,
         "respect_max_tokens": False,
+        "unit": "sentence",
     }
 
     supports_multiple_generations = False
     generator_family_name = "Test"
     name = "Reasoning Lipsum"
+
+    def _generate_lorem(self, min_length: int, variance: float = 0.0) -> str:
+        """Generate lorem text of approximately target_length characters.
+
+        Builds up text sentence-by-sentence until the target is reached.
+
+        Args:
+            target_length: Target number of characters to generate.
+            variance: Fraction (0.0–1.0) by which the actual length may
+                randomly deviate from target_length. E.g. 0.1 means ±10%.
+        """
+        if variance > 0:
+            deviation = self._rng.uniform(-variance, variance) * min_length
+            min_length = max(1, int(min_length + deviation))
+
+        if self.unit not in self._unit_separators:
+            raise ValueError(
+                f"Invalid unit '{self.unit}', must be one of {set(self._unit_separators)}"
+            )
+
+        gen_func = getattr(lorem, self.unit)
+
+        parts = []
+        current_length = 0
+        while current_length < min_length:
+            part = gen_func()
+            parts.append(part)
+            current_length += len(part) + len(self._unit_separators[self.unit])
+        return self._unit_separators[self.unit].join(parts)
 
     def _call_model(
         self, prompt: Conversation, generations_this_call: int = 1

--- a/garak/generators/test.py
+++ b/garak/generators/test.py
@@ -135,14 +135,17 @@ class ReasoningLipsum(Lipsum):
     probe/detector behavior with long structured outputs.
 
     Generates output in the format:
-        {skip_seq_start}\\n{reasoning text}\\n{skip_seq_end}\\n{output text}
+        {skip_seq_start}{reasoning text}{skip_seq_end}{output text}
 
     Configurable parameters:
         skip_seq_start: str - Opening delimiter for the reasoning trace.
         skip_seq_end: str - Closing delimiter for the reasoning trace.
         reasoning_length: int - Target character count for the reasoning trace.
         output_length: int - Target character count for the output text.
-        variance: float - Fraction (0.0–1.0) by which reasoning_length and output_length may independently and randomly deviate from their configured values. E.g. 0.1 means ±10%.
+        variance: float - Fraction (0.0–1.0) by which reasoning_length and
+            output_length may deviate from configured values. 0.1 means ±10%.
+        respect_max_tokens: bool - Cap the output text (not the
+            reasoning trace) to approximately max_tokens * 1.4 characters.
     """
 
     DEFAULT_PARAMS = Lipsum.DEFAULT_PARAMS | {
@@ -151,6 +154,7 @@ class ReasoningLipsum(Lipsum):
         "reasoning_length": 1500,
         "output_length": 1000,
         "variance": 0.1,
+        "respect_max_tokens": False,
     }
 
     supports_multiple_generations = False
@@ -160,11 +164,16 @@ class ReasoningLipsum(Lipsum):
     def _call_model(
         self, prompt: Conversation, generations_this_call: int = 1
     ) -> List[Message | None]:
+        output_length = self.output_length
+        if self.respect_max_tokens and self.max_tokens is not None:
+            token_char_budget = int(self.max_tokens * 1.4)
+            output_length = min(output_length, token_char_budget)
+
         results = []
         for _ in range(generations_this_call):
             reasoning = self._generate_lorem(self.reasoning_length, self.variance)
-            output = self._generate_lorem(self.output_length, self.variance)
-            text = f"{self.skip_seq_start}{reasoning}" f"{self.skip_seq_end}{output}"
+            output = self._generate_lorem(output_length, self.variance)
+            text = f"{self.skip_seq_start}{reasoning}{self.skip_seq_end}{output}"
             results.append(Message(text))
         return results
 

--- a/tests/generators/test_test.py
+++ b/tests/generators/test_test.py
@@ -7,7 +7,7 @@ import random
 import garak._plugins
 from garak.attempt import Message, Turn, Conversation
 import garak.generators.base
-from garak.generators.test import Blank, Repeat, Single
+from garak.generators.test import Blank, Repeat, Single, Lipsum, ReasoningLipsum
 
 TEST_GENERATORS = [
     a
@@ -152,3 +152,198 @@ def test_generators_test_blank_many():
     assert output[1] == Message(
         ""
     ), "Blank generator .generate() output list should contain Turns (second position) w empty prompt"
+
+
+def _make_conv():
+    return Conversation([Turn("user", Message("test"))])
+
+
+def test_lipsum_default_returns_message():
+    g = Lipsum()
+    output = g.generate(_make_conv())
+    assert len(output) == 1
+    assert isinstance(output[0], Message)
+    assert len(str(output[0])) > 0, "Lipsum should produce non-empty output"
+
+
+def test_lipsum_unit_sentence():
+    g = Lipsum()
+    g.unit = "sentence"
+    g.count = 1
+    output = g._call_model(_make_conv())
+    text = output[0].text
+    assert text.endswith("."), "A single lorem sentence should end with a period"
+    assert "\n" not in text, "A single sentence should not contain newlines"
+
+
+def test_lipsum_unit_paragraph():
+    g = Lipsum()
+    g.unit = "paragraph"
+    g.count = 1
+    output = g._call_model(_make_conv())
+    text = output[0].text
+    assert len(text) > 0
+    assert text.count(".") > 1, "A paragraph should contain multiple sentences"
+
+
+def test_lipsum_unit_text():
+    g = Lipsum()
+    g.unit = "text"
+    g.count = 1
+    output = g._call_model(_make_conv())
+    text = output[0].text
+    assert len(text) > 0
+    assert "\n" in text, "A text block should contain newlines between paragraphs"
+
+
+def test_lipsum_count_joins_multiple_units():
+    g = Lipsum()
+    g.unit = "sentence"
+    g.count = 5
+    output = g._call_model(_make_conv())
+    text = output[0].text
+    assert text.count(".") >= 5, "count=5 sentences should yield at least 5 periods"
+
+
+def test_lipsum_invalid_unit_raises():
+    g = Lipsum()
+    g.unit = "chapter"
+    with pytest.raises(ValueError, match="Invalid unit"):
+        g._call_model(_make_conv())
+
+
+def test_lipsum_outputs_vary():
+    g = Lipsum()
+    results = {g._call_model(_make_conv())[0].text for _ in range(20)}
+    assert len(results) > 1, "Lipsum outputs should vary across calls"
+
+
+def test_lipsum_generate_lorem_target_length():
+    g = Lipsum()
+    target = 500
+    text = g._generate_lorem(target, variance=0.0)
+    assert (
+        len(text) >= target
+    ), f"_generate_lorem should produce at least {target} chars, got {len(text)}"
+    assert (
+        len(text) < target + 200
+    ), "_generate_lorem should not overshoot the target by more than one sentence"
+
+
+def test_lipsum_generate_lorem_variance_zero_is_stable():
+    g = Lipsum()
+    target = 300
+    lengths = [len(g._generate_lorem(target, variance=0.0)) for _ in range(10)]
+    spread = max(lengths) - min(lengths)
+    assert (
+        spread < 200
+    ), "With variance=0.0, length spread should be small (only sentence granularity)"
+
+
+def test_lipsum_generate_lorem_variance_affects_length():
+    g = Lipsum()
+    target = 1000
+    lengths = [len(g._generate_lorem(target, variance=0.4)) for _ in range(30)]
+    spread = max(lengths) - min(lengths)
+    assert spread > 0, "With high variance, outputs should differ in length"
+
+
+# --- ReasoningLipsum tests ---
+
+
+def test_reasoning_lipsum_default_returns_message():
+    g = ReasoningLipsum()
+    output = g.generate(_make_conv())
+    assert len(output) == 1
+    assert isinstance(output[0], Message)
+
+
+def test_reasoning_lipsum_contains_delimiters():
+    g = ReasoningLipsum()
+    output = g._call_model(_make_conv())
+    text = output[0].text
+    assert g.skip_seq_start in text, "Output should contain skip_seq_start delimiter"
+    assert g.skip_seq_end in text, "Output should contain skip_seq_end delimiter"
+
+
+def test_reasoning_lipsum_structure():
+    g = ReasoningLipsum()
+    output = g._call_model(_make_conv())
+    text = output[0].text
+    start_idx = text.index(g.skip_seq_start)
+    end_idx = text.index(g.skip_seq_end)
+    assert start_idx < end_idx, "skip_seq_start must appear before skip_seq_end"
+    assert text.startswith(g.skip_seq_start), "Output should start with skip_seq_start"
+    after_end = text[end_idx + len(g.skip_seq_end) :]
+    assert len(after_end) > 0, "There should be output text after skip_seq_end"
+
+
+def test_reasoning_lipsum_approximate_total_length():
+    g = ReasoningLipsum()
+    g.variance = 0.0
+    output = g._call_model(_make_conv())
+    character_grace_window = 100
+    text = output[0].text
+    assert (
+        len(text) > g.reasoning_length + g.output_length - character_grace_window
+    ), f"Default output should be roughly 2500 chars, got {len(text)}"
+    assert (
+        len(text) < g.reasoning_length + g.output_length + character_grace_window
+    ), f"Default output should be roughly 2500 chars, got {len(text)}"
+
+
+def test_reasoning_lipsum_custom_delimiters():
+    g = ReasoningLipsum()
+    g.skip_seq_start = "[[REASON]]"
+    g.skip_seq_end = "[[/REASON]]"
+    output = g._call_model(_make_conv())
+    text = output[0].text
+    assert text.startswith(g.skip_seq_start)
+    assert g.skip_seq_end in text
+
+
+def test_reasoning_lipsum_custom_lengths():
+    g = ReasoningLipsum()
+    g.reasoning_length = 500
+    g.output_length = 200
+    g.variance = 0.0
+    output = g._call_model(_make_conv())
+    text = output[0].text
+    end_idx = text.index(g.skip_seq_end)
+    reasoning_section = text[len(g.skip_seq_start) : end_idx]
+    output_section = text[end_idx + len(g.skip_seq_end) :]
+    assert (
+        len(reasoning_section) >= 500
+    ), f"Reasoning section should be >= 500 chars, got {len(reasoning_section)}"
+    assert (
+        len(output_section) >= 200
+    ), f"Output section should be >= 200 chars, got {len(output_section)}"
+
+
+def test_reasoning_lipsum_variance_zero_consistent():
+    g = ReasoningLipsum()
+    g.variance = 0.0
+    lengths = [len(g._call_model(_make_conv())[0].text) for _ in range(10)]
+    spread = max(lengths) - min(lengths)
+    assert (
+        spread < 300
+    ), f"With variance=0.0, total length spread should be small, got {spread}"
+
+
+def test_reasoning_lipsum_variance_produces_variation():
+    g = ReasoningLipsum()
+    g.variance = 0.4
+    lengths = [len(g._call_model(_make_conv())[0].text) for _ in range(30)]
+    spread = max(lengths) - min(lengths)
+    assert spread > 0, "With high variance, output lengths should vary"
+
+
+def test_reasoning_lipsum_multiple_generations():
+    g = ReasoningLipsum()
+    output = g._call_model(_make_conv(), generations_this_call=3)
+    assert len(output) == 3, "Should return requested number of generations"
+    for msg in output:
+        assert isinstance(msg, Message)
+        text = msg.text
+        assert g.skip_seq_start in text
+        assert g.skip_seq_end in text

--- a/tests/generators/test_test.py
+++ b/tests/generators/test_test.py
@@ -158,8 +158,7 @@ def _make_conv():
     return Conversation([Turn("user", Message("test"))])
 
 
-LIPSUM_MARGIN = 120
-LIPSUM_GENERATIONS = 15
+LIPSUM_GENERATIONS = 200
 
 
 def test_lipsum_default_returns_message():
@@ -225,40 +224,6 @@ def test_lipsum_outputs_vary():
     assert len(results) > 1, "Lipsum outputs should vary across calls"
 
 
-def test_lipsum_generate_lorem_target_length():
-    g = Lipsum()
-    target = 500
-    text = g._generate_lorem(target, variance=0.0)
-    assert (
-        len(text) >= target
-    ), f"_generate_lorem should produce at least {target} chars, got {len(text)}"
-    assert (
-        len(text) < target + LIPSUM_MARGIN
-    ), "_generate_lorem should not overshoot the target by more than one sentence"
-
-
-def test_lipsum_generate_lorem_variance_zero_is_stable():
-    g = Lipsum()
-    target = 300
-    lengths = [
-        len(g._generate_lorem(target, variance=0.0)) for _ in range(LIPSUM_GENERATIONS)
-    ]
-    spread = max(lengths) - min(lengths)
-    assert (
-        spread < LIPSUM_MARGIN
-    ), "With variance=0.0, length spread should be small (only sentence granularity)"
-
-
-def test_lipsum_generate_lorem_variance_affects_length():
-    g = Lipsum()
-    target = 1000
-    lengths = [
-        len(g._generate_lorem(target, variance=0.4)) for _ in range(LIPSUM_GENERATIONS)
-    ]
-    spread = max(lengths) - min(lengths)
-    assert spread > LIPSUM_MARGIN, "With high variance, outputs should differ in length"
-
-
 def test_reasoning_lipsum_default_returns_message():
     g = ReasoningLipsum()
     output = g.generate(_make_conv())
@@ -294,11 +259,11 @@ def test_reasoning_lipsum_approximate_total_length():
     delimiters_len = len(g.skip_seq_start) + len(g.skip_seq_end)
     expected = g.reasoning_length + g.output_length + delimiters_len
     assert (
-        len(text) > expected - LIPSUM_MARGIN
-    ), f"Default output should be roughly {expected} chars, got {len(text)}"
+        len(text) > expected
+    ), f"Default output should be at least {expected} chars, got {len(text)}"
     assert (
-        len(text) < expected + LIPSUM_MARGIN
-    ), f"Default output should be roughly {expected} chars, got {len(text)}"
+        len(text) < 2 * expected
+    ), f"Default output should be under 2x {expected} chars, got {len(text)}"
 
 
 def test_reasoning_lipsum_custom_delimiters():
@@ -329,26 +294,42 @@ def test_reasoning_lipsum_custom_lengths():
     ), f"Output section should be >= {g.output_length} chars, got {len(output_section)}"
 
 
-def test_reasoning_lipsum_variance_zero_consistent():
+LIPSUM_MARGIN = 100
+SENT_MAX = 120
+PARA_MAX = 800
+TEXT_MAX = 4000
+
+
+@pytest.mark.parametrize(
+    "unit,max_margin",
+    [("sentence", SENT_MAX), ("paragraph", PARA_MAX), ("text", TEXT_MAX)],
+)
+def test_reasoning_lipsum_variance_zero_consistent(unit, max_margin):
     g = ReasoningLipsum()
     g.variance = 0.0
+    g.unit = unit
     lengths = [
         len(g._call_model(_make_conv())[0].text) for _ in range(LIPSUM_GENERATIONS)
     ]
     spread = max(lengths) - min(lengths)
     assert (
-        spread < LIPSUM_MARGIN
+        spread < max_margin
     ), f"With variance=0.0, total length spread should be small, got {spread}"
 
 
-def test_reasoning_lipsum_variance_produces_variation():
+@pytest.mark.parametrize(
+    "unit,min_margin",
+    [("sentence", SENT_MAX / 2), ("paragraph", PARA_MAX / 2), ("text", TEXT_MAX / 2)],
+)
+def test_reasoning_lipsum_variance_produces_variation(unit, min_margin):
     g = ReasoningLipsum()
     g.variance = 0.4
+    g.unit = unit
     lengths = [
         len(g._call_model(_make_conv())[0].text) for _ in range(LIPSUM_GENERATIONS)
     ]
     spread = max(lengths) - min(lengths)
-    assert spread > LIPSUM_MARGIN, "With high variance, output lengths should vary"
+    assert spread > min_margin, "With high variance, output lengths should vary"
 
 
 def test_reasoning_lipsum_multiple_generations():

--- a/tests/generators/test_test.py
+++ b/tests/generators/test_test.py
@@ -158,7 +158,7 @@ def _make_conv():
     return Conversation([Turn("user", Message("test"))])
 
 
-LIPSUM_MARGIN = 100
+LIPSUM_MARGIN = 120
 LIPSUM_GENERATIONS = 15
 
 
@@ -291,12 +291,14 @@ def test_reasoning_lipsum_approximate_total_length():
     g.variance = 0.0
     output = g._call_model(_make_conv())
     text = output[0].text
+    delimiters_len = len(g.skip_seq_start) + len(g.skip_seq_end)
+    expected = g.reasoning_length + g.output_length + delimiters_len
     assert (
-        len(text) > g.reasoning_length + g.output_length - LIPSUM_MARGIN
-    ), f"Default output should be roughly 2500 chars, got {len(text)}"
+        len(text) > expected - LIPSUM_MARGIN
+    ), f"Default output should be roughly {expected} chars, got {len(text)}"
     assert (
-        len(text) < g.reasoning_length + g.output_length + LIPSUM_MARGIN
-    ), f"Default output should be roughly 2500 chars, got {len(text)}"
+        len(text) < expected + LIPSUM_MARGIN
+    ), f"Default output should be roughly {expected} chars, got {len(text)}"
 
 
 def test_reasoning_lipsum_custom_delimiters():
@@ -311,8 +313,8 @@ def test_reasoning_lipsum_custom_delimiters():
 
 def test_reasoning_lipsum_custom_lengths():
     g = ReasoningLipsum()
-    g.reasoning_length = 500
-    g.output_length = 200
+    g.reasoning_length = 5000
+    g.output_length = 2000
     g.variance = 0.0
     output = g._call_model(_make_conv())
     text = output[0].text

--- a/tests/generators/test_test.py
+++ b/tests/generators/test_test.py
@@ -158,6 +158,10 @@ def _make_conv():
     return Conversation([Turn("user", Message("test"))])
 
 
+LIPSUM_MARGIN = 100
+LIPSUM_GENERATIONS = 15
+
+
 def test_lipsum_default_returns_message():
     g = Lipsum()
     output = g.generate(_make_conv())
@@ -197,12 +201,15 @@ def test_lipsum_unit_text():
 
 
 def test_lipsum_count_joins_multiple_units():
+    count = 5
     g = Lipsum()
     g.unit = "sentence"
-    g.count = 5
+    g.count = count
     output = g._call_model(_make_conv())
     text = output[0].text
-    assert text.count(".") >= 5, "count=5 sentences should yield at least 5 periods"
+    assert (
+        text.count(".") >= count
+    ), f"count={count} sentences should yield at least {count} stops"
 
 
 def test_lipsum_invalid_unit_raises():
@@ -214,7 +221,7 @@ def test_lipsum_invalid_unit_raises():
 
 def test_lipsum_outputs_vary():
     g = Lipsum()
-    results = {g._call_model(_make_conv())[0].text for _ in range(20)}
+    results = {g._call_model(_make_conv())[0].text for _ in range(LIPSUM_GENERATIONS)}
     assert len(results) > 1, "Lipsum outputs should vary across calls"
 
 
@@ -226,29 +233,30 @@ def test_lipsum_generate_lorem_target_length():
         len(text) >= target
     ), f"_generate_lorem should produce at least {target} chars, got {len(text)}"
     assert (
-        len(text) < target + 200
+        len(text) < target + LIPSUM_MARGIN
     ), "_generate_lorem should not overshoot the target by more than one sentence"
 
 
 def test_lipsum_generate_lorem_variance_zero_is_stable():
     g = Lipsum()
     target = 300
-    lengths = [len(g._generate_lorem(target, variance=0.0)) for _ in range(10)]
+    lengths = [
+        len(g._generate_lorem(target, variance=0.0)) for _ in range(LIPSUM_GENERATIONS)
+    ]
     spread = max(lengths) - min(lengths)
     assert (
-        spread < 200
+        spread < LIPSUM_MARGIN
     ), "With variance=0.0, length spread should be small (only sentence granularity)"
 
 
 def test_lipsum_generate_lorem_variance_affects_length():
     g = Lipsum()
     target = 1000
-    lengths = [len(g._generate_lorem(target, variance=0.4)) for _ in range(30)]
+    lengths = [
+        len(g._generate_lorem(target, variance=0.4)) for _ in range(LIPSUM_GENERATIONS)
+    ]
     spread = max(lengths) - min(lengths)
-    assert spread > 0, "With high variance, outputs should differ in length"
-
-
-# --- ReasoningLipsum tests ---
+    assert spread > LIPSUM_MARGIN, "With high variance, outputs should differ in length"
 
 
 def test_reasoning_lipsum_default_returns_message():
@@ -282,13 +290,12 @@ def test_reasoning_lipsum_approximate_total_length():
     g = ReasoningLipsum()
     g.variance = 0.0
     output = g._call_model(_make_conv())
-    character_grace_window = 100
     text = output[0].text
     assert (
-        len(text) > g.reasoning_length + g.output_length - character_grace_window
+        len(text) > g.reasoning_length + g.output_length - LIPSUM_MARGIN
     ), f"Default output should be roughly 2500 chars, got {len(text)}"
     assert (
-        len(text) < g.reasoning_length + g.output_length + character_grace_window
+        len(text) < g.reasoning_length + g.output_length + LIPSUM_MARGIN
     ), f"Default output should be roughly 2500 chars, got {len(text)}"
 
 
@@ -313,35 +320,41 @@ def test_reasoning_lipsum_custom_lengths():
     reasoning_section = text[len(g.skip_seq_start) : end_idx]
     output_section = text[end_idx + len(g.skip_seq_end) :]
     assert (
-        len(reasoning_section) >= 500
-    ), f"Reasoning section should be >= 500 chars, got {len(reasoning_section)}"
+        len(reasoning_section) >= g.reasoning_length
+    ), f"Reasoning section should be >= {g.reasoning_length} chars, got {len(reasoning_section)}"
     assert (
-        len(output_section) >= 200
-    ), f"Output section should be >= 200 chars, got {len(output_section)}"
+        len(output_section) >= g.output_length
+    ), f"Output section should be >= {g.output_length} chars, got {len(output_section)}"
 
 
 def test_reasoning_lipsum_variance_zero_consistent():
     g = ReasoningLipsum()
     g.variance = 0.0
-    lengths = [len(g._call_model(_make_conv())[0].text) for _ in range(10)]
+    lengths = [
+        len(g._call_model(_make_conv())[0].text) for _ in range(LIPSUM_GENERATIONS)
+    ]
     spread = max(lengths) - min(lengths)
     assert (
-        spread < 300
+        spread < LIPSUM_MARGIN
     ), f"With variance=0.0, total length spread should be small, got {spread}"
 
 
 def test_reasoning_lipsum_variance_produces_variation():
     g = ReasoningLipsum()
     g.variance = 0.4
-    lengths = [len(g._call_model(_make_conv())[0].text) for _ in range(30)]
+    lengths = [
+        len(g._call_model(_make_conv())[0].text) for _ in range(LIPSUM_GENERATIONS)
+    ]
     spread = max(lengths) - min(lengths)
-    assert spread > 0, "With high variance, output lengths should vary"
+    assert spread > LIPSUM_MARGIN, "With high variance, output lengths should vary"
 
 
 def test_reasoning_lipsum_multiple_generations():
     g = ReasoningLipsum()
-    output = g._call_model(_make_conv(), generations_this_call=3)
-    assert len(output) == 3, "Should return requested number of generations"
+    output = g._call_model(_make_conv(), generations_this_call=LIPSUM_GENERATIONS)
+    assert (
+        len(output) == LIPSUM_GENERATIONS
+    ), "Should return requested number of generations"
     for msg in output:
         assert isinstance(msg, Message)
         text = msg.text

--- a/tests/generators/test_test.py
+++ b/tests/generators/test_test.py
@@ -235,8 +235,20 @@ def test_reasoning_lipsum_contains_delimiters():
     g = ReasoningLipsum()
     output = g._call_model(_make_conv())
     text = output[0].text
-    assert g.skip_seq_start in text, "Output should contain skip_seq_start delimiter"
-    assert g.skip_seq_end in text, "Output should contain skip_seq_end delimiter"
+    if g.skip_seq_start:
+        assert text.startswith(
+            g.skip_seq_start
+        ), "Output should begin with skip_seq_start delimiter"
+    if g.skip_seq_end:
+        assert g.skip_seq_end in text, "Output should contain skip_seq_end delimiter"
+        if g.skip_seq_end != g.skip_seq_start:
+            assert not text.startswith(
+                g.skip_seq_end
+            ), "Output should not start with skip_seq_end"
+        if g.output_length > 0:
+            assert not text.endswith(
+                g.skip_seq_end
+            ), "Output should end with lipsum, ends with skip_seq_end"
 
 
 def test_reasoning_lipsum_structure():


### PR DESCRIPTION
Needed to help eval downstream effects of reasoning traces and longer outputs

* Add option to specify requested length to `test.Lipsum` generator
* Add option to specify requested output generation unit with `test.Lipsum`
* Add option to build in variance over requested output length in `test.Lipsum`
* Add a `test.ReasoningLipsum` generator that uses `test.Lipsum` to create long reasoning traces
* Add tests for the above

resolves #1696