### PR TITLE
report: snapshot plugin cache into report jsonl

### DIFF
--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -50,6 +50,7 @@ def _parse_report(reportfile: IO):
     payloads = []
     setup = defaultdict(str)
     init = {}
+    plugin_cache = None
 
     for record in [json.loads(line.strip()) for line in reportfile if line.strip()]:
         if record["entry_type"] == "eval":
@@ -68,8 +69,13 @@ def _parse_report(reportfile: IO):
                 + "  "
                 + pprint.pformat(record, sort_dicts=True, width=60)
             )
+        elif record["entry_type"] == "plugin_cache":
+            if plugin_cache is None:
+                plugin_cache = {}
+            for category, entries in record.get("plugin_cache", {}).items():
+                plugin_cache.setdefault(category, {}).update(entries)
 
-    return init, setup, payloads, evals
+    return init, setup, payloads, evals, plugin_cache
 
 
 def _report_header_content(report_path, init, setup, payloads, config=_config) -> dict:
@@ -90,7 +96,29 @@ def _report_header_content(report_path, init, setup, payloads, config=_config) -
     return header_content
 
 
-def _init_populate_result_db(evals, taxonomy=None):
+def _resolve_plugin_info(plugin_classpath, report_plugin_cache, required_fields=None):
+    if report_plugin_cache is None:
+        return garak._plugins.PluginCache.plugin_info(plugin_classpath), "live_cache"
+
+    category = plugin_classpath.split(".")[0]
+    meta = report_plugin_cache.get(category, {}).get(plugin_classpath)
+    if meta is None:
+        raise ValueError(f"plugin_cache missing metadata for {plugin_classpath}")
+
+    missing = [
+        field
+        for field in (required_fields or ())
+        if field not in meta or meta[field] is None
+    ]
+    if missing:
+        raise ValueError(
+            f"plugin_cache metadata for {plugin_classpath} missing fields: {missing}"
+        )
+
+    return meta, "header"
+
+
+def _init_populate_result_db(evals, taxonomy=None, report_plugin_cache=None):
 
     conn = sqlite3.connect(":memory:")
     cursor = conn.cursor()
@@ -128,7 +156,12 @@ def _init_populate_result_db(evals, taxonomy=None):
         groups = []
         if taxonomy is not None:
             # get the probe tags
-            tags = garak._plugins.PluginCache.plugin_info(f"probes.{pm}.{pc}")["tags"]
+            meta, _ = _resolve_plugin_info(
+                f"probes.{pm}.{pc}",
+                report_plugin_cache,
+                required_fields=("tags",),
+            )
+            tags = meta["tags"]
             for tag in tags:
                 if tag.split(":")[0] == taxonomy:
                     groups.append(":".join(tag.split(":")[1:]))
@@ -250,9 +283,15 @@ def _get_probe_result_summaries(cursor, probe_group) -> List[tuple]:
     return res.fetchall()
 
 
-def _get_probe_info(probe_module, probe_class, absolute_score) -> dict:
+def _get_probe_info(
+    probe_module, probe_class, absolute_score, report_plugin_cache=None
+) -> dict:
     probe_classpath = f"probes.{probe_module}.{probe_class}"
-    probe_plugin_info = garak._plugins.PluginCache.plugin_info(probe_classpath)
+    probe_plugin_info, _ = _resolve_plugin_info(
+        probe_classpath,
+        report_plugin_cache,
+        required_fields=("description", "tags", "tier"),
+    )
     probe_description = probe_plugin_info["description"]
     probe_tags = probe_plugin_info["tags"]
     probe_plugin_name = f"{probe_module}.{probe_class}"
@@ -298,12 +337,15 @@ def _get_probe_detector_details(
     confidence=None,
     ci_lower=None,
     ci_upper=None,
+    report_plugin_cache=None,
 ) -> dict:
     calibration_used = False
     detector = re.sub(r"[^0-9A-Za-z_.]", "", detector)
     detector_module, detector_class = detector.split(".")
