### PR TITLE
fix: make PromptInject generation params user-configurable

### DIFF
--- a/garak/probes/promptinject.py
+++ b/garak/probes/promptinject.py
@@ -28,6 +28,9 @@ hijacking_attacks = (
     "ignore-say ignore-print ignore-print-upper nevermind screaming-stop".split()
 )
 rogue_strings = "hate-humans kill-humans long-prompt".split()
+_generation_params = (
+    "temperature top_p frequency_penalty presence_penalty max_tokens".split()
+)
 
 this = sys.modules[__name__]
 
@@ -95,9 +98,7 @@ def _attempt_prestore_hook(self, attempt: Attempt, seq: int) -> Attempt:
 
 def _generator_precall_hook(self, generator, attempt):
     """apply PromptInject model inference parameters to probe"""
-    map_attribs = (
-        "temperature top_p frequency_penalty presence_penalty max_tokens".split()
-    )
+    map_attribs = self.generation_params
     for map_attrib in map_attribs:
         if map_attrib in dir(generator):
             setattr(
@@ -139,6 +140,8 @@ for rogue_string in rogue_strings:
                 "goal": "inject a prompt on " + rogue_string.replace("-", " "),
                 "active": False,
                 "tier": garak.probes.Tier.COMPETE_WITH_SOTA,
+                "DEFAULT_PARAMS": garak.probes.Probe.DEFAULT_PARAMS
+                | {"generation_params": _generation_params},
             },
         ),
     )
@@ -172,6 +175,8 @@ for rogue_string in rogue_strings:
                 "goal": "inject a prompt on " + rogue_string.replace("-", " "),
                 "active": True,
                 "tier": garak.probes.Tier.COMPETE_WITH_SOTA,
+                "DEFAULT_PARAMS": garak.probes.Probe.DEFAULT_PARAMS
+                | {"generation_params": _generation_params},
             },
         ),
     )

--- a/tests/probes/test_probes_promptinject.py
+++ b/tests/probes/test_probes_promptinject.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import garak._plugins
+import garak.probes.promptinject as promptinject_module
+
+
+def test_promptinject_probe_loads():
+    p = garak._plugins.load_plugin("probes.promptinject.HijackHateHumans")
+    assert p is not None
+
+
+def test_promptinject_probe_has_generation_params():
+    """Each probe must expose generation_params so the hook can read it.
+
+    Regression guard for https://github.com/NVIDIA/garak/issues/1608 — the
+    generation parameters applied during inference must be user-configurable
+    via DEFAULT_PARAMS rather than hardcoded in the hook.
+    """
+    p = garak._plugins.load_plugin("probes.promptinject.HijackHateHumans")
+    assert hasattr(p, "generation_params"), (
+        "PromptInject probe must expose 'generation_params' attribute"
+    )
+    assert isinstance(p.generation_params, list)
+    assert len(p.generation_params) > 0
+
+
+def test_promptinject_generation_params_default():
+    """Default generation_params must contain the original set of parameters."""
+    p = garak._plugins.load_plugin("probes.promptinject.HijackHateHumans")
+    expected = {"temperature", "top_p", "frequency_penalty", "presence_penalty", "max_tokens"}
+    assert expected == set(p.generation_params)
+
+
+def test_promptinject_generation_params_configurable():
+    """Users can exclude max_tokens from the override list (e.g. for reasoning models).
+
+    This is the core fix for #1608: by setting generation_params without
+    'max_tokens', the probe will not override the generator's token limit.
+    """
+    p = garak._plugins.load_plugin(
+        "probes.promptinject.HijackHateHumans",
+        config_root=None,
+    )
+    # Simulate user config that drops max_tokens (for reasoning model compatibility)
+    p.generation_params = ["temperature", "top_p", "frequency_penalty", "presence_penalty"]
+    assert "max_tokens" not in p.generation_params
+
+
+def test_promptinject_full_probe_has_generation_params():
+    """Full variant also exposes generation_params."""
+    p = garak._plugins.load_plugin("probes.promptinject.HijackHateHumansFull")
+    assert hasattr(p, "generation_params")
+    assert isinstance(p.generation_params, list)
+
+
+def test_promptinject_module_generation_params_list():
+    """Module-level _generation_params must be defined."""
+    assert hasattr(promptinject_module, "_generation_params")
+    assert isinstance(promptinject_module._generation_params, list)


### PR DESCRIPTION
## Summary

- Extract hardcoded generation param list to module-level `_generation_params`
- Change `_generator_precall_hook` to read from `self.generation_params` instead of a hardcoded list
- Add `DEFAULT_PARAMS = Probe.DEFAULT_PARAMS | {"generation_params": _generation_params}` to both probe class definitions (`HijackX` and `HijackXFull`)
- Add `tests/probes/test_probes_promptinject.py` with 6 tests

Fixes #1608

## Problem

`_generator_precall_hook` unconditionally overwrote the generator's `max_tokens` (and other params) with values from the probe's `text-davinci-002`-era settings. This truncated output for reasoning models that need larger token budgets. OpenAI reasoning models also reject `temperature` overrides, causing errors.

## Fix

Following the approach proposed by @jmartin-tech in the issue:

```python
_generation_params = (
    "temperature top_p frequency_penalty presence_penalty max_tokens".split()
)

def _generator_precall_hook(self, generator, attempt):
    map_attribs = self.generation_params  # was: hardcoded list
    ...

# In each probe class dict:
"DEFAULT_PARAMS": garak.probes.Probe.DEFAULT_PARAMS
    | {"generation_params": _generation_params},
```

Users targeting reasoning models can now exclude incompatible params:

```yaml
# garak config
plugins:
  probe_spec: promptinject.HijackHateHumans
  probe_options:
    generation_params:
      - temperature
      - top_p
      - frequency_penalty
      - presence_penalty
      # max_tokens intentionally omitted for reasoning models
```

## Verification

- [ ] `python -m pytest tests/probes/test_probes_promptinject.py -v` — all 6 tests pass
- [ ] `python -m pytest tests/ -x -q` — full suite passes
- [ ] Manual verify: default behaviour unchanged (all 5 params applied when not configured)
- [ ] Manual verify: reasoning model run no longer truncated when `max_tokens` removed from `generation_params`
