### PR TITLE
fix(generators): handle None response.choices in OpenAICompatible (#1525)

### DIFF
--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -327,7 +327,12 @@ class OpenAICompatible(Generator):
             else:
                 raise e
 
-        if not hasattr(response, "choices"):
+        if not hasattr(response, "choices") or response.choices is None:
+            # Some OpenAI-compatible deployments (Azure, AWS Bedrock, ...) return
+            # a response object whose .choices attribute is present but None when
+            # they hit a downstream error or rate limit. Treat that the same as a
+            # missing attribute instead of letting the comprehension below blow up
+            # with TypeError: 'NoneType' object is not iterable. See issue #1525.
             logging.debug(
                 "Did not get a well-formed response, retrying. Expected object with .choices member, got: '%s'"
                 % repr(response)

--- a/tests/generators/test_openai.py
+++ b/tests/generators/test_openai.py
@@ -99,3 +99,53 @@ def test_reasoning_switch():
         generator = OpenAIGenerator(
             name="o1-mini"
         )  # o1 models should use ReasoningGenerator
+
+
+class _FakeResponseChoicesNone:
+    """OpenAI-compatible response stub whose .choices attribute is None.
+
+    Some hosted endpoints (Azure, AWS Bedrock, ...) hand back this shape on
+    upstream errors, which used to crash _call_model with TypeError.
+    """
+
+    choices = None
+
+
+@pytest.mark.usefixtures("set_fake_env")
+def test_call_model_handles_none_choices(monkeypatch):
+    """Regression test for issue #1525.
+
+    When the upstream response object has ``choices = None`` (rather than the
+    attribute being absent), _call_model should fall through the
+    'no .choices member' path and return [None] / raise GeneratorBackoffTrigger
+    depending on retry_json — never iterate None directly.
+    """
+    generator = OpenAIGenerator(name="gpt-3.5-turbo-instruct")
+    generator._load_unsafe = lambda: None  # don't try to actually open a client
+
+    class _FakeChatCompletions:
+        @staticmethod
+        def create(**_kwargs):
+            return _FakeResponseChoicesNone()
+
+    class _FakeClient:
+        completions = object()  # sentinel: chat path is taken because != generator
+        chat = type("_Chat", (), {"completions": _FakeChatCompletions})()
+
+    fake_client = _FakeClient()
+    monkeypatch.setattr(generator, "client", fake_client, raising=False)
+    monkeypatch.setattr(generator, "generator", _FakeChatCompletions, raising=False)
+
+    # retry_json False → should return [None] without raising.
+    monkeypatch.setattr(generator, "retry_json", False, raising=False)
+    out = generator._call_model(
+        Conversation([Turn("user", Message("hi"))]), generations_this_call=1
+    )
+    assert out == [None]
+
+    # retry_json True → should raise GeneratorBackoffTrigger to retry.
+    monkeypatch.setattr(generator, "retry_json", True, raising=False)
+    with pytest.raises(garak.exception.GeneratorBackoffTrigger):
+        generator._call_model(
+            Conversation([Turn("user", Message("hi"))]), generations_this_call=1
+        )


### PR DESCRIPTION
## Summary

Closes #1525.

Some OpenAI-compatible deployments hand back a response object whose `.choices` attribute is **present but None** when the upstream hits a downstream error or rate limit. The issue captures two real cases:

- AWS Bedrock endpoint for `ibm-granite/granite-4.0-h-micro` mid-`probes.atkgen.Tox`
- Azure endpoint mid-`injectascii85`

Both crash at `garak/generators/openai.py:296`:

```
return [Message(c.message.content) for c in response.choices]
TypeError: 'NoneType' object is not iterable
```

The existing guard

```python
if not hasattr(response, \"choices\"):
```

doesn't help — `hasattr` is true; the attribute itself is None.

## Fix

Extend the guard:

```python
if not hasattr(response, \"choices\") or response.choices is None:
```

so the malformed-response branch is taken: depending on `retry_json`, `_call_model` either raises `GeneratorBackoffTrigger` (so backoff retries the call) or returns `[None]` (so the run continues). Behavior with a well-formed response is unchanged — every existing happy path still falls through to the iteration.

## Tests

`tests/generators/test_openai.py::test_call_model_handles_none_choices` — exercises both branches against a `_FakeChatCompletions.create()` returning `_FakeResponseChoicesNone` (whose `choices = None`):

- `retry_json=False` → returns `[None]` (no exception).
- `retry_json=True` → raises `GeneratorBackoffTrigger` so backoff retries.

## Verification checklist

- [x] Commit signed off (`Signed-off-by: ChrisJr404 …`).
- [x] Single new test, additive change, no public API changes.
- [ ] `python -m pytest tests/generators/test_openai.py -k test_call_model_handles_none_choices`