### PR TITLE
fix: add threading lock to prevent hitlog race condition

### DIFF
--- a/garak/evaluators/base.py
+++ b/garak/evaluators/base.py
@@ -5,6 +5,7 @@ These describe evaluators for assessing detector results.
 
 import json
 import logging
+import threading
 from pathlib import Path
 
 from typing import Iterable, Optional, Tuple, List
@@ -22,6 +23,9 @@ import garak.resources.theme
 # Minimum CI width (in percentage points) to display in output
 # CIs narrower than this provide no meaningful uncertainty information
 CI_DISPLAY_MIN_WIDTH = 0.001
+
+# Lock for thread-safe hitlog file open and write operations
+_hitlog_lock = threading.Lock()
 
 
 class Evaluator:
@@ -96,48 +100,49 @@ class Evaluator:
                         messages.append(
                             attempt.outputs[idx]
                         )  # this is an opinion about scope of detection; expects that detector_results aligns with attempt.outputs (not all_outputs)
-                        if (
-                            _config.transient.hitlogfile is None
-                            or _config.transient.hitlogfile.closed
-                        ):
-                            hitlog_mode = (
-                                "w" if _config.transient.hitlogfile is None else "a"
-                            )
-                            hitlog_filename = Path(
-                                str(_config.transient.report_filename).replace(
-                                    ".report.jsonl", ".hitlog.jsonl"
+                        with _hitlog_lock:
+                            if (
+                                _config.transient.hitlogfile is None
+                                or _config.transient.hitlogfile.closed
+                            ):
+                                hitlog_mode = (
+                                    "w" if _config.transient.hitlogfile is None else "a"
                                 )
-                            )
-                            logging.info("hit log in %s", hitlog_filename)
-                            _config.transient.hitlogfile = open(
-                                hitlog_filename,
-                                hitlog_mode,
-                                buffering=1,
-                                encoding="utf-8",
-                            )
+                                hitlog_filename = Path(
+                                    str(_config.transient.report_filename).replace(
+                                        ".report.jsonl", ".hitlog.jsonl"
+                                    )
+                                )
+                                logging.info("hit log in %s", hitlog_filename)
+                                _config.transient.hitlogfile = open(
+                                    hitlog_filename,
+                                    hitlog_mode,
+                                    buffering=1,
+                                    encoding="utf-8",
+                                )
 
-                        triggers = attempt.notes.get("triggers", None)
-                        _config.transient.hitlogfile.write(
-                            json.dumps(
-                                {
-                                    "goal": attempt.goal,
-                                    "prompt": asdict(attempt.prompt),
-                                    "output": asdict(attempt.outputs[idx]),
-                                    "triggers": triggers,
-                                    "score": score,
-                                    "run_id": str(_config.transient.run_id),
-                                    "attempt_id": str(attempt.uuid),
-                                    "attempt_seq": attempt.seq,
-                                    "attempt_idx": idx,
-                                    "generator": f"{_config.plugins.target_type} {_config.plugins.target_name}",
-                                    "probe": self.probename,
-                                    "detector": detector,
-                                    "generations_per_prompt": _config.run.generations,
-                                },
-                                ensure_ascii=False,
+                            triggers = attempt.notes.get("triggers", None)
+                            _config.transient.hitlogfile.write(
+                                json.dumps(
+                                    {
+                                        "goal": attempt.goal,
+                                        "prompt": asdict(attempt.prompt),
+                                        "output": asdict(attempt.outputs[idx]),
+                                        "triggers": triggers,
+                                        "score": score,
+                                        "run_id": str(_config.transient.run_id),
+                                        "attempt_id": str(attempt.uuid),
+                                        "attempt_seq": attempt.seq,
+                                        "attempt_idx": idx,
+                                        "generator": f"{_config.plugins.target_type} {_config.plugins.target_name}",
+                                        "probe": self.probename,
+                                        "detector": detector,
+                                        "generations_per_prompt": _config.run.generations,
+                                    },
+                                    ensure_ascii=False,
+                                )
+                                + "\n"  # generator,probe,prompt,trigger,result,detector,score,run id,attemptid,
                             )
-                            + "\n"  # generator,probe,prompt,trigger,result,detector,score,run id,attemptid,
-                        )
 
             outputs_evaluated = passes + fails
             outputs_processed = passes + fails + nones

--- a/tests/test_hitlog.py
+++ b/tests/test_hitlog.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import threading
 from pathlib import Path
 
 from garak import cli, _config
@@ -15,3 +16,53 @@ def test_hitlog_codepath():
     cli.main(args)
     report_path = Path(_config.transient.report_filename).parent
     assert os.path.isfile(report_path / f"{CODEPATH_PREFIX}.hitlog.jsonl")
+
+
+def test_hitlog_lock_exists():
+    """The module-level _hitlog_lock must be a threading.Lock instance.
+
+    Regression guard for https://github.com/NVIDIA/garak/issues/1355 — ensures
+    the lock that serialises concurrent hitlog writes is present and of the
+    correct type.
+    """
+    from garak.evaluators.base import _hitlog_lock
+
+    assert isinstance(_hitlog_lock, type(threading.Lock())), (
+        "_hitlog_lock must be a threading.Lock"
+    )
+
+
+def test_hitlog_concurrent_writes(tmp_path):
+    """Concurrent hitlog writes from multiple threads must produce valid JSONL.
+
+    Regression test for https://github.com/NVIDIA/garak/issues/1355 — before
+    the fix, multiple threads could interleave writes and corrupt lines in the
+    hitlog file.
+    """
+    import json
+    from garak.evaluators.base import _hitlog_lock
+
+    hitlog_path = tmp_path / "run.hitlog.jsonl"
+    errors = []
+
+    def write_entry(idx):
+        entry = json.dumps({"idx": idx, "data": "x" * 200}) + "\n"
+        try:
+            with _hitlog_lock:
+                with open(hitlog_path, "a", buffering=1, encoding="utf-8") as f:
+                    f.write(entry)
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=write_entry, args=(i,)) for i in range(50)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == [], f"Exceptions during concurrent writes: {errors}"
+
+    lines = hitlog_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 50, f"Expected 50 lines, got {len(lines)}"
+    for line in lines:
+        json.loads(line)  # raises JSONDecodeError if line is corrupt


### PR DESCRIPTION
## Summary

- Add a module-level `threading.Lock` (`_hitlog_lock`) in `garak/evaluators/base.py`
- Wrap the hitlog file open+write block with the lock to serialise concurrent access
- Add regression tests: `test_hitlog_lock_exists` and `test_hitlog_concurrent_writes`

Fixes #1355

## Problem

When `parallel_attempts > 1`, multiple threads call `evaluate()` concurrently. All threads can pass the `hitlogfile is None` check simultaneously before any one of them opens the file, leading to:
- Multiple `open()` calls on the same file (potential `OSError`)
- Interleaved `write()` calls producing corrupt/truncated JSONL lines

## Fix

Wrap the entire check-open-write block with a `threading.Lock`:

```python
_hitlog_lock = threading.Lock()

# inside evaluate():
with _hitlog_lock:
    if _config.transient.hitlogfile is None or _config.transient.hitlogfile.closed:
        # open file ...
    _config.transient.hitlogfile.write(...)
```

## Verification

- [ ] `python -m pytest tests/test_hitlog.py -v` — all 3 tests pass
- [ ] `python -m pytest tests/ -x -q` — full suite passes
- [ ] Manual verify: hitlog file produced correctly with `parallel_attempts > 1`
- [ ] Manual verify: no regression in single-threaded usage
