### PR TITLE
Log detector skip info

### DIFF
--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -160,10 +160,20 @@ class Harness(Configurable):
                 attempt_iterator.set_description("detectors." + detector_probe_name)
                 for attempt in attempt_iterator:
                     if d.skip:
+                        logging.info(
+                            "detector skipped: detector=%s probe=%s reason=skip_config_enabled",
+                            detector_probe_name,
+                            probe.probename,
+                        )
                         continue
-                    attempt.detector_results[detector_probe_name] = list(
-                        d.detect(attempt)
+                    detector_results = list(d.detect(attempt))
+                    _log_detector_skip_info(
+                        detector_probe_name,
+                        probe.probename,
+                        attempt,
+                        detector_results,
                     )
+                    attempt.detector_results[detector_probe_name] = detector_results
 
             for attempt in attempt_results:
                 attempt.status = garak.attempt.ATTEMPT_COMPLETE
@@ -194,3 +204,34 @@ def _modality_match(probe_modality, generator_modality, strict):
         return set(probe_modality).intersection(generator_modality) == set(
             probe_modality
         )
+
+
+def _log_detector_skip_info(detector_name, probe_name, attempt, detector_results):
+    result_count = len(detector_results)
+    if result_count == 0:
+        logging.info(
+            "detector skipped outputs: detector=%s probe=%s attempt=%s reason=no_detector_results",
+            detector_name,
+            probe_name,
+            attempt.uuid,
+        )
+        return
+
+    none_count = sum(score is None for score in detector_results)
+    if none_count == 0:
+        return
+
+    if none_count == result_count:
+        reason = "all_results_none"
+    else:
+        reason = "some_results_none"
+
+    logging.info(
+        "detector skipped outputs: detector=%s probe=%s attempt=%s reason=%s skipped=%d total=%d",
+        detector_name,
+        probe_name,
+        attempt.uuid,
+        reason,
+        none_count,
+        result_count,
+    )

--- a/tests/harnesses/test_harnesses.py
+++ b/tests/harnesses/test_harnesses.py
@@ -3,9 +3,11 @@
 
 import pytest
 import importlib
+import logging
 
 from garak import _plugins
 
+from garak.attempt import Attempt
 import garak.harnesses.base
 
 HARNESSES = [
@@ -47,3 +49,38 @@ def test_harness_modality_match():
     assert garak.harnesses.base._modality_match(t, tvi, False) is True
     assert garak.harnesses.base._modality_match(ti, tvi, False) is True
     assert garak.harnesses.base._modality_match(t, ti, False) is True
+
+
+def test_log_detector_skip_info_for_no_results(caplog):
+    attempt = Attempt()
+
+    with caplog.at_level(logging.INFO):
+        garak.harnesses.base._log_detector_skip_info(
+            "always.Pass", "test.Blank", attempt, []
+        )
+
+    assert "reason=no_detector_results" in caplog.text
+    assert "detector=always.Pass" in caplog.text
+
+
+def test_log_detector_skip_info_for_none_results(caplog):
+    attempt = Attempt()
+
+    with caplog.at_level(logging.INFO):
+        garak.harnesses.base._log_detector_skip_info(
+            "always.Pass", "test.Blank", attempt, [None, 0.0, None]
+        )
+
+    assert "reason=some_results_none" in caplog.text
+    assert "skipped=2 total=3" in caplog.text
+
+
+def test_log_detector_skip_info_ignores_complete_results(caplog):
+    attempt = Attempt()
+
+    with caplog.at_level(logging.INFO):
+        garak.harnesses.base._log_detector_skip_info(
+            "always.Pass", "test.Blank", attempt, [0.0, 1.0]
+        )
+
+    assert caplog.text == ""


### PR DESCRIPTION

This fixes #1061.

When detector results are skipped, the run can end up with `None` values or no detector output, but the log does not say much about why.

This change adds logging in the harness where detector results are already being collected. It logs when a detector is skipped through config, when a detector returns no results, and when a detector returns `None` for some outputs.

I kept the scoring and report JSON unchanged. This is only extra information in the logs.

This is submitted from the `add-detector-skip-info` branch in my fork to upstream `main`.


**Verification**: Verified locally with a direct helper check. Calling `_log_detector_skip_info()` with `[None, 0.0]` now logs that one detector result was skipped. Calling it with `[0.0, 1.0]` stays quiet, so normal detector output does not add extra log noise.

Added tests in `tests/harnesses/test_harnesses.py` for the no-results case, the partial-`None` case, and the all-results-present case.

I also ran:
```
python -m compileall garak\harnesses\base.py tests\harnesses\test_harnesses.py
python -c "import logging; from garak.harnesses.base import _log_detector_skip_info; from garak.attempt import Attempt; logging.basicConfig(level=logging.INFO); _log_detector_skip_info('always.Pass', 'test.Blank', Attempt(), [None, 0.0]); print('helper smoke ok')"
python -m black --check garak\harnesses\base.py tests\harnesses\test_harnesses.py
```
I tried `python -m pytest tests\harnesses\test_harnesses.py -q`, but local collection is blocked by repo-wide plugin imports. After installing `xdg-base-dirs`, `tiktoken`, and `nltk`, the next missing package was `wn`. I stopped there instead of installing the full model/NLP dependency stack.

I did not run `garak -t <target_type> -n <model_name>` because this change is in harness logging and does not depend on a specific model or generator config.

Open to feedback and any changes necessary.

Cheers,

Volk