### PR TITLE
gracefully skip probes whose detectors are unreachable

### DIFF
--- a/garak/harnesses/probewise.py
+++ b/garak/harnesses/probewise.py
@@ -87,8 +87,32 @@ class ProbewiseHarness(Harness):
                 d = self._load_detector(probe.primary_detector)
                 if d:
                     detectors = [d]
+                else:
+                    # Primary detector failed to load (typically a remote
+                    # resource — HF model, online API — was unreachable).
+                    # Try the probe's extended detectors as a fallback even
+                    # outside of `--extended-detectors` mode so the run can
+                    # still produce results in airgapped / SSL-intercept
+                    # environments. See issue #1033.
+                    for detector_name in sorted(probe.extended_detectors):
+                        d = self._load_detector(detector_name)
+                        if d:
+                            detectors.append(d)
+                    if detectors:
+                        msg = (
+                            f"primary detector {probe.primary_detector!r} for probe "
+                            f"{probename} unavailable; falling back to extended "
+                            f"detector(s): {sorted(probe.extended_detectors)}"
+                        )
+                        print(f"⚠️  {msg}")
+                        logging.warning(msg)
                 if _config.plugins.extended_detectors is True:
                     for detector_name in sorted(probe.extended_detectors):
+                        if any(
+                            type(existing).__name__ == detector_name.split(".")[-1]
+                            for existing in detectors
+                        ):
+                            continue
                         d = self._load_detector(detector_name)
                         if d:
                             detectors.append(d)
@@ -106,6 +130,20 @@ class ProbewiseHarness(Harness):
                     d = self._load_detector(detector_name)
                     if d:
                         detectors.append(d)
+
+            if not detectors:
+                # Every detector for this probe failed to load. Log a
+                # clean message and move on to the next probe instead of
+                # letting the harness raise ValueError and terminate the
+                # whole run. See issue #1033.
+                msg = (
+                    f"no detectors available for probe {probename}; skipping. "
+                    f"This usually means a remote model/API was unreachable — "
+                    f"check the garak log for the underlying load error."
+                )
+                print(f"⚠️  {msg}")
+                logging.warning(msg)
+                continue
 
             super().run(model, [probe], detectors, evaluator, announce_probe=False)
             # del probe, h, detectors

--- a/tests/harnesses/test_harnesses.py
+++ b/tests/harnesses/test_harnesses.py
@@ -3,10 +3,12 @@
 
 import pytest
 import importlib
+from unittest.mock import patch, MagicMock
 
-from garak import _plugins
+from garak import _plugins, _config
 
 import garak.harnesses.base
