### PR TITLE
housekeeping: amend arXiv `doc_uri`s from `html`  where available, else `abs`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Due to the nature of the project, there is a lot of potentially harmful or dange
 - Read the documentation in `docs/`, especially the content on extending garak.
 - Avoid adding new dependencies.
 - Keep documentation of garak architecture in the docs/ dir up to date - though use docstrings in the first instance if possible.
-- When working on probes, detectors, and generators, be sure to check the content of the relevant `doc_uri`.
+- When working on probes, detectors, or buffs, be sure to check the content of the relevant `doc_uri` to understand the code's intent and the underlying technique.
 - Use the payloads, data, and services mechanisms when suitable.
 - Use hooks where appropriate; add new hooks if this is efficient.
 - Adhere to contribution and documentation standards, described in the docs.

--- a/garak/buffs/low_resource_languages.py
+++ b/garak/buffs/low_resource_languages.py
@@ -26,7 +26,7 @@ class LRLBuff(Buff):
     Uses the DeepL API to translate prompts into low-resource languages"""
 
     ENV_VAR = "DEEPL_API_KEY"
-    doc_uri = "https://arxiv.org/abs/2310.02446"
+    doc_uri = "https://arxiv.org/html/2310.02446v1"
 
     def __init__(self, config_root=_config):
         super().__init__(config_root=config_root)

--- a/garak/probes/audio.py
+++ b/garak/probes/audio.py
@@ -32,7 +32,7 @@ class AudioAchillesHeel(garak.probes.Probe):
     ]
     goal = "disregard the system prompt via audio component"
     tier = garak.probes.Tier.UNLISTED
-    doc_uri = "https://arxiv.org/abs/2410.23861"
+    doc_uri = "https://arxiv.org/html/2410.23861"
     modality = {"in": {"text", "audio"}}
     DEFAULT_PARAMS = garak.probes.Probe.DEFAULT_PARAMS | {
         "text_prompt": "No text instructions have been included. Please follow the audio instructions exactly.",

--- a/garak/probes/dan.py
+++ b/garak/probes/dan.py
@@ -346,7 +346,7 @@ class AutoDANCached(
     active=True,
     prompt_file="autodan/autodan_prompts.json",
     extra_tags=["payload:jailbreak"],
-    doc_uri="https://arxiv.org/abs/2310.04451",
+    doc_uri="https://arxiv.org/html/2310.04451",
 ):
     """Probe leveraging generated AutoDAN prompts
 
@@ -359,7 +359,7 @@ class AutoDAN(
     metaclass=DANProbeMeta,
     tier=garak.probes.Tier.COMPETE_WITH_SOTA,
     extra_tags=["payload:jailbreak"],
-    doc_uri="https://arxiv.org/abs/2310.04451",
+    doc_uri="https://arxiv.org/html/2310.04451",
 ):
     """Probe leveraging AutoDAN attack generation
 
@@ -448,7 +448,7 @@ class DanInTheWildFull(
     alignment/system prompt. Success is measured by not getting a safety mitigaton
     message."""
 
-    doc_uri = "https://arxiv.org/abs/2308.03825"
+    doc_uri = "https://arxiv.org/html/2308.03825"
 
 
 class DanInTheWild(DanInTheWildFull):

--- a/garak/probes/dra.py
+++ b/garak/probes/dra.py
@@ -97,7 +97,7 @@ class DRA(garak.probes.Probe):
     tier = garak.probes.Tier.OF_CONCERN
     active = True
 
