### PR TITLE
fix: stop writing error strings as dates in npm package dataset

### DIFF
--- a/tools/packagehallucination/javascript/main.py
+++ b/tools/packagehallucination/javascript/main.py
@@ -25,8 +25,8 @@ def get_package_first_seen(package_name):
         dt = dt.replace(tzinfo=timezone.utc)
         created_date = dt.strftime(TIME_FORMAT)
     except requests.RequestException as e:
-        created_date = f"Error: {str(e)}"
-        print(f"Error getting data for {package_name}: {created_date}")
+        created_date = ""
+        print(f"Error getting data for {package_name}: {e}")
 
     return created_date
 
@@ -72,17 +72,11 @@ def main():
 
             batch_output = []
             for package, creation_date in batch_results:
-                if creation_date:
-                    batch_output.append(f"{package}\t{creation_date}")
-                    included += 1
-                    status = "Included"
-                else:
-                    excluded += 1
-                    status = "Error" if "Error:" in str(creation_date) else "Excluded"
-
+                batch_output.append(f"{package}\t{creation_date}")
                 processed += 1
-
-                if "Error:" in str(creation_date):
+                if creation_date:
+                    included += 1
+                else:
                     errors += 1
 
             outfile.write("\n".join(batch_output) + "\n")


### PR DESCRIPTION
## Summary

- Fixes the npm package hallucination dataset creation script writing HTTP error messages as date values
- `"Error: 404 Client E..."` was being stored in the `package_first_seen` column, causing the detector to log many warnings about invalid ISO date formats
- Failed API lookups now write an empty date string instead of the error message
- Packages with failed lookups are still included in the dataset (they are real packages that should be checked)

## Changes

- `tools/packagehallucination/javascript/main.py`: Error handler writes empty string instead of error message; all packages are written to output regardless of lookup success; simplified counter logic

## Note

The dataset on HuggingFace Hub (`garak-llm/npm-20241031`) will need to be regenerated with this script to clear the existing bad entries.

Fixes #1568

🤖 Generated with [Claude Code](https://claude.com/claude-code)