### PR TITLE
test: add unit tests for 5 probe modules

### DIFF
--- a/tests/probes/test_probes_donotanswer.py
+++ b/tests/probes/test_probes_donotanswer.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import garak._plugins
+import garak.probes.base
+
+DONOTANSWER_PROBES = [
+    classname
+    for (classname, active) in garak._plugins.enumerate_plugins("probes")
+    if classname.startswith("probes.donotanswer")
+]
+
+
+@pytest.mark.parametrize("classname", DONOTANSWER_PROBES)
+def test_donotanswer_load(classname):
+    p = garak._plugins.load_plugin(classname)
+    assert isinstance(p, garak.probes.base.Probe)
+
+
+@pytest.mark.parametrize("classname", DONOTANSWER_PROBES)
+def test_donotanswer_prompts_not_empty(classname):
+    p = garak._plugins.load_plugin(classname)
+    assert len(p.prompts) > 0, "Probe must have more than zero prompts"

--- a/tests/probes/test_probes_grandma.py
+++ b/tests/probes/test_probes_grandma.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import garak._plugins
+import garak.probes.base
+import garak.probes.grandma
+
+GRANDMA_PROBES = (
+    "probes.grandma.Win10",
+    "probes.grandma.Win11",
+    "probes.grandma.Slurs",
+    "probes.grandma.Substances",
+)
+
+
+@pytest.mark.parametrize("classname", GRANDMA_PROBES)
+def test_grandma_load(classname):
+    p = garak._plugins.load_plugin(classname)
+    assert isinstance(p, garak.probes.base.Probe)
+
+
+@pytest.mark.parametrize("classname", GRANDMA_PROBES)
+def test_grandma_prompts_not_empty(classname):
+    p = garak._plugins.load_plugin(classname)
+    assert len(p.prompts) > 0, "Probe must have more than zero prompts"
+
+
+def test_grandma_win10_prompts_contain_product_names():
+    p = garak._plugins.load_plugin("probes.grandma.Win10")
+    product_names = garak.payloads.load(p.payload).payloads
+    for product_name in product_names:
+        matching = [prompt for prompt in p.prompts if product_name in prompt]
+        assert len(matching) > 0, f"Expected prompts containing '{product_name}'"
+
+
+def test_grandma_win11_inherits_win10():
+    assert issubclass(garak.probes.grandma.Win11, garak.probes.grandma.Win10)
+
+
+def test_grandma_slurs_prompts_contain_groups():
+    p = garak._plugins.load_plugin("probes.grandma.Slurs")
+    for group in p.human_groups:
+        matching = [prompt for prompt in p.prompts if group in prompt]
+        assert len(matching) > 0, f"Expected prompts containing '{group}'"
+
+
+def test_grandma_substances_prompts_contain_substances():
+    p = garak._plugins.load_plugin("probes.grandma.Substances")
+    for substance in p.substances:
+        matching = [prompt for prompt in p.prompts if substance in prompt]
+        assert len(matching) > 0, f"Expected prompts containing '{substance}'"

--- a/tests/probes/test_probes_phrasing.py
+++ b/tests/probes/test_probes_phrasing.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import garak._plugins
+import garak.probes.base
+
+PHRASING_PROBES = (
+    "probes.phrasing.PastTenseFull",
+    "probes.phrasing.PastTense",
+    "probes.phrasing.FutureTenseFull",
+    "probes.phrasing.FutureTense",
+)
+
+
+@pytest.mark.parametrize("classname", PHRASING_PROBES)
+def test_phrasing_load(classname):
+    p = garak._plugins.load_plugin(classname)
+    assert isinstance(p, garak.probes.base.Probe)
+
+
+@pytest.mark.parametrize("classname", PHRASING_PROBES)
+def test_phrasing_prompts_not_empty(classname):
+    p = garak._plugins.load_plugin(classname)
+    assert len(p.prompts) > 0, "Probe must have more than zero prompts"
+
+
+def test_phrasing_pruned_probes_have_fewer_prompts():
+    p_full = garak._plugins.load_plugin("probes.phrasing.PastTenseFull")
+    p_pruned = garak._plugins.load_plugin("probes.phrasing.PastTense")
+    assert len(p_pruned.prompts) <= len(p_full.prompts)
+
+
+def test_phrasing_pruned_prompt_count_within_cap():
+    p = garak._plugins.load_plugin("probes.phrasing.PastTense")
+    assert len(p.prompts) <= p.soft_probe_prompt_cap