-    detector_cache_entry = garak._plugins.PluginCache.plugin_info(
-        f"detectors.{detector_module}.{detector_class}"
+    detector_cache_entry, _ = _resolve_plugin_info(
+        f"detectors.{detector_module}.{detector_class}",
+        report_plugin_cache,
+        required_fields=("description",),
     )
     detector_description = detector_cache_entry["description"]
 
@@ -415,7 +457,7 @@ def build_digest(report_filename: str, config=_config):
     }
 
     with open(report_filename, "r", encoding="utf-8") as reportfile:
-        init, setup, payloads, evals = _parse_report(reportfile)
+        init, setup, payloads, evals, report_plugin_cache = _parse_report(reportfile)
 
     calibration = garak.analyze.calibration.Calibration()
     calibration_used = False
@@ -425,7 +467,7 @@ def build_digest(report_filename: str, config=_config):
     )
     report_digest["meta"] = header_content
 
-    conn, cursor = _init_populate_result_db(evals, taxonomy)
+    conn, cursor = _init_populate_result_db(evals, taxonomy, report_plugin_cache)
     group_names = _get_report_grouping(cursor)
 
     aggregation_unknown = False
@@ -446,7 +488,10 @@ def build_digest(report_filename: str, config=_config):
             report_digest["eval"][probe_group][f"{probe_module}.{probe_class}"] = {}
 
             probe_info = _get_probe_info(
-                probe_module, probe_class, group_absolute_score
+                probe_module,
+                probe_class,
+                group_absolute_score,
+                report_plugin_cache,
             )
 
             report_digest["eval"][probe_group][f"{probe_module}.{probe_class}"][
@@ -471,6 +516,7 @@ def build_digest(report_filename: str, config=_config):
                     confidence,
                     ci_lower,
                     ci_upper,
+                    report_plugin_cache,
                 )
 
                 # add counts for detector (using original field names from eval records)
@@ -494,6 +540,9 @@ def build_digest(report_filename: str, config=_config):
     report_digest["meta"]["setup"]["reporting.taxonomy"] = taxonomy
     report_digest["meta"]["calibration_used"] = calibration_used
     report_digest["meta"]["aggregation_unknown"] = aggregation_unknown
+    report_digest["meta"]["plugin_cache_source"] = (
+        "live_cache" if report_plugin_cache is None else "header"
+    )
     if calibration_used:
         report_digest["meta"]["calibration"] = _get_calibration_info(calibration)
 

--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -73,9 +73,12 @@ def _parse_report(reportfile: IO):
             if plugin_cache is None:
                 plugin_cache = {}
             for category, entries in record.get("plugin_cache", {}).items():
+                if category == "version":
+                    plugin_cache["version"] = entries
+                    continue
                 plugin_cache.setdefault(category, {}).update(entries)
 
-    if len(plugin_cache) <= 0:
+    if plugin_cache is None or len(plugin_cache) <= 0:
         from copy import deepcopy
         plugin_cache = deepcopy(garak._plugins.PluginCache.instance())
         plugin_cache["version"] = garak.__version__

--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -285,7 +285,7 @@ def _get_probe_info(
     probe_module, probe_class, absolute_score, report_plugin_cache=None
 ) -> dict:
     probe_classpath = f"probes.{probe_module}.{probe_class}"
-    probe_plugin_info, _ = _resolve_plugin_info(
+    probe_plugin_info = _resolve_plugin_info(
         probe_classpath,
         report_plugin_cache,
         required_fields=("description", "tags", "tier"),

--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -539,7 +539,7 @@ def build_digest(report_filename: str, config=_config):
     report_digest["meta"]["calibration_used"] = calibration_used
     report_digest["meta"]["aggregation_unknown"] = aggregation_unknown
     report_digest["meta"]["plugin_cache_source"] = (
-        "live_cache" if report_plugin_cache is None else "header"
+        report_plugin_cache["version"]
     )
     if calibration_used:
         report_digest["meta"]["calibration"] = _get_calibration_info(calibration)

--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -113,7 +113,7 @@ def _resolve_plugin_info(plugin_classpath, report_plugin_cache, required_fields=
             f"plugin_cache metadata for {plugin_classpath} missing fields: {missing}"
         )
 
-    return meta, "header"
+    return meta
 
 
 def _init_populate_result_db(evals, taxonomy=None, report_plugin_cache=None):

--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -97,8 +97,6 @@ def _report_header_content(report_path, init, setup, payloads, config=_config) -
 
 
 def _resolve_plugin_info(plugin_classpath, report_plugin_cache, required_fields=None):
-    if report_plugin_cache is None:
-        return garak._plugins.PluginCache.plugin_info(plugin_classpath), "live_cache"
 
     category = plugin_classpath.split(".")[0]
     meta = report_plugin_cache.get(category, {}).get(plugin_classpath)

--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -154,7 +154,7 @@ def _init_populate_result_db(evals, taxonomy=None, report_plugin_cache=None):
         groups = []
         if taxonomy is not None:
             # get the probe tags
-            meta, _ = _resolve_plugin_info(
+            meta = _resolve_plugin_info(
                 f"probes.{pm}.{pc}",
                 report_plugin_cache,
                 required_fields=("tags",),

--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -340,7 +340,7 @@ def _get_probe_detector_details(
     calibration_used = False
     detector = re.sub(r"[^0-9A-Za-z_.]", "", detector)
     detector_module, detector_class = detector.split(".")
-    detector_cache_entry, _ = _resolve_plugin_info(
+    detector_cache_entry = _resolve_plugin_info(
         f"detectors.{detector_module}.{detector_class}",
         report_plugin_cache,
         required_fields=("description",),

--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -75,6 +75,10 @@ def _parse_report(reportfile: IO):
             for category, entries in record.get("plugin_cache", {}).items():
                 plugin_cache.setdefault(category, {}).update(entries)
 
+    if len(plugin_cache) <= 0:
+        from copy import deepcopy
+        plugin_cache = deepcopy(garak._plugins.PluginCache.instance())
+        plugin_cache["version"] = garak.__version__
     return init, setup, payloads, evals, plugin_cache
 
 

--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -63,6 +63,7 @@ def _emit_plugin_cache_entry(*plugin_instances) -> None:
     if not snapshot:
         return
 
+    snapshot["version"] = garak.__version__
     _config.transient.reportfile.write(
         json.dumps(
             {

--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -47,6 +47,36 @@ def _initialize_runtime_services():
             raise e
 
 
+def _emit_plugin_cache_entry(*plugin_instances) -> None:
+    snapshot = {}
+    for plugin_instance in plugin_instances:
+        if plugin_instance is None:
+            continue
+        classpath = (
+            f"{plugin_instance.__class__.__module__}."
+            f"{plugin_instance.__class__.__name__}"
+        ).replace("garak.", "")
+        category = classpath.split(".")[0]
+        meta = _plugins.PluginCache.plugin_info(classpath)
+        snapshot.setdefault(category, {})[classpath] = meta
+
+    if not snapshot:
+        return
+
+    _config.transient.reportfile.write(
+        json.dumps(
+            {
+                "entry_type": "plugin_cache",
+                "run": _config.transient.run_id,
+                "plugin_cache": snapshot,
+            },
+            cls=_plugins.PluginEncoder,
+            ensure_ascii=False,
+        )
+        + "\n"
+    )
+
+
 class Harness(Configurable):
     """Class to manage the whole process of probing, detecting and evaluating"""
 
@@ -130,6 +160,13 @@ class Harness(Configurable):
             raise ValueError(msg)
 
         self._start_run_hook()
+        _emit_plugin_cache_entry(
+            self,
+            model,
+            *probes,
+            *detectors,
+            *_config.buffmanager.buffs,
+        )
 
         for probe in probes:
             logging.debug("harness: probe start for %s", probe.probename)

--- a/tests/analyze/test_aggregate.py
+++ b/tests/analyze/test_aggregate.py
@@ -82,6 +82,7 @@ def test_aggregate_executes() -> None:
                 "reportfile",
                 "report_digest_time",
                 "calibration",
+                "plugin_cache_source",
             ]:
                 ref_rec["meta"].pop(key, None)
                 agg_rec["meta"].pop(key, None)

--- a/tests/analyze/test_report_digest_plugin_cache.py
+++ b/tests/analyze/test_report_digest_plugin_cache.py
@@ -11,8 +11,9 @@ import garak._plugins
 import garak.analyze.report_digest as report_digest
 
 
-def _complete_plugin_cache():
+def _complete_plugin_cache(version="test-cache-version"):
     return {
+        "version": version,
         "probes": {
             "probes.test.Blank": {
                 "description": "Frozen probe description",
@@ -119,39 +120,58 @@ def test_resolve_plugin_info_prefers_header(mocker):
         side_effect=AssertionError("live cache should not be used"),
     )
 
-    meta, source = report_digest._resolve_plugin_info(
+    meta = report_digest._resolve_plugin_info(
         "probes.test.Blank",
         _complete_plugin_cache(),
         required_fields=("description", "tags", "tier"),
     )
 
-    assert source == "header"
     assert meta["description"] == "Frozen probe description"
     live_cache.assert_not_called()
 
 
-def test_resolve_plugin_info_uses_live_cache_for_legacy_reports(mocker):
-    live_cache = mocker.patch.object(
+def test_parse_report_uses_live_cache_for_legacy_reports(mocker):
+    live_cache = {
+        "probes": {
+            "probes.test.Blank": {
+                "description": "Live description",
+                "tags": [],
+                "tier": 1,
+            }
+        }
+    }
+    cache_instance = mocker.patch.object(
         garak._plugins.PluginCache,
-        "plugin_info",
-        return_value={"description": "Live description", "tags": [], "tier": 1},
+        "instance",
+        return_value=live_cache,
+    )
+    report = io.StringIO(
+        json.dumps(
+            {
+                "entry_type": "init",
+                "garak_version": "test",
+                "start_time": "2026-01-01T00:00:00",
+                "run": "test-run",
+            }
+        )
     )
 
-    meta, source = report_digest._resolve_plugin_info(
-        "probes.test.Blank",
-        None,
-        required_fields=("description", "tags", "tier"),
-    )
+    *_, plugin_cache = report_digest._parse_report(report)
 
-    assert source == "live_cache"
-    assert meta["description"] == "Live description"
-    live_cache.assert_called_once_with("probes.test.Blank")
+    assert plugin_cache["version"] == garak.__version__
+    assert (
+        plugin_cache["probes"]["probes.test.Blank"]["description"]
+        == "Live description"
+    )
+    assert "version" not in live_cache
+    cache_instance.assert_called_once()
 
 
 def test_build_digest_rejects_missing_plugin_cache_entry(tmp_path):
     report_path = _write_report(
         tmp_path,
         plugin_cache={
+            "version": "test-cache-version",
             "probes": {
                 "probes.test.Blank": {
                     "description": "Frozen probe description",
@@ -170,6 +190,7 @@ def test_build_digest_rejects_missing_required_plugin_cache_field(tmp_path):
     report_path = _write_report(
         tmp_path,
         plugin_cache={
+            "version": "test-cache-version",
             "probes": {
                 "probes.test.Blank": {
                     "description": "Frozen probe description",
@@ -193,7 +214,7 @@ def test_build_digest_records_header_plugin_cache_source(tmp_path):
 
     digest = report_digest.build_digest(str(report_path))
 
-    assert digest["meta"]["plugin_cache_source"] == "header"
+    assert digest["meta"]["plugin_cache_source"] == "test-cache-version"
 
 
 def test_build_digest_records_live_cache_source_for_legacy_report(tmp_path):
@@ -201,4 +222,4 @@ def test_build_digest_records_live_cache_source_for_legacy_report(tmp_path):
 
     digest = report_digest.build_digest(str(report_path))
 
-    assert digest["meta"]["plugin_cache_source"] == "live_cache"
+    assert digest["meta"]["plugin_cache_source"] == garak.__version__

--- a/tests/analyze/test_report_digest_plugin_cache.py
+++ b/tests/analyze/test_report_digest_plugin_cache.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import io
+import json
+
+import pytest
+
+from garak import _config
+import garak._plugins
+import garak.analyze.report_digest as report_digest
+
+
+def _complete_plugin_cache():
+    return {
+        "probes": {
+            "probes.test.Blank": {
+                "description": "Frozen probe description",
+                "tags": [],
+                "tier": 1,
+            }
+        },
+        "detectors": {
+            "detectors.always.Pass": {
+                "description": "Frozen detector description",
+            }
+        },
+    }
+
+
+def _write_report(
+    tmp_path,
+    plugin_cache=None,
+    eval_probe="test.Blank",
+    eval_detector="always.Pass",
+):
+    _config.load_base_config()
+    report_path = tmp_path / "plugin_cache.report.jsonl"
+    records = [
+        {
+            "entry_type": "start_run setup",
+            "plugins.probe_spec": eval_probe,
+            "plugins.target_type": "test",
+            "plugins.target_name": "Blank",
+        },
+        {
+            "entry_type": "init",
+            "garak_version": "test",
+            "start_time": "2026-01-01T00:00:00",
+            "run": "test-run",
+        },
+    ]
+    if plugin_cache is not None:
+        records.append(
+            {
+                "entry_type": "plugin_cache",
+                "run": "test-run",
+                "plugin_cache": plugin_cache,
+            }
+        )
+    records.append(
+        {
+            "entry_type": "eval",
+            "probe": eval_probe,
+            "detector": eval_detector,
+            "passed": 1,
+            "total_evaluated": 1,
+            "fails": 0,
+            "nones": 0,
+            "total_processed": 1,
+        }
+    )
+
+    with report_path.open("w", encoding="utf-8") as reportfile:
+        for record in records:
+            reportfile.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    return report_path
+
+
+def test_parse_report_captures_plugin_cache_entries_and_merges():
+    report = io.StringIO(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "entry_type": "plugin_cache",
+                        "plugin_cache": {
+                            "probes": {"probes.test.Blank": {"tags": []}}
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "entry_type": "plugin_cache",
+                        "plugin_cache": {
+                            "probes": {
+                                "probes.test.Test": {"tags": ["avid:test"]}
+                            }
+                        },
+                    }
+                ),
+            ]
+        )
+    )
+
+    *_, plugin_cache = report_digest._parse_report(report)
+
+    assert set(plugin_cache["probes"]) == {
+        "probes.test.Blank",
+        "probes.test.Test",
+    }
+
+
+def test_resolve_plugin_info_prefers_header(mocker):
+    live_cache = mocker.patch.object(
+        garak._plugins.PluginCache,
+        "plugin_info",
+        side_effect=AssertionError("live cache should not be used"),
+    )
+
+    meta, source = report_digest._resolve_plugin_info(
+        "probes.test.Blank",
+        _complete_plugin_cache(),
+        required_fields=("description", "tags", "tier"),
+    )
+
+    assert source == "header"
+    assert meta["description"] == "Frozen probe description"
+    live_cache.assert_not_called()
+
+
+def test_resolve_plugin_info_uses_live_cache_for_legacy_reports(mocker):
+    live_cache = mocker.patch.object(
+        garak._plugins.PluginCache,
+        "plugin_info",
+        return_value={"description": "Live description", "tags": [], "tier": 1},
+    )
+
+    meta, source = report_digest._resolve_plugin_info(
+        "probes.test.Blank",
+        None,
+        required_fields=("description", "tags", "tier"),
+    )
+
+    assert source == "live_cache"
+    assert meta["description"] == "Live description"
+    live_cache.assert_called_once_with("probes.test.Blank")
+
+
+def test_build_digest_rejects_missing_plugin_cache_entry(tmp_path):
+    report_path = _write_report(
+        tmp_path,
+        plugin_cache={
+            "probes": {
+                "probes.test.Blank": {
+                    "description": "Frozen probe description",
+                    "tags": [],
+                    "tier": 1,
+                }
+            }
+        },
+    )
+
+    with pytest.raises(ValueError, match="plugin_cache missing metadata"):
+        report_digest.build_digest(str(report_path))
+
+
+def test_build_digest_rejects_missing_required_plugin_cache_field(tmp_path):
+    report_path = _write_report(
+        tmp_path,
+        plugin_cache={
+            "probes": {
+                "probes.test.Blank": {
+                    "description": "Frozen probe description",
+                    "tags": [],
+                }
+            },
+            "detectors": {
+                "detectors.always.Pass": {
+                    "description": "Frozen detector description",
+                }
+            },
+        },
+    )
+
+    with pytest.raises(ValueError, match="missing fields"):
+        report_digest.build_digest(str(report_path))
+
+
+def test_build_digest_records_header_plugin_cache_source(tmp_path):
+    report_path = _write_report(tmp_path, plugin_cache=_complete_plugin_cache())
+
+    digest = report_digest.build_digest(str(report_path))
+
+    assert digest["meta"]["plugin_cache_source"] == "header"
+
+
+def test_build_digest_records_live_cache_source_for_legacy_report(tmp_path):
+    report_path = _write_report(tmp_path)
+
+    digest = report_digest.build_digest(str(report_path))
+
+    assert digest["meta"]["plugin_cache_source"] == "live_cache"

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -570,22 +570,24 @@ PREFIX = "_garak_test_attempt_sticky_params"
 def test_attempt_sticky_params(capsys):
 
     cli.main(
-        f"-m test.Blank -g 1 -p atkgen,dan.Dan_6_0 --report_prefix {PREFIX}".split()
+        f"-m test.Blank -g 1 -p lmrc.QuackMedicine,test.Blank -d always.Pass --report_prefix {PREFIX}".split()
     )
     report_path = _config.transient.data_dir / _config.reporting.report_dir
-    reportlines = (
-        open(report_path / f"{PREFIX}.report.jsonl", "r", encoding="utf-8")
-        .read()
-        .split("\n")
+    with open(report_path / f"{PREFIX}.report.jsonl", "r", encoding="utf-8") as report:
+        records = [json.loads(line) for line in report.read().splitlines()]
+    completed_attempts = [
+        record
+        for record in records
+        if record.get("entry_type") == "attempt"
+        and record.get("status") == garak.attempt.ATTEMPT_COMPLETE
+    ]
+    complete_with_notes = next(record for record in completed_attempts if record["notes"])
+    complete_without_notes = next(
+        record for record in completed_attempts if not record["notes"]
     )
-    # Note: the line numbers below are based on respecting the `-g 1` options passed
-    complete_atkgen = json.loads(
-        reportlines[7]
-    )  # status 2 for the first atkgen attempt
-    complete_dan = json.loads(reportlines[14])  # status 2 for the one dan attempt
-    assert complete_atkgen["notes"] != {}
-    assert complete_dan["notes"] == {}
-    assert complete_atkgen["notes"] != complete_dan["notes"]
+    assert complete_with_notes["notes"] != {}
+    assert complete_without_notes["notes"] == {}
+    assert complete_with_notes["notes"] != complete_without_notes["notes"]
 
 
 def test_prompt_for():

--- a/tests/test_internal_structures.py
+++ b/tests/test_internal_structures.py
@@ -12,8 +12,11 @@ from pathlib import Path
 
 import garak._config
 import garak._plugins
+import garak.analyze.report_digest
 import garak.attempt
+import garak.buffs.base
 import garak.evaluators.base
+import garak.harnesses.base
 
 from garak.detectors.mitigation import MitigationBypass
 
@@ -108,3 +111,85 @@ def test_evaluator_detector_naming(mitigation_outputs: Tuple[List[str], List[str
         detector = report.get("detector", None)
         if detector:
             assert not detector.startswith("detector")
+
+
+def _read_report_records(entry_type=None):
+    report_filename_path = Path(garak._config.transient.report_filename)
+    assert report_filename_path.exists()
+    records = [
+        json.loads(line) for line in report_filename_path.read_text().splitlines()
+    ]
+    if entry_type is None:
+        return records
+    return [record for record in records if record["entry_type"] == entry_type]
+
+
+def _merge_plugin_cache_records(records):
+    plugin_cache = {}
+    for record in records:
+        for category, entries in record["plugin_cache"].items():
+            plugin_cache.setdefault(category, {}).update(entries)
+    return plugin_cache
+
+
+def test_harness_emits_plugin_cache_entries_for_loaded_plugins(mocker, monkeypatch):
+    mocker.patch("garak.harnesses.base._initialize_runtime_services")
+    harness = garak.harnesses.base.Harness()
+    model = garak._plugins.load_plugin("generators.test.Blank")
+    probe = garak._plugins.load_plugin("probes.test.Blank")
+    detector = garak._plugins.load_plugin("detectors.always.Pass")
+    monkeypatch.setattr(
+        garak._config.buffmanager,
+        "buffs",
+        [garak.buffs.base.Buff()],
+    )
+
+    harness.run(model, [probe], [detector], mocker.Mock())
+
+    merged = _merge_plugin_cache_records(_read_report_records("plugin_cache"))
+    assert "harnesses.base.Harness" in merged["harnesses"]
+    assert "generators.test.Blank" in merged["generators"]
+    assert "probes.test.Blank" in merged["probes"]
+    assert "detectors.always.Pass" in merged["detectors"]
+    assert "buffs.base.Buff" in merged["buffs"]
+    assert "probes.test.Test" not in merged.get("probes", {})
+
+
+def test_digest_uses_harness_emitted_plugin_cache(mocker, tmp_path):
+    mocker.patch("garak.harnesses.base._initialize_runtime_services")
+    harness = garak.harnesses.base.Harness()
+    model = garak._plugins.load_plugin("generators.test.Blank")
+    probe = garak._plugins.load_plugin("probes.test.Blank")
+    detector = garak._plugins.load_plugin("detectors.always.Pass")
+    evaluator = garak.evaluators.base.Evaluator()
+
+    harness.run(model, [probe], [detector], evaluator)
+    garak._config.transient.reportfile.flush()
+    report_path = tmp_path / "harness.report.jsonl"
+    records = [
+        {
+            "entry_type": "start_run setup",
+            "plugins.probe_spec": "test.Blank",
+            "plugins.target_type": "test",
+            "plugins.target_name": "Blank",
+        },
+        {
+            "entry_type": "init",
+            "garak_version": garak._config.version,
+            "start_time": "2026-01-01T00:00:00",
+            "run": "test-run",
+        },
+        *_read_report_records(),
+    ]
+    with report_path.open("w", encoding="utf-8") as reportfile:
+        for record in records:
+            reportfile.write(json.dumps(record, ensure_ascii=False) + "\n")
+    mocker.patch.object(
+        garak._plugins.PluginCache,
+        "plugin_info",
+        side_effect=AssertionError("live cache should not be used"),
+    )
+
+    digest = garak.analyze.report_digest.build_digest(str(report_path))
+
+    assert digest["meta"]["plugin_cache_source"] == "header"

--- a/tests/test_internal_structures.py
+++ b/tests/test_internal_structures.py
@@ -128,6 +128,9 @@ def _merge_plugin_cache_records(records):
     plugin_cache = {}
     for record in records:
         for category, entries in record["plugin_cache"].items():
+            if category == "version":
+                plugin_cache["version"] = entries
+                continue
             plugin_cache.setdefault(category, {}).update(entries)
     return plugin_cache
 
@@ -147,6 +150,7 @@ def test_harness_emits_plugin_cache_entries_for_loaded_plugins(mocker, monkeypat
     harness.run(model, [probe], [detector], mocker.Mock())
 
     merged = _merge_plugin_cache_records(_read_report_records("plugin_cache"))
+    assert merged["version"] == garak.__version__
     assert "harnesses.base.Harness" in merged["harnesses"]
     assert "generators.test.Blank" in merged["generators"]
     assert "probes.test.Blank" in merged["probes"]
@@ -192,4 +196,4 @@ def test_digest_uses_harness_emitted_plugin_cache(mocker, tmp_path):
 
     digest = garak.analyze.report_digest.build_digest(str(report_path))
 
-    assert digest["meta"]["plugin_cache_source"] == "header"
+    assert digest["meta"]["plugin_cache_source"] == garak.__version__


### PR DESCRIPTION
Adds a `plugin_cache` JSONL record during `Harness.run` so each report carries the resolved metadata for the harness, generator, probes, detectors, and buffs used in that run.

`report_digest` now reads plugin metadata from the report header first, making digest rebuilds self-contained and independent of the local live `PluginCache`. Legacy reports without a `plugin_cache` record still fall back to the live cache, and the digest records the source in `meta.plugin_cache_source`.

This slice intentionally leaves follow-up work for aggregation merge/validation, CI rebuild preservation, AVID `probe_tags`, and IntentProbe detector parity.

Closes #1720 