### PR TITLE
fix(detectors): keep packagehallucination entries with invalid dates

### DIFF
--- a/garak/detectors/packagehallucination.py
+++ b/garak/detectors/packagehallucination.py
@@ -80,7 +80,15 @@ class PackageHallucinationDetector(Detector, ABC):
                         )
                         if first_seen <= cutoff:
                             filtered_packages.append(pkg)
-                    except ValueError as e:
+                    except (TypeError, ValueError) as e:
+                        # The dataset can contain rows whose package_first_seen field is
+                        # missing (None) or carries an upstream registry error message
+                        # ("Error: 404 Client Error: ...") instead of an ISO date. The log
+                        # text below has long claimed we keep these packages with an
+                        # unknown creation date; this branch now actually does that, so
+                        # genuine packages are not flagged as hallucinations just because
+                        # their dataset metadata is incomplete.
+                        filtered_packages.append(pkg)
                         if not invalid_pkg_date_seen_flag:
                             logging.debug(
                                 "Invalid %s package date format: %s. Keeping package %s with unknown creation date. Only logging first package"

--- a/tests/detectors/test_detectors_packagehallucination.py
+++ b/tests/detectors/test_detectors_packagehallucination.py
@@ -392,3 +392,54 @@ def test_dart_hallucinated_package():
     assert detector.detect(attempt) == [
         1.0
     ], "Expected hallucination detection for unknown package"
+
+
+def test_load_package_list_keeps_packages_with_invalid_date(monkeypatch):
+    """Regression for #1568.
+
+    When a row in the package-hallucination dataset has a non-ISO
+    `package_first_seen` value (the npm dataset returns upstream registry
+    error strings like "Error: 404 Client Error: ..." for some packages),
+    the detector previously dropped the package from the filtered set
+    even though the surrounding log message claimed the package was kept.
+    That caused real packages to be flagged as hallucinations.
+    """
+
+    detector = garak.detectors.packagehallucination.JavaScriptNpm()
+
+    fake_dataset = {
+        "text": ["alpha-pkg", "beta-pkg", "gamma-pkg"],
+        "package_first_seen": [
+            "2020-01-15T12:00:00",
+            "Error: 404 Client Error: Not Found for url: ...",
+            None,
+        ],
+        "column_names": ["text", "package_first_seen"],
+    }
+
+    class _FakeDataset(dict):
+        @property
+        def column_names(self):
+            return ["text", "package_first_seen"]
+
+        def __getitem__(self, key):
+            return fake_dataset[key]
+
+    def _fake_load_dataset(name, split=None):
+        return _FakeDataset()
+
+    import datasets
+
+    monkeypatch.setattr(datasets, "load_dataset", _fake_load_dataset)
+
+    detector.cutoff_date = None
+    detector.packages = None
+    detector._load_package_list()
+
+    assert "alpha-pkg" in detector.packages, "valid-date package should be kept"
+    assert "beta-pkg" in detector.packages, (
+        "package with non-ISO error-string date should be kept"
+    )
+    assert "gamma-pkg" in detector.packages, (
+        "package with None date should be kept"
+    )


### PR DESCRIPTION
## Summary

Relates to #1568.

The npm package-hallucination dataset contains rows whose `package_first_seen` field is missing (None) or carries an upstream registry error string in place of an ISO date — exactly what the issue body shows:

```
WARNING  Invalid package date format: Invalid isoformat string: 'Error: 404 Client E'.
         Keeping package @zalastax/nolb-_6 with unknown creation date
```

`_load_package_list()` calls `datetime.fromisoformat()` on each value in a `try/except ValueError`. The log message inside the `except` branch claims the package is being **kept** with an unknown creation date, but the package was never actually appended to `filtered_packages` — so it was silently dropped from the package set. Any model output that referenced one of those packages was then flagged as a hallucination, even though the package is real.

## Fix

Append the package to `filtered_packages` in the `except` branch, so the behavior matches the log line. Also extend the caught exceptions to include `TypeError` for the case where `package_first_seen` is `None` and the `[0:19]` slice raises before `fromisoformat`.

```diff
-                    except ValueError as e:
+                    except (TypeError, ValueError) as e:
+                        filtered_packages.append(pkg)
                         if not invalid_pkg_date_seen_flag:
                             logging.debug(
                                 "Invalid %s package date format: %s. Keeping package %s with unknown creation date. ..."
```

## Test

`test_load_package_list_keeps_packages_with_invalid_date` monkey-patches `datasets.load_dataset` with a fake dataset containing one valid ISO date, one error-string date, and one `None` date, then asserts all three packages end up in `detector.packages`. Without the fix, only the valid-date package is kept; with the fix, all three are.

```
$ pytest tests/detectors/test_detectors_packagehallucination.py::test_load_package_list_keeps_packages_with_invalid_date -v
PASSED
```

## Verification checklist

- [x] Commit signed off (`Signed-off-by: ChrisJr404 …`).
- [x] One narrow test added; no public API changes.
- [x] No change to behavior on rows with a valid ISO date.