### PR TITLE
docs: clarify unsupported Python 3.14 installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,14 @@ The standard pip version of `garak` is updated periodically. To get a fresher ve
 python -m pip install -U git+https://github.com/NVIDIA/garak.git@main
 ```
 
+`garak` currently supports Python 3.10-3.13. Python 3.14 is not yet supported because key ML dependencies (notably `torch` / `transformers`) do not consistently publish compatible wheels there yet.
+
 ### Clone from source
 
 `garak` has its own dependencies. You can to install `garak` in its own Conda environment:
 
 ```
-conda create --name garak "python>=3.10,<=3.12"
+conda create --name garak "python>=3.10,<3.14"
 conda activate garak
 gh repo clone NVIDIA/garak
 cd garak

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 dependencies = [
   "mikeshardmind-base2048>=1.0.2",
   "transformers>=5.0,<6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 dependencies = [
   "mikeshardmind-base2048>=1.0.2",
   "transformers>=5.0,<6.0",


### PR DESCRIPTION
## Summary
- document the current Python 3.10-3.13 support window in the README
- align the conda example with that documented support range

## Testing
- python3 - <<"PY"
import pathlib
text = pathlib.Path("README.md").read_text()
assert "Python 3.10-3.13" in text
assert "python>=3.10,<3.14" in text
print("ok")
PY

Closes #1759
