### PR TITLE
fix: handle null choices in OpenAI-compatible response

### DIFF
--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -327,12 +327,12 @@ class OpenAICompatible(Generator):
             else:
                 raise e
 
-        if not hasattr(response, "choices"):
+        if not hasattr(response, "choices") or response.choices is None:
             logging.debug(
                 "Did not get a well-formed response, retrying. Expected object with .choices member, got: '%s'"
                 % repr(response)
             )
-            msg = "no .choices member in generator response"
+            msg = "no usable .choices in generator response"
             if self.retry_json:
                 raise garak.exception.GeneratorBackoffTrigger(msg)
             else:

--- a/tests/generators/test_openai.py
+++ b/tests/generators/test_openai.py
@@ -94,6 +94,31 @@ def test_openai_chat():
 
 
 @pytest.mark.usefixtures("set_fake_env")
+@pytest.mark.respx(base_url="https://api.openai.com/v1", assert_all_called=False)
+def test_null_choices_does_not_crash(respx_mock):
+    """API sometimes returns choices=null (content filter, empty response).
+    Generator should return [None] instead of raising TypeError."""
+    respx_mock.post("/chat/completions").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-null",
+                "object": "chat.completion",
+                "choices": None,
+                "created": 1677858242,
+                "model": "gpt-3.5-turbo",
+                "usage": {"prompt_tokens": 10, "total_tokens": 10},
+            },
+        )
+    )
+    generator = OpenAIGenerator(name="gpt-3.5-turbo")
+    generator.retry_json = False
+    prompt = Conversation([Turn(role="user", content=Message("test"))])
+    result = generator.generate(prompt)
+    assert result == [None]
+
+
+@pytest.mark.usefixtures("set_fake_env")
 def test_reasoning_switch():
     with pytest.raises(garak.exception.BadGeneratorException):
         generator = OpenAIGenerator(


### PR DESCRIPTION
Fixes #1525

When the OpenAI API returns `choices: null` (happens with content filters on Azure/AWS endpoints), the generator crashes with `TypeError: 'NoneType' object is not iterable` on line 345.

The existing `hasattr(response, "choices")` check on line 330 only catches a missing attribute — it passes fine when `choices` exists but is `None`. Then the list comprehension blows up.

Fix is one line: added `or response.choices is None` to the existing check. Now it falls through to the same retry/return-None path that already handles missing attributes.

Added a test that mocks a null-choices response and verifies the generator returns `[None]` instead of crashing.

Signed-off-by: Sadik Erisen <elmanoukdesign@gmail.com>