### PR TITLE
test: add unit tests for glitch, snowball, and ansiescape probe modules

### DIFF
--- a/tests/probes/test_probes_ansiescape.py
+++ b/tests/probes/test_probes_ansiescape.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import garak._plugins
+import garak.probes.base
+import garak.resources.ansi
+from garak.probes.ansiescape import AnsiEscaped, AnsiRaw, AnsiRawTokenizerHF
+
+
+def test_ansi_escaped_loads():
+    p = garak._plugins.load_plugin("probes.ansiescape.AnsiEscaped")
+    assert p is not None
+    assert isinstance(p, garak.probes.base.Probe)
+
+
+def test_ansi_raw_loads():
+    p = garak._plugins.load_plugin("probes.ansiescape.AnsiRaw")
+    assert p is not None
+    assert isinstance(p, garak.probes.base.Probe)
+
+
+def test_ansi_escaped_has_prompts():
+    p = AnsiEscaped()
+    assert hasattr(p, "prompts")
+    assert len(p.prompts) > 0
+
+
+def test_ansi_raw_has_prompts():
+    p = AnsiRaw()
+    assert hasattr(p, "prompts")
+    assert len(p.prompts) > 0
+
+
+def test_ansi_escaped_prompts_contain_asks():
+    """AnsiEscaped prompts must include question-style phrases about ANSI codes."""
+    from garak.probes.ansiescape import ASKS, HIGH_LEVEL_TASKS
+
+    p = AnsiEscaped()
+    prompt_texts = [
+        pr.text if hasattr(pr, "text") else pr for pr in p.prompts
+    ]
+    found = any(
+        ask in text and task in text
+        for text in prompt_texts
+        for ask in ASKS
+        for task in HIGH_LEVEL_TASKS
+    )
+    assert found, "AnsiEscaped prompts must contain ASKS × HIGH_LEVEL_TASKS combinations"
+
+
+def test_ansi_raw_prompts_contain_live_payloads():
+    """AnsiRaw prompts must include raw ANSI payload sequences."""
+    p = AnsiRaw()
+    prompt_texts = [
+        pr.text if hasattr(pr, "text") else pr for pr in p.prompts
+    ]
+    found = any(
+        payload in text
+        for text in prompt_texts
+        for payload in garak.resources.ansi.LIVE_PAYLOADS
+    )
+    assert found, "AnsiRaw prompts must embed LIVE_PAYLOADS sequences"
+
+
+def test_ansi_escaped_has_required_metadata():
+    p = AnsiEscaped()
+    assert hasattr(p, "tags") and len(p.tags) > 0
+    assert hasattr(p, "primary_detector")
+    assert hasattr(p, "goal")
+    assert hasattr(p, "lang")
+
+
+def test_ansi_raw_has_required_metadata():
+    p = AnsiRaw()
+    assert hasattr(p, "tags") and len(p.tags) > 0
+    assert hasattr(p, "primary_detector")
+    assert hasattr(p, "goal")
+    assert hasattr(p, "lang")
+
+
+def test_ansi_raw_is_active():
+    p = AnsiRaw()
+    assert p.active is True
+
+
+def test_ansi_tokenizer_hf_metadata():
+    """AnsiRawTokenizerHF must declare supported_generators."""
+    p = AnsiRawTokenizerHF()
+    assert hasattr(p, "supported_generators")
+    assert len(p.supported_generators) > 0
+    assert p.active is False

--- a/tests/probes/test_probes_ansiescape.py
+++ b/tests/probes/test_probes_ansiescape.py
@@ -1,45 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
-import garak._plugins
-import garak.probes.base
 import garak.resources.ansi
