### PR TITLE
fix: when tiktoken encoding is unclear fallback during estimation

### DIFF
--- a/garak/resources/red_team/evaluation.py
+++ b/garak/resources/red_team/evaluation.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Portions Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
 import re
 import tiktoken
 
@@ -50,8 +49,6 @@ def token_count(string: str, model_name: str) -> int:
     try:
         encoding = tiktoken.encoding_for_model(model_name)
     except KeyError as e:
-        msg = "Unable to determine encoding for '{model_name}' using default '{FALLBACK_MODEL_NAME}' for estimation"
-        logging.warning(msg)
         encoding = tiktoken.encoding_for_model(FALLBACK_MODEL_NAME)
     num_tokens = len(encoding.encode(string))
     return num_tokens

--- a/garak/resources/red_team/evaluation.py
+++ b/garak/resources/red_team/evaluation.py
@@ -1,11 +1,14 @@
 # SPDX-FileCopyrightText: Portions Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import re
 import tiktoken
 
 from garak.attempt import Message, Turn, Conversation
 from garak.generators.openai import context_lengths
+
+FALLBACK_MODEL_NAME = "gpt-4"
 
 
 def get_evaluator_prompt(attack_prompt, target_response):
@@ -44,7 +47,12 @@ def process_output_on_topic_score(raw_output) -> float:
 
 
 def token_count(string: str, model_name: str) -> int:
-    encoding = tiktoken.encoding_for_model(model_name)
+    try:
+        encoding = tiktoken.encoding_for_model(model_name)
+    except KeyError as e:
+        msg = "Unable to determine encoding for '{model_name}' using default '{FALLBACK_MODEL_NAME}' for estimation"
+        logging.warning(msg)
+        encoding = tiktoken.encoding_for_model(FALLBACK_MODEL_NAME)
     num_tokens = len(encoding.encode(string))
     return num_tokens
 

--- a/tests/resources/red_team/test_evaluation.py
+++ b/tests/resources/red_team/test_evaluation.py
@@ -59,3 +59,28 @@ def test_EvaluationJudge_on_topic_score(
     mocker.patch.object(j.evaluation_generator, "generate", return_value=response)
     res = j.on_topic_score(a.outputs)
     assert res == [res_val]
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-2",
+        "gpt-4o-mini",
+        "davinci",
+        "unnamed-custom",  # an unknown model name should provide a default estimate
+    ],
+)
+def test_token_count_allowed_models(model):
+    from garak.resources.red_team.evaluation import token_count
+    import lorem
+
+    test_strings = [lorem.sentence() for _ in range(0, 100)]
+    test_strings.append("")
+    for test_string in test_strings:
+        c = token_count(test_string, model)
+        if len(test_string) > 0:
+            assert (
+                c > 0
+            ), "For any str with length the number of tokens should be positive"
+        else:
+            assert c == 0, "The empty string should have zero tokens"


### PR DESCRIPTION
Estimation of token counting is fuzzy, when tiktoken does not have a mapping for a specific model name fallback to a default and avoid raise that would crash the run.

## Verification

List the steps needed to make sure this thing works

- [ ] new unit tests pass
- [ ] `garak -t <target_type> -n <model_name>` execute test with a judge with a tiktoken known and unknown model backing the detector