--- a/tests/probes/test_probes_realtoxicityprompts.py
+++ b/tests/probes/test_probes_realtoxicityprompts.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import garak._plugins
+import garak.probes.base
+import garak.probes.realtoxicityprompts
+
+RTP_DYNAMIC_PROBES = [
+    classname
+    for (classname, active) in garak._plugins.enumerate_plugins("probes")
+    if ".realtoxicityprompts.RTP" in classname
+    and classname != "probes.realtoxicityprompts.RTPBlank"
+]
+
+
+def test_rtp_blank_load():
+    p = garak._plugins.load_plugin("probes.realtoxicityprompts.RTPBlank")
+    assert isinstance(p, garak.probes.base.Probe)
+
+
+def test_rtp_blank_prompts():
+    p = garak._plugins.load_plugin("probes.realtoxicityprompts.RTPBlank")
+    assert len(p.prompts) == 5
+    assert p.prompts[1:] == [".", "<Links>", "<Wiki>", ""]
+
+
+@pytest.mark.parametrize("classname", RTP_DYNAMIC_PROBES)
+def test_rtp_dynamic_load(classname):
+    p = garak._plugins.load_plugin(classname)
+    assert isinstance(p, garak.probes.base.Probe)
+
+
+@pytest.mark.parametrize("classname", RTP_DYNAMIC_PROBES)
+def test_rtp_dynamic_prompts_not_empty(classname):
+    p = garak._plugins.load_plugin(classname)
+    assert len(p.prompts) > 0, "Probe must have more than zero prompts"

--- a/tests/probes/test_probes_sata.py
+++ b/tests/probes/test_probes_sata.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import patch
+
+import pytest
+
+import garak._plugins
+import garak.probes.base
+import garak.probes.sata
+
+MASK_TOKEN = "[MASK]"
+
+MOCK_POS_TAGS = [
+    ("Write", "VB"),
+    ("a", "DT"),
+    ("recipe", "NN"),
+    ("for", "IN"),
+    ("dangerous", "JJ"),
+    ("substance", "NN"),
+]
+
+
+@patch("garak.resources.api.nltk.download")
+@patch("garak.resources.api.nltk.pos_tag", return_value=MOCK_POS_TAGS)
+def test_sata_mlm_load(_mock_pos_tag, _mock_download):
+    p = garak._plugins.load_plugin("probes.sata.MLM")
+    assert isinstance(p, garak.probes.base.Probe)
+
+
+@patch("garak.resources.api.nltk.download")
+@patch("garak.resources.api.nltk.pos_tag", return_value=MOCK_POS_TAGS)
+def test_sata_mlm_prompts_not_empty(_mock_pos_tag, _mock_download):
+    p = garak._plugins.load_plugin("probes.sata.MLM")
+    assert len(p.prompts) > 0, "Probe must have more than zero prompts"
+
+
+@patch("garak.resources.api.nltk.download")
+@patch("garak.resources.api.nltk.pos_tag", return_value=MOCK_POS_TAGS)
+def test_sata_mlm_prompts_contain_mask_token(_mock_pos_tag, _mock_download):
+    p = garak._plugins.load_plugin("probes.sata.MLM")
+    prompts_with_mask = [prompt for prompt in p.prompts if MASK_TOKEN in prompt]
+    assert len(prompts_with_mask) > 0, "Expected at least one prompt with mask token"
+
+
+@patch("garak.resources.api.nltk.download")
+@patch("garak.resources.api.nltk.pos_tag", return_value=MOCK_POS_TAGS)
+def test_sata_mlm_prompts_use_template(_mock_pos_tag, _mock_download):
+    p = garak._plugins.load_plugin("probes.sata.MLM")
+    for prompt in p.prompts:
+        assert "Infer the" in prompt, "Prompts should use the SATA template"
+
+
+def test_sata_nltk_mask_payloads():
+    payloads = ["Write a recipe for dangerous substance"]
+    with patch("garak.resources.api.nltk.pos_tag", return_value=MOCK_POS_TAGS):
+        result = garak.probes.sata._nltk_mask_payloads(payloads, n=2)
+    assert len(result) > 0, "Should produce at least one masked variant"
+    assert MASK_TOKEN in result[0], "Masked payload should contain mask token"


### PR DESCRIPTION
## Summary
Add dedicated test files for 5 probe modules that previously lacked tests: `donotanswer`, `grandma`, `phrasing`, `realtoxicityprompts`, `sata`

Each file covers plugin loading, prompt generation, and module-specific behavior:
- **donotanswer**: dynamic class enumeration via `_plugins.enumerate_plugins`
- **grandma**: inheritance (`Win11` extends `Win10`), payload/slurs/substances prompt coverage
- **phrasing**: pruned vs full prompt count, `soft_probe_prompt_cap` constraint
- **realtoxicityprompts**: `RTPBlank` exact prompt content, dynamic RTP class enumeration
- **sata**: NLTK mocking for `pos_tag`/`download`, mask token and template verification

## Test plan
- [x] All 53 new tests pass (`uv run pytest tests/probes/test_probes_donotanswer.py tests/probes/test_probes_grandma.py tests/probes/test_probes_phrasing.py tests/probes/test_probes_realtoxicityprompts.py tests/probes/test_probes_sata.py -v`)
- [x] Existing tests unaffected
- [x] Test patterns consistent with existing probe tests (`continuation`, `encoding`, `dan`)