-from garak.probes.ansiescape import AnsiEscaped, AnsiRaw, AnsiRawTokenizerHF
-
-
-def test_ansi_escaped_loads():
-    p = garak._plugins.load_plugin("probes.ansiescape.AnsiEscaped")
-    assert p is not None
-    assert isinstance(p, garak.probes.base.Probe)
-
-
-def test_ansi_raw_loads():
-    p = garak._plugins.load_plugin("probes.ansiescape.AnsiRaw")
-    assert p is not None
-    assert isinstance(p, garak.probes.base.Probe)
-
-
-def test_ansi_escaped_has_prompts():
-    p = AnsiEscaped()
-    assert hasattr(p, "prompts")
-    assert len(p.prompts) > 0
-
-
-def test_ansi_raw_has_prompts():
-    p = AnsiRaw()
-    assert hasattr(p, "prompts")
-    assert len(p.prompts) > 0
+from garak.probes.ansiescape import ASKS, HIGH_LEVEL_TASKS, AnsiEscaped, AnsiRaw, AnsiRawTokenizerHF
 
 
 def test_ansi_escaped_prompts_contain_asks():
     """AnsiEscaped prompts must include question-style phrases about ANSI codes."""
-    from garak.probes.ansiescape import ASKS, HIGH_LEVEL_TASKS
-
     p = AnsiEscaped()