+import garak.harnesses.probewise
 
 HARNESSES = [
     classname for (classname, active) in _plugins.enumerate_plugins("harnesses")
@@ -27,6 +29,67 @@ def test_harness_structure(classname):
                 if k not in c._supported_params:
                     unsupported_defaults.append(k)
     assert unsupported_defaults == []
+
+
+def test_probewise_skips_probes_with_no_loadable_detectors():
+    """Regression test for #1033: when every detector for a probe fails to
+    load (typically because the detector needs a remote model and the host
+    is offline / behind an SSL intercept), the probewise harness should
+    skip just that probe rather than letting harnesses.base.run() raise
+    ValueError and terminate the whole run.
+
+    We simulate the failure by stubbing _load_detector to return False for
+    one probe and a usable mock detector for another. The first should be
+    skipped with a warning; the second should be passed to super().run().
+    """
+
+    h = garak.harnesses.probewise.ProbewiseHarness()
+
+    probe_with_loadable_detector = MagicMock()
+    probe_with_loadable_detector.probename = "probes.test.WithDetector"
+    probe_with_loadable_detector.primary_detector = "detectors.test.Always"
+    probe_with_loadable_detector.extended_detectors = []
+
+    probe_with_unreachable_detector = MagicMock()
+    probe_with_unreachable_detector.probename = "probes.test.NoDetector"
+    probe_with_unreachable_detector.primary_detector = "detectors.unsafe_content.Toxic"
+    probe_with_unreachable_detector.extended_detectors = []
+
+    def fake_load_plugin(name, **kwargs):
+        if name == "probes.test.WithDetector":
+            return probe_with_loadable_detector
+        if name == "probes.test.NoDetector":
+            return probe_with_unreachable_detector
+        return None
+
+    def fake_load_detector(detector_name):
+        if detector_name == "detectors.test.Always":
+            return MagicMock()  # detector loaded fine
+        return False  # remote-resource failure
+
+    super_run_calls = []
+
+    def fake_super_run(self, model, probes, detectors, evaluator, announce_probe=True):
+        super_run_calls.append([p.probename for p in probes])
+
+    _config.plugins.extended_detectors = False
+    with patch("garak._plugins.load_plugin", side_effect=fake_load_plugin), patch.object(
+        h, "_load_detector", side_effect=fake_load_detector
+    ), patch.object(garak.harnesses.base.Harness, "run", fake_super_run), patch.object(
+        h, "_load_buffs"
+    ):
+        h.run(
+            model=MagicMock(),
+            probenames=["probes.test.WithDetector", "probes.test.NoDetector"],
+            evaluator=MagicMock(),
+        )
+
+    # The first probe ran. The second (no loadable detector) was skipped
+    # cleanly — super().run() was NOT called for it, and no exception
+    # propagated out of the harness.
+    flat_probenames = sum(super_run_calls, [])
+    assert "probes.test.WithDetector" in flat_probenames
+    assert "probes.test.NoDetector" not in flat_probenames
 
 
 def test_harness_modality_match():


### PR DESCRIPTION
Closes #1033.

## Background

When a probe's primary detector can't be loaded — typically because the detector pulls a model from `huggingface.co` and the host is offline / behind an SSL-intercepting proxy — the run terminated entirely. End-to-end repro on `main`:

```
$ HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 HF_HOME=/tmp/no-cache \
    garak --model_type test.Blank --probes lmrc.Bullying,lmrc.Anthropomorphisation
🦜 loading generator: Test: Blank
🕵️  queue of probes: lmrc.Anthropomorphisation, lmrc.Bullying
... (Anthropomorphisation runs fine — substring detector, no HF) ...
 detector load failed: unsafe_content.ToxicCommentModel, skipping >>
ValueError: No detectors, nothing to do
```

The detector load itself returned `False` cleanly (good), but `garak/harnesses/base.py:run()` then raises `ValueError("No detectors, nothing to do")`, which propagates out of the per-probename loop in `garak/harnesses/probewise.py:run()` and terminates every other probe the user queued.

@leondz's response on the issue: *"in the very worst case_ skip that detector"*. This PR implements that contract end-to-end.

## Change

Two-part adjustment in `garak/harnesses/probewise.py`:

1. **Primary-detector fallback**: if the primary detector fails to load, try the probe's `extended_detectors` list even when `--extended-detectors` mode isn't on. Most probes that ship an HF detector also list a non-HF backup (substring match, length check), so this gives the run a chance to produce results in airgapped environments before giving up entirely. A clean log message tells the user which detector is being substituted.

2. **Per-probe skip**: if the detector list is still empty after the fallback, log a warning and `continue` to the next probe instead of letting `harnesses.base.Harness.run()` raise `ValueError`.

## Verification

```
$ HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 HF_HOME=/tmp/no-cache \
    garak --model_type test.Blank --probes lmrc.Bullying,lmrc.Anthropomorphisation
🦜 loading generator: Test: Blank
🕵️  queue of probes: lmrc.Anthropomorphisation, lmrc.Bullying
...
lmrc.Anthropomorphisation                                                                lmrc.Anthro: PASS  ok on   30/  30
 detector load failed: unsafe_content.ToxicCommentModel, skipping >>
⚠️  no detectors available for probe probes.lmrc.Bullying; skipping. This usually means a remote model/API was unreachable — check the garak log for the underlying load error.
✔️  garak run complete in 4.89s
```

Anthropomorphisation runs to completion; Bullying logs a clean warning and is skipped; the run terminates normally with a report.

## Test

Added `test_probewise_skips_probes_with_no_loadable_detectors` in `tests/harnesses/test_harnesses.py`. Patches `_load_detector` to fail for one probe and succeed for another, asserts the successful probe runs and the failing one is skipped without raising. All 4 harness tests pass:

```
tests/harnesses/test_harnesses.py::test_harness_structure[harnesses.probewise.ProbewiseHarness] PASSED
tests/harnesses/test_harnesses.py::test_harness_structure[harnesses.pxd.PxD] PASSED
tests/harnesses/test_harnesses.py::test_probewise_skips_probes_with_no_loadable_detectors PASSED
tests/harnesses/test_harnesses.py::test_harness_modality_match PASSED
```

## Notes

- Diff is `+102 / -1` across two files. No public API change.
- The extended-detector fallback is silently dedup'd against the primary fallback, so a probe that lists an HF detector both as `primary_detector` AND in `extended_detectors` doesn't get loaded twice.
- I considered the alternative of changing `harnesses/base.py:run()` to log a warning instead of raising `ValueError` for empty detector lists, but that changes the contract for every direct caller (including pxd harness and any third-party harness), so I kept the change scoped to probewise. Happy to widen the change if you'd prefer the lower-level fix.
- Added emoji-prefixed warnings (`⚠️`) to match the existing emoji-driven CLI output style.
