### PR TITLE
Fix ggml generator call output handling

### DIFF
--- a/garak/generators/ggml.py
+++ b/garak/generators/ggml.py
@@ -122,9 +122,10 @@ class GgmlGenerator(Generator):
         # test all params for None type
         command.extend(self._command_args_list())
         command = [str(param) for param in command]
-        if _config.system.verbose > 1:
+        if getattr(_config.system, "verbose", 0) > 1:
             print("GGML invoked with", command)
         try:
+            prompt_text = prompt.last_message().text
             result = subprocess.run(
                 command,
                 stdout=subprocess.PIPE,
@@ -132,7 +133,7 @@ class GgmlGenerator(Generator):
                 check=self.exception_on_failure,
             )
             output = result.stdout.decode("utf-8")
-            output = re.sub("^" + re.escape(prompt.lstrip()), "", output.lstrip())
+            output = re.sub("^" + re.escape(prompt_text.lstrip()), "", output.lstrip())
             self.first_call = False
             return [Message(output)]
         except subprocess.CalledProcessError as err:

--- a/tests/generators/test_ggml.py
+++ b/tests/generators/test_ggml.py
@@ -81,39 +81,26 @@ def test_command_args_list():
         assert type(g) is garak.generators.ggml.GgmlGenerator
 
 
-def test_call_model_removes_echoed_prompt(tmp_path, monkeypatch):
-    model_path = tmp_path / "test_model.gguf"
-    model_path.write_bytes(garak.generators.ggml.GGUF_MAGIC)
+def test_call_model_removes_echoed_prompt(mocker):
+    with tempfile.NamedTemporaryFile(
+        mode="wb", suffix="_test_model.gguf", delete=False
+    ) as file:
+        file.write(garak.generators.ggml.GGUF_MAGIC)
+        file.close()
 
-    fake_llama = tmp_path / "llama-cli"
-    fake_llama.write_text("", encoding="utf-8")
-    monkeypatch.setenv(garak.generators.ggml.ENV_VAR, str(fake_llama))
+        import subprocess
+        from unittest.mock import MagicMock
 
-    generator = garak.generators.ggml.GgmlGenerator(str(model_path))
-    prompt = Conversation([Turn("user", Message("prompt:"))])
-    captured = {}
+        prompt = Conversation([Turn("user", Message("prompt:"))])
 
-    def fake_run(command, stdout, stderr, check):
-        captured["command"] = command
-        assert stdout == garak.generators.ggml.subprocess.PIPE
-        assert stderr == garak.generators.ggml.subprocess.PIPE
-        assert check == generator.exception_on_failure
-        prompt_arg = command[command.index("-p") + 1]
-        return garak.generators.ggml.subprocess.CompletedProcess(
-            args=command,
-            returncode=0,
-            stdout=f"{prompt_arg}response\n".encode("utf-8"),
-            stderr=b"",
-        )
+        mock_response = MagicMock()
+        test_response = "response"
+        mock_response.stdout = f"{prompt.last_message().text}{test_response}".encode()
+        mocker.patch.object(subprocess, "run", return_value=mock_response)
 
-    monkeypatch.setattr(garak.generators.ggml.subprocess, "run", fake_run)
+        generator = garak.generators.ggml.GgmlGenerator(file.name)
+        result = generator._call_model(prompt)
 
-    result = generator._call_model(prompt)
-
-    command = captured["command"]
-    assert command[0] == str(fake_llama)
-    assert command[command.index("-p") + 1] == "prompt:"
-    assert command[command.index("-m") + 1] == str(model_path)
-    assert len(result) == 1
-    assert isinstance(result[0], Message)
-    assert result[0].text == "response\n"
+        assert len(result) == 1
+        assert isinstance(result[0], Message)
+        assert result[0].text == test_response

--- a/tests/generators/test_ggml.py
+++ b/tests/generators/test_ggml.py
@@ -2,6 +2,7 @@ import os
 import pytest
 import tempfile
 import garak.generators.ggml
+from garak.attempt import Conversation, Message, Turn
 
 STORED_ENV = os.getenv(garak.generators.ggml.ENV_VAR)
 MODEL_NAME = None
@@ -78,3 +79,41 @@ def test_command_args_list():
 
         os.remove(file.name)
         assert type(g) is garak.generators.ggml.GgmlGenerator
+
+
+def test_call_model_removes_echoed_prompt(tmp_path, monkeypatch):
+    model_path = tmp_path / "test_model.gguf"
+    model_path.write_bytes(garak.generators.ggml.GGUF_MAGIC)
+
+    fake_llama = tmp_path / "llama-cli"
+    fake_llama.write_text("", encoding="utf-8")
+    monkeypatch.setenv(garak.generators.ggml.ENV_VAR, str(fake_llama))
+
+    generator = garak.generators.ggml.GgmlGenerator(str(model_path))
+    prompt = Conversation([Turn("user", Message("prompt:"))])
+    captured = {}
+
+    def fake_run(command, stdout, stderr, check):
+        captured["command"] = command
+        assert stdout == garak.generators.ggml.subprocess.PIPE
+        assert stderr == garak.generators.ggml.subprocess.PIPE
+        assert check == generator.exception_on_failure
+        prompt_arg = command[command.index("-p") + 1]
+        return garak.generators.ggml.subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout=f"{prompt_arg}response\n".encode("utf-8"),
+            stderr=b"",
+        )
+
+    monkeypatch.setattr(garak.generators.ggml.subprocess, "run", fake_run)
+
+    result = generator._call_model(prompt)
+
+    command = captured["command"]
+    assert command[0] == str(fake_llama)
+    assert command[command.index("-p") + 1] == "prompt:"
+    assert command[command.index("-m") + 1] == str(model_path)
+    assert len(result) == 1
+    assert isinstance(result[0], Message)
+    assert result[0].text == "response\n"


### PR DESCRIPTION
## Summary

`GgmlGenerator._call_model()` crashed before invoking `llama-cli` when `_config.system.verbose` was absent, the failure reported in #1366. After that guard, the successful-call path also tried to call `lstrip()` on the `Conversation` object while removing echoed prompt text, so a successful subprocess response could become `[None]`.

This PR reads `verbose` with a default of `0`, stores the prompt text before the subprocess call, and strips the echoed prompt from that string.

## Reproducer

I added `test_call_model_removes_echoed_prompt`, which uses a temporary GGUF header file and a fake `llama-cli` executable. On upstream `main` at `81a82ab1e043baefc6fde029a214e8af66485f34`, this command fails with `AttributeError: 'GarakSubConfig' object has no attribute 'verbose'`:

```bash
uv run --python 3.12 --extra tests python -m pytest tests/generators/test_ggml.py -q
```

## Verification

```bash
uv run --python 3.12 --extra tests python -m pytest tests/generators/test_ggml.py -q
uv run --python 3.12 --extra tests python -m pytest tests/generators/test_ggml.py tests/generators/test_generators_base.py tests/generators/test_openai_compatible.py -q
uv run --python 3.12 --extra tests python -m pytest tests/generators/test_nim.py -q
uv run --python 3.12 --extra lint black --check garak/generators/ggml.py tests/generators/test_ggml.py
git diff --check
```

Fixes #1366.