### PR TITLE
bug: avoid TBSA double horizontal rule

### DIFF
--- a/garak/analyze/tbsa.py
+++ b/garak/analyze/tbsa.py
@@ -25,6 +25,10 @@ import garak.resources.theme
 PROBE_DETECTOR_SEP = "+"
 
 
+def _print_hr() -> None:
+    print("─" * 50, flush=True)
+
+
 def build_tiers() -> dict:
     from garak._plugins import enumerate_plugins, plugin_info
 
@@ -74,7 +78,7 @@ def digest_to_tbsa(digest: dict, verbose=False, quiet=False) -> Tuple[float, str
     c = garak.analyze.calibration.Calibration()
     if not quiet:
         print(f"📐 Calibration was {c.calibration_filename} from {c.metadata['date']}")
-        print("─" * 50, flush=True)
+        # _print_hr()
     probe_detector_scores = {}
     probe_detector_defcons = {}
 
@@ -269,7 +273,7 @@ def main(argv=None) -> None:
         print(
             f"garak {garak.__description__} v{garak._config.version} ( https://github.com/NVIDIA/garak ) TBSA"
         )
-        print("─" * 50)
+        _print_hr()
         print(f"📜 Report file: {args.report_path}")
 
         if args.json_output:
@@ -299,7 +303,7 @@ def main(argv=None) -> None:
     )
 
     if not args.quiet:
-        print("─" * 50)
+        _print_hr()
 
     if not (args.quiet and args.json_output):
         print(f"📝 Probe/detector pairs contributing: {pd_count}")

--- a/garak/analyze/tbsa.py
+++ b/garak/analyze/tbsa.py
@@ -78,7 +78,6 @@ def digest_to_tbsa(digest: dict, verbose=False, quiet=False) -> Tuple[float, str
     c = garak.analyze.calibration.Calibration()
     if not quiet:
         print(f"📐 Calibration was {c.calibration_filename} from {c.metadata['date']}")
-        # _print_hr()
     probe_detector_scores = {}
     probe_detector_defcons = {}
 


### PR DESCRIPTION
garak.analyze.tbsa would print two horizontal rules in a row if no comments

avoid this - remove the upper one. we still want a visual delineation above the important stuff at the report end.