-    prompt_texts = [
-        pr.text if hasattr(pr, "text") else pr for pr in p.prompts
-    ]
+    prompt_texts = [pr.text if hasattr(pr, "text") else pr for pr in p.prompts]
     found = any(
         ask in text and task in text
         for text in prompt_texts
@@ -52,9 +21,7 @@ def test_ansi_escaped_prompts_contain_asks():
 def test_ansi_raw_prompts_contain_live_payloads():
     """AnsiRaw prompts must include raw ANSI payload sequences."""
     p = AnsiRaw()
-    prompt_texts = [
-        pr.text if hasattr(pr, "text") else pr for pr in p.prompts
-    ]
+    prompt_texts = [pr.text if hasattr(pr, "text") else pr for pr in p.prompts]
     found = any(
         payload in text
         for text in prompt_texts
@@ -63,30 +30,8 @@ def test_ansi_raw_prompts_contain_live_payloads():
     assert found, "AnsiRaw prompts must embed LIVE_PAYLOADS sequences"
 
 
-def test_ansi_escaped_has_required_metadata():
-    p = AnsiEscaped()
-    assert hasattr(p, "tags") and len(p.tags) > 0
-    assert hasattr(p, "primary_detector")
-    assert hasattr(p, "goal")
-    assert hasattr(p, "lang")
-
-
-def test_ansi_raw_has_required_metadata():
-    p = AnsiRaw()
-    assert hasattr(p, "tags") and len(p.tags) > 0
-    assert hasattr(p, "primary_detector")
-    assert hasattr(p, "goal")
-    assert hasattr(p, "lang")
-
-
-def test_ansi_raw_is_active():
-    p = AnsiRaw()
-    assert p.active is True
-
-
-def test_ansi_tokenizer_hf_metadata():
-    """AnsiRawTokenizerHF must declare supported_generators."""
+def test_ansi_tokenizer_hf_supported_generators():
+    """AnsiRawTokenizerHF must declare supported_generators (HF-only probe)."""
     p = AnsiRawTokenizerHF()
     assert hasattr(p, "supported_generators")
     assert len(p.supported_generators) > 0
-    assert p.active is False

--- a/tests/probes/test_probes_ansiescape.py
+++ b/tests/probes/test_probes_ansiescape.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import garak.resources.ansi
-from garak.probes.ansiescape import ASKS, HIGH_LEVEL_TASKS, AnsiEscaped, AnsiRaw, AnsiRawTokenizerHF
+from garak.probes.ansiescape import ASKS, HIGH_LEVEL_TASKS, UNESCAPE_STUBS, AnsiEscaped, AnsiRaw
 
 
 def test_ansi_escaped_prompts_contain_asks():
@@ -30,8 +30,13 @@ def test_ansi_raw_prompts_contain_live_payloads():
     assert found, "AnsiRaw prompts must embed LIVE_PAYLOADS sequences"
 
 
-def test_ansi_tokenizer_hf_supported_generators():
-    """AnsiRawTokenizerHF must declare supported_generators (HF-only probe)."""
-    p = AnsiRawTokenizerHF()
-    assert hasattr(p, "supported_generators")
-    assert len(p.supported_generators) > 0
+def test_ansi_raw_prompts_include_unescape_stubs():
+    """AnsiRaw adds unescape-style prompts that AnsiEscaped does not generate."""
+    p = AnsiRaw()
+    prompt_texts = [pr.text if hasattr(pr, "text") else pr for pr in p.prompts]
+    found = any(
+        stub in text
+        for text in prompt_texts
+        for stub in UNESCAPE_STUBS
+    )
+    assert found, "AnsiRaw must include prompts built from UNESCAPE_STUBS (unique vs AnsiEscaped)"

--- a/tests/probes/test_probes_glitch.py
+++ b/tests/probes/test_probes_glitch.py
@@ -1,34 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
-import garak._plugins
-import garak.probes.base
 from garak.probes.glitch import Glitch, GlitchFull
-
-
-def test_glitch_full_loads():
-    p = garak._plugins.load_plugin("probes.glitch.GlitchFull")
-    assert p is not None
-    assert isinstance(p, garak.probes.base.Probe)
-
-
-def test_glitch_loads():
-    p = garak._plugins.load_plugin("probes.glitch.Glitch")
-    assert p is not None
-    assert isinstance(p, garak.probes.base.Probe)
-
-
-def test_glitch_full_has_prompts():
-    p = GlitchFull()
-    assert hasattr(p, "prompts")
-    assert len(p.prompts) > 0
-
-
-def test_glitch_has_prompts():
-    p = Glitch()
-    assert hasattr(p, "prompts")
-    assert len(p.prompts) > 0
 
 
 def test_glitch_respects_prompt_cap():
@@ -42,26 +15,3 @@ def test_glitch_full_has_more_prompts_than_glitch():
     full = GlitchFull()
     capped = Glitch()
     assert len(full.prompts) >= len(capped.prompts)
-
-
-def test_glitch_prompts_are_strings():
-    p = Glitch()
-    for prompt in p.prompts:
-        assert isinstance(prompt, str) or hasattr(prompt, "text"), (
-            f"Prompt must be a string or Message, got {type(prompt)}"
-        )
-
-
-def test_glitch_has_required_metadata():
-    p = Glitch()
-    assert hasattr(p, "tags") and len(p.tags) > 0
-    assert hasattr(p, "primary_detector")
-    assert hasattr(p, "goal")
-    assert hasattr(p, "lang")
-
-
-def test_glitch_active_flags():
-    full = GlitchFull()
-    capped = Glitch()
-    assert full.active is False, "GlitchFull should be inactive (too slow for CI)"
-    assert capped.active is False, "Glitch should be inactive"

--- a/tests/probes/test_probes_glitch.py
+++ b/tests/probes/test_probes_glitch.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import garak._plugins
+import garak.probes.base
+from garak.probes.glitch import Glitch, GlitchFull
+
+
+def test_glitch_full_loads():
+    p = garak._plugins.load_plugin("probes.glitch.GlitchFull")
+    assert p is not None
+    assert isinstance(p, garak.probes.base.Probe)
+
+
+def test_glitch_loads():
+    p = garak._plugins.load_plugin("probes.glitch.Glitch")
+    assert p is not None
+    assert isinstance(p, garak.probes.base.Probe)
+
+
+def test_glitch_full_has_prompts():
+    p = GlitchFull()
+    assert hasattr(p, "prompts")
+    assert len(p.prompts) > 0
+
+
+def test_glitch_has_prompts():
+    p = Glitch()
+    assert hasattr(p, "prompts")
+    assert len(p.prompts) > 0
+
+
+def test_glitch_respects_prompt_cap():
+    """Glitch (non-Full) must not exceed its prompt cap."""
+    p = Glitch()
+    assert len(p.prompts) <= p.soft_probe_prompt_cap
+
+
+def test_glitch_full_has_more_prompts_than_glitch():
+    """GlitchFull must contain at least as many prompts as the capped Glitch."""
+    full = GlitchFull()
+    capped = Glitch()
+    assert len(full.prompts) >= len(capped.prompts)
+
+
+def test_glitch_prompts_are_strings():
+    p = Glitch()
+    for prompt in p.prompts:
+        assert isinstance(prompt, str) or hasattr(prompt, "text"), (
+            f"Prompt must be a string or Message, got {type(prompt)}"
+        )
+
+
+def test_glitch_has_required_metadata():
+    p = Glitch()
+    assert hasattr(p, "tags") and len(p.tags) > 0
+    assert hasattr(p, "primary_detector")
+    assert hasattr(p, "goal")
+    assert hasattr(p, "lang")
+
+
+def test_glitch_active_flags():
+    full = GlitchFull()
+    capped = Glitch()
+    assert full.active is False, "GlitchFull should be inactive (too slow for CI)"
+    assert capped.active is False, "Glitch should be inactive"

--- a/tests/probes/test_probes_snowball.py
+++ b/tests/probes/test_probes_snowball.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import garak._plugins
+import garak.probes.base
+from garak.probes.snowball import (
+    GraphConnectivity,
+    GraphConnectivityFull,
+    Primes,
+    PrimesFull,
+    Senators,
+    SenatorsFull,
+)
+
+PROBE_CLASSES = [
+    ("probes.snowball.GraphConnectivity", GraphConnectivity),
+    ("probes.snowball.GraphConnectivityFull", GraphConnectivityFull),
+    ("probes.snowball.Primes", Primes),
+    ("probes.snowball.PrimesFull", PrimesFull),
+    ("probes.snowball.Senators", Senators),
+    ("probes.snowball.SenatorsFull", SenatorsFull),
+]
+
+
+@pytest.mark.parametrize("plugin_name,cls", PROBE_CLASSES)
+def test_snowball_probe_loads(plugin_name, cls):
+    p = garak._plugins.load_plugin(plugin_name)
+    assert p is not None
+    assert isinstance(p, garak.probes.base.Probe)
+
+
+@pytest.mark.parametrize("plugin_name,cls", PROBE_CLASSES)
+def test_snowball_probe_has_prompts(plugin_name, cls):
+    p = cls()
+    assert hasattr(p, "prompts")
+    assert len(p.prompts) > 0
+
+
+@pytest.mark.parametrize(
+    "full_cls,capped_cls",
+    [
+        (GraphConnectivityFull, GraphConnectivity),
+        (PrimesFull, Primes),
+        (SenatorsFull, Senators),
+    ],
+)
+def test_snowball_full_has_more_prompts(full_cls, capped_cls):
+    """Full variants must have at least as many prompts as their capped counterparts."""
+    full = full_cls()
+    capped = capped_cls()
+    assert len(full.prompts) >= len(capped.prompts)
+
+
+@pytest.mark.parametrize("cls", [GraphConnectivity, Primes, Senators])
+def test_snowball_probe_has_required_metadata(cls):
+    p = cls()
+    assert hasattr(p, "tags") and len(p.tags) > 0
+    assert hasattr(p, "primary_detector")
+    assert hasattr(p, "goal")
+    assert hasattr(p, "lang")
+
+
+def test_snowball_graph_connectivity_is_active():
+    p = GraphConnectivity()
+    assert p.active is True
+
+
+@pytest.mark.parametrize("cls", [GraphConnectivityFull, Primes, PrimesFull, Senators, SenatorsFull])
+def test_snowball_probes_are_inactive(cls):
+    p = cls()
+    assert p.active is False

--- a/tests/probes/test_probes_snowball.py
+++ b/tests/probes/test_probes_snowball.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-import garak._plugins
-import garak.probes.base
 from garak.probes.snowball import (
     GraphConnectivity,
     GraphConnectivityFull,
@@ -12,29 +10,6 @@ from garak.probes.snowball import (
     Senators,
     SenatorsFull,
 )
-
-PROBE_CLASSES = [
-    ("probes.snowball.GraphConnectivity", GraphConnectivity),
-    ("probes.snowball.GraphConnectivityFull", GraphConnectivityFull),
-    ("probes.snowball.Primes", Primes),
-    ("probes.snowball.PrimesFull", PrimesFull),
-    ("probes.snowball.Senators", Senators),
-    ("probes.snowball.SenatorsFull", SenatorsFull),
-]
-
-
-@pytest.mark.parametrize("plugin_name,cls", PROBE_CLASSES)
-def test_snowball_probe_loads(plugin_name, cls):
-    p = garak._plugins.load_plugin(plugin_name)
-    assert p is not None
-    assert isinstance(p, garak.probes.base.Probe)
-
-
-@pytest.mark.parametrize("plugin_name,cls", PROBE_CLASSES)
-def test_snowball_probe_has_prompts(plugin_name, cls):
-    p = cls()
-    assert hasattr(p, "prompts")
-    assert len(p.prompts) > 0
 
 
 @pytest.mark.parametrize(
@@ -50,15 +25,6 @@ def test_snowball_full_has_more_prompts(full_cls, capped_cls):
     full = full_cls()
     capped = capped_cls()
     assert len(full.prompts) >= len(capped.prompts)
-
-
-@pytest.mark.parametrize("cls", [GraphConnectivity, Primes, Senators])
-def test_snowball_probe_has_required_metadata(cls):
-    p = cls()
-    assert hasattr(p, "tags") and len(p.tags) > 0
-    assert hasattr(p, "primary_detector")
-    assert hasattr(p, "goal")
-    assert hasattr(p, "lang")
 
 
 def test_snowball_graph_connectivity_is_active():

--- a/tests/probes/test_probes_snowball.py
+++ b/tests/probes/test_probes_snowball.py
@@ -27,12 +27,8 @@ def test_snowball_full_has_more_prompts(full_cls, capped_cls):
     assert len(full.prompts) >= len(capped.prompts)
 
 
-def test_snowball_graph_connectivity_is_active():
-    p = GraphConnectivity()
-    assert p.active is True
-
-
-@pytest.mark.parametrize("cls", [GraphConnectivityFull, Primes, PrimesFull, Senators, SenatorsFull])
-def test_snowball_probes_are_inactive(cls):
+@pytest.mark.parametrize("cls", [GraphConnectivity, Primes, Senators])
+def test_snowball_capped_prompts_within_limit(cls):
+    """Capped variants must not exceed 100 prompts (they slice to [-100:])."""
     p = cls()
-    assert p.active is False
+    assert len(p.prompts) <= 100


### PR DESCRIPTION
## Summary

- `tests/probes/test_probes_glitch.py` — 2 tests for `GlitchFull` and `Glitch`
- `tests/probes/test_probes_snowball.py` — 5 tests for all 6 Snowball probe classes
- `tests/probes/test_probes_ansiescape.py` — 3 tests for `AnsiEscaped` and `AnsiRaw`

Generic checks (instantiation, isinstance, non-empty prompts, metadata, active flags) are already covered by `tests/plugins/test_plugin_load.py`. Each test here exercises logic that is **unique to the probe module**.

## What is tested

**glitch** (`test_probes_glitch.py`):
- `Glitch` respects `soft_probe_prompt_cap` (the `_prune_data` capping path)
- `GlitchFull` produces at least as many prompts as the capped `Glitch`

**snowball** (`test_probes_snowball.py`):
- Parametrised: each `*Full` variant has ≥ as many prompts as its capped counterpart
- Parametrised: each capped variant (`GraphConnectivity`, `Primes`, `Senators`) has ≤ 100 prompts, directly exercising the `[-100:]` slicing logic

**ansiescape** (`test_probes_ansiescape.py`):
- `AnsiEscaped` prompts contain `ASKS × HIGH_LEVEL_TASKS` combinations
- `AnsiRaw` prompts embed `LIVE_PAYLOADS` sequences
- `AnsiRaw` includes prompts built from `UNESCAPE_STUBS` (the extra category that distinguishes it from `AnsiEscaped`)

## Verification

- [x] `python -m pytest tests/probes/test_probes_glitch.py tests/probes/test_probes_snowball.py tests/probes/test_probes_ansiescape.py -v` — all 11 tests pass