### PR TITLE
fix: handle null choices in OpenAI-compatible generator responses

### DIFF
--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -327,7 +327,7 @@ class OpenAICompatible(Generator):
             else:
                 raise e
 
-        if not hasattr(response, "choices"):
+        if not hasattr(response, "choices") or response.choices is None:
             logging.debug(
                 "Did not get a well-formed response, retrying. Expected object with .choices member, got: '%s'"
                 % repr(response)

--- a/tests/_assets/generators/openai.json
+++ b/tests/_assets/generators/openai.json
@@ -111,6 +111,21 @@
          }
       }
    },
+   "null_choices" : {
+      "code" : 200,
+      "json" : {
+         "choices" : null,
+         "created" : 1677858242,
+         "id" : "chatcmpl-null-choices",
+         "model" : "gpt-3.5-turbo-0613",
+         "object" : "chat.completion",
+         "usage" : {
+            "completion_tokens" : 0,
+            "prompt_tokens" : 13,
+            "total_tokens" : 13
+         }
+      }
+   },
    "models" : {
       "code" : 200,
       "json" : {

--- a/tests/generators/test_openai.py
+++ b/tests/generators/test_openai.py
@@ -94,6 +94,25 @@ def test_openai_chat():
 
 
 @pytest.mark.usefixtures("set_fake_env")
+@pytest.mark.respx(base_url="https://api.openai.com/v1")
+def test_openai_null_choices(respx_mock, openai_compat_mocks):
+    mock_resp = openai_compat_mocks["models"]
+    respx_mock.get("/models").mock(
+        return_value=httpx.Response(mock_resp["code"], json=mock_resp["json"])
+    )
+    mock_resp = openai_compat_mocks["null_choices"]
+    respx_mock.post("/chat/completions").mock(
+        return_value=httpx.Response(mock_resp["code"], json=mock_resp["json"])
+    )
+    generator = OpenAIGenerator(name="gpt-3.5-turbo")
+    generator.retry_json = False
+    output = generator.generate(
+        Conversation([Turn(role="user", content=Message("Hello"))])
+    )
+    assert output == [None]
+
+
+@pytest.mark.usefixtures("set_fake_env")
 def test_reasoning_switch():
     with pytest.raises(garak.exception.BadGeneratorException):
         generator = OpenAIGenerator(


### PR DESCRIPTION
## Summary

- Fixes `TypeError: 'NoneType' object is not iterable` when `response.choices` is `None`
- AWS Bedrock and Azure endpoints can return a response object where `.choices` exists as an attribute but is `None`, bypassing the existing `hasattr` check and crashing at the list comprehension
- Added `or response.choices is None` to the guard on line 330 of `openai.py`

## Test plan

- [x] Added `null_choices` mock response to `tests/_assets/generators/openai.json`
- [x] Added `test_openai_null_choices` test that verifies the generator returns `[None]` instead of raising `TypeError`

Fixes #1525

🤖 Generated with [Claude Code](https://claude.com/claude-code)