### PR TITLE
Handle local paths in Hugging Face file probe

### DIFF
--- a/garak/probes/fileformats.py
+++ b/garak/probes/fileformats.py
@@ -11,9 +11,11 @@ The probes check in the model background for file types that may have known weak
 """
 
 import logging
+from pathlib import Path
 from typing import Iterable
 
 import huggingface_hub
+from huggingface_hub.errors import HFValidationError
 import tqdm
 
 from garak import _config
@@ -54,6 +56,26 @@ class HF_Files(garak.probes.Probe):
         self._load_config(config_root)
         super().__init__(config_root=config_root)
 
+    @staticmethod
+    def _get_local_files(model_name: str) -> list[str] | None:
+        """Return local model files when model_name points to the filesystem."""
+        model_path = Path(model_name).expanduser()
+        if not model_path.exists():
+            return None
+
+        model_path = model_path.resolve()
+        if model_path.is_file():
+            return [str(model_path)]
+
+        if model_path.is_dir():
+            return [
+                str(local_path)
+                for local_path in sorted(model_path.rglob("*"))
+                if local_path.is_file()
+            ]
+
+        return []
+
     def probe(self, generator) -> Iterable[garak.attempt.Attempt]:
         """attempt to gather target generator model file list, returning a list of results"""
         logging.debug("probe execute: %s", self)
@@ -65,18 +87,39 @@ class HF_Files(garak.probes.Probe):
             return []
         attempt = self._mint_attempt(generator.name)
 
-        repo_filenames = huggingface_hub.list_repo_files(generator.name)
-        local_filenames = []
-        for repo_filename in tqdm.tqdm(
-            repo_filenames,
-            leave=False,
-            desc=f"Gathering files in {generator.name}",
-            colour=f"#{garak.resources.theme.PROBE_RGB}",
-        ):
-            local_filename = huggingface_hub.hf_hub_download(
-                generator.name, repo_filename, force_download=False
+        local_filenames = self._get_local_files(generator.name)
+        if local_filenames is None:
+            try:
+                repo_filenames = huggingface_hub.list_repo_files(generator.name)
+            except HFValidationError:
+                logging.info(
+                    "Skipping Hugging Face file probe for non-Hub model name: %s",
+                    generator.name,
+                )
+                return []
+
+            local_filenames = []
+            for repo_filename in tqdm.tqdm(
+                repo_filenames,
+                leave=False,
+                desc=f"Gathering files in {generator.name}",
+                colour=f"#{garak.resources.theme.PROBE_RGB}",
+            ):
+                local_filename = huggingface_hub.hf_hub_download(
+                    generator.name, repo_filename, force_download=False
+                )
+                local_filenames.append(local_filename)
+
+        else:
+            logging.debug(
+                "Gathered %s files directly from local Hugging Face model path: %s",
+                len(local_filenames),
+                generator.name,
             )
-            local_filenames.append(local_filename)
+
+        if not local_filenames:
+            logging.debug("probe return: %s with no filenames", self)
+            return []
 
         attempt.notes["format"] = "local filename"
         attempt.outputs = local_filenames

--- a/tests/probes/test_probes_fileformats.py
+++ b/tests/probes/test_probes_fileformats.py
@@ -11,9 +11,61 @@ import garak.probes.fileformats
 import garak.attempt
 
 
+def _local_hf_generator(name):
+    generator_class = type(
+        "Model", (), {"__module__": "garak.generators.huggingface"}
+    )
+    generator = generator_class()
+    generator.name = str(name)
+    return generator
+
+
 def test_hf_files_load():
     p = garak.probes.fileformats.HF_Files()
     assert isinstance(p, garak.probes.base.Probe)
+
+
+def test_hf_files_local_directory(tmp_path, monkeypatch):
+    model_file = tmp_path / "config.json"
+    nested_model_file = tmp_path / "weights" / "model.safetensors"
+    nested_model_file.parent.mkdir()
+    model_file.write_text("{}", encoding="utf-8")
+    nested_model_file.write_bytes(b"test model data")
+
+    def fail_list_repo_files(*args, **kwargs):
+        raise AssertionError("local model paths should not be listed through HF Hub")
+
+    monkeypatch.setattr(
+        garak.probes.fileformats.huggingface_hub,
+        "list_repo_files",
+        fail_list_repo_files,
+    )
+
+    p = garak.probes.fileformats.HF_Files()
+    r = p.probe(_local_hf_generator(tmp_path))
+
+    assert isinstance(r, list), ".probe should return a list"
+    assert len(r) == 1, "HF_Files.probe() should return one attempt"
+    assert isinstance(
+        r[0], garak.attempt.Attempt
+    ), "HF_Files.probe() must return an Attempt"
+    assert sorted(filename.text for filename in r[0].outputs) == sorted(
+        [str(model_file.resolve()), str(nested_model_file.resolve())]
+    )
+
+
+def test_hf_files_empty_local_directory(tmp_path, monkeypatch):
+    def fail_list_repo_files(*args, **kwargs):
+        raise AssertionError("local model paths should not be listed through HF Hub")
+
+    monkeypatch.setattr(
+        garak.probes.fileformats.huggingface_hub,
+        "list_repo_files",
+        fail_list_repo_files,
+    )
+
+    p = garak.probes.fileformats.HF_Files()
+    assert p.probe(_local_hf_generator(tmp_path)) == []
 
 
 # files could be their own thing if Turns start taking named/typed entries


### PR DESCRIPTION
## Summary
- Detect when a Hugging Face generator name points to a local filesystem path and gather files from that path directly instead of calling Hugging Face Hub.
- Skip empty local directories cleanly so the fileformats probe does not create an empty `Attempt.outputs` update.
- Catch `HFValidationError` from ambiguous non-Hub names and skip the probe instead of letting the validation error escape.
- Add regression coverage proving local paths do not call `huggingface_hub.list_repo_files()`.

Fixes #1034.

## Testing
- `.venv\Scripts\python -m pytest tests/probes/test_probes_fileformats.py -k "hf_files_load or local_directory" -q` - 3 passed, 1 deselected
- `.venv\Scripts\python -m compileall garak/probes/fileformats.py tests/probes/test_probes_fileformats.py`
- `git diff --check` - no whitespace errors; local Git emitted Windows autocrlf warnings

Full `tests/probes/test_probes_fileformats.py` was not completed in this local venv because the pre-existing `test_hf_files_hf_repo` imports `garak.generators.huggingface`, which requires `torch` and this lightweight test environment does not include it.