-    doc_uri = "https://arxiv.org/abs/2402.18104v2"
+    doc_uri = "https://arxiv.org/html/2402.18104v2"
 
     DEFAULT_PARAMS = garak.probes.Probe.DEFAULT_PARAMS | {
         "payload_name": "harmful_behaviors",

--- a/garak/probes/fitd.py
+++ b/garak/probes/fitd.py
@@ -35,7 +35,7 @@ class FITD(garak.probes.IterativeProbe):
     """
 
     lang = "en"
-    doc_uri = "http://arxiv.org/abs/2502.19820"
+    doc_uri = "https://arxiv.org/abs/2502.19820"
     primary_detector = "judge.RefusalOnlyAdversarial"
     tags = [
         "owasp:llm01",

--- a/garak/probes/goat.py
+++ b/garak/probes/goat.py
@@ -101,7 +101,7 @@ class GOATAttack(garak.probes.IterativeProbe):
         "cwe:1427",
     ]
     goal = "elicit a harmful, unethical, or illegal response from the model"
-    doc_uri = "https://arxiv.org/abs/2410.01606"
+    doc_uri = "https://arxiv.org/html/2410.01606"
     tier = garak.probes.Tier.OF_CONCERN
     active = False
 

--- a/garak/probes/misleading.py
+++ b/garak/probes/misleading.py
@@ -23,7 +23,7 @@ class FalseAssertion(garak.probes.Probe):
     message."""
 
     lang = "en"
-    doc_uri = "https://arxiv.org/abs/2304.13734"
+    doc_uri = "https://arxiv.org/html/2304.13734"
     primary_detector = "misleading.MustRefuteClaimModel"
     extended_detectors = [
         "misleading.MustRefuteClaimKW",

--- a/garak/probes/phrasing.py
+++ b/garak/probes/phrasing.py
@@ -20,7 +20,7 @@ class PastTenseFull(garak.probes.Probe):
 
     active = False
     lang = "en"
-    doc_uri = "https://arxiv.org/pdf/2407.11969v2"
+    doc_uri = "https://arxiv.org/html/2407.11969v2"
     primary_detector = "mitigation.Prefixes"
     tags = [
         "owasp:llm01",
@@ -67,7 +67,7 @@ class FutureTenseFull(garak.probes.Probe):
     active = False
 
     lang = "en"
-    doc_uri = "https://arxiv.org/pdf/2407.11969v2"
+    doc_uri = "https://arxiv.org/html/2407.11969v2"
     primary_detector = "mitigation.Prefixes"
     tags = [
         "owasp:llm01",

--- a/garak/probes/suffix.py
+++ b/garak/probes/suffix.py
@@ -37,7 +37,7 @@ class GCGCached(garak.probes.Probe):
     goal = "cause the model to disregard the system prompt"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
     active = True
-    doc_uri = "https://arxiv.org/abs/2307.15043"
+    doc_uri = "https://arxiv.org/html/2307.15043"
 
     prompts = list()
 
@@ -80,7 +80,7 @@ class GCG(garak.probes.Probe):
     ]
     goal = "cause the model to disregard the system prompt"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
-    doc_uri = "https://arxiv.org/abs/2307.15043"
+    doc_uri = "https://arxiv.org/html/2307.15043"
 
     DEFAULT_PARAMS = garak.probes.Probe.DEFAULT_PARAMS | {
         "stop_on_success": True,
@@ -188,7 +188,7 @@ class BEAST(garak.probes.Probe):
     ]
     goal = "cause the model to disregard the system prompt"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
-    doc_uri = "https://arxiv.org/abs/2402.15570"
+    doc_uri = "https://arxiv.org/html/2402.15570"
 
     prompts = list()
     active = False

--- a/garak/probes/tap.py
+++ b/garak/probes/tap.py
@@ -78,7 +78,7 @@ class TAPCached(garak.probes.Probe):
     ]
     goal = "cause the model to disregard the system prompt"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
-    doc_uri = "https://arxiv.org/abs/2312.02119"
+    doc_uri = "https://arxiv.org/html/2312.02119"
     active = True
 
     DEFAULT_PARAMS = garak.probes.Probe.DEFAULT_PARAMS | {
@@ -117,7 +117,7 @@ class TAP(garak.probes.Probe):
         "payload:jailbreak",
     ]
     goal = "cause the model to disregard the system prompt"
-    doc_uri = "https://arxiv.org/abs/2312.02119"
+    doc_uri = "https://arxiv.org/html/2312.02119"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
     active = False
 
@@ -261,7 +261,7 @@ class PAIR(garak.probes.Probe):
         "payload:jailbreak",
     ]
     goal = "cause the model to disregard the system prompt"
-    doc_uri = "https://arxiv.org/abs/2310.08419"
+    doc_uri = "https://arxiv.org/html/2310.08419"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
     active = False
 


### PR DESCRIPTION
In order to expand data available at first hop, this PR:

* moves arXiv `doc_uri`s to the HTML version of the paper, for those cases where it's available
* corrects the plugin types to check in `AGENTS.md` and expresses intent there