### PR TITLE
improve compatibility with older reports

### DIFF
--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -88,6 +88,12 @@ def _parse_report(reportfile: IO):
 
 
 def _report_header_content(report_path, init, setup, payloads, config=_config) -> dict:
+    target_type = setup.get(
+        "plugins.target_type", setup.get("plugins.model_type", None)
+    )
+    target_name = setup.get(
+        "plugins.target_name", setup.get("plugins.model_name", None)
+    )
     header_content = {
         "reportfile": report_path.split(os.sep)[-1],
         "garak_version": init["garak_version"],
@@ -95,8 +101,8 @@ def _report_header_content(report_path, init, setup, payloads, config=_config) -
         "run_uuid": init["run_uuid"],
         "setup": setup,
         "probespec": setup["plugins.probe_spec"],
-        "target_type": setup["plugins.target_type"],
-        "target_name": setup["plugins.target_name"],
+        "target_type": target_type,
+        "target_name": target_name,
         "payloads": payloads,
         "group_aggregation_function": config.reporting.group_aggregation_function,
         "report_digest_time": datetime.datetime.now().isoformat(),
@@ -152,7 +158,7 @@ def _init_populate_result_db(evals, taxonomy=None, report_plugin_cache=None):
         pm, pc = eval["probe"].split(".")
         detector = eval["detector"].replace("detector.", "")
         passes = eval["passed"]
-        instances = eval["total_evaluated"]
+        instances = eval.get("total_evaluated", eval.get("total", None))
         score = passes / instances if instances else 0
 
         # Extract CI fields if present


### PR DESCRIPTION
Changes to some configuration and eval attributes have limited report generation, being more compatible is reasonable.

Example errors now accounted for:
Introduced by https://github.com/NVIDIA/garak/pull/1383 and released in v0.13.1
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/jemartin/Projects/nvidia/garak-main/garak/analyze/report_digest.py", line 689, in <module>
    digest = build_digest(report_path)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jemartin/Projects/nvidia/garak-main/garak/analyze/report_digest.py", line 506, in build_digest
    header_content = _report_header_content(
                     ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jemartin/Projects/nvidia/garak-main/garak/analyze/report_digest.py", line 98, in _report_header_content
    "target_type": setup["plugins.target_type"],
                   ~~~~~^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'plugins.target_type'
```

Introduced by https://github.com/NVIDIA/garak/pull/1547 and released in v0.14.0
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/jemartin/Projects/nvidia/garak-main/garak/analyze/report_digest.py", line 689, in <module>
    digest = build_digest(report_path)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jemartin/Projects/nvidia/garak-main/garak/analyze/report_digest.py", line 511, in build_digest
    conn, cursor = _init_populate_result_db(evals, taxonomy, report_plugin_cache)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jemartin/Projects/nvidia/garak-main/garak/analyze/report_digest.py", line 155, in _init_populate_result_db
    instances = eval["total_evaluated"]
                ~~~~^^^^^^^^^^^^^^^^^^^
KeyError: 'total_evaluated'
```

## Verification

List the steps needed to make sure this thing works

- [ ] execute report_digest reprocessing on test reports from `v0.13.0` and `v0.13.3`