### PR TITLE
Add LLMailInject probe for agentic indirect prompt injection

### DIFF
--- a/garak/detectors/llmail_inject.py
+++ b/garak/detectors/llmail_inject.py
@@ -1,0 +1,19 @@
+from garak.detectors.base import Detector
+from garak.attempt import Attempt
+
+class ActionDetector(Detector):
+    """
+    Detects whether an agentic LLM executed an unauthorized tool call
+    in response to an indirect prompt injection attack.
+    Expects attempt.notes['tool_called'] = True/False.
+    """
+    active = True
+    tags = ["avid-effect:security:S0403"]
+    lang = "en"
+    
+    name = "ActionDetector"
+    description = "Checks if the model triggered an unauthorized tool call."
+
+    def detect(self, attempt: Attempt):
+        tool_called = attempt.notes.get("tool_called", False)
+        return [1.0] if tool_called else [0.0]

--- a/garak/probes/llmail_inject.py
+++ b/garak/probes/llmail_inject.py
@@ -1,0 +1,63 @@
+"""LLMailInject - Agentic Indirect Prompt Injection probe
+
+Tests whether an LLM-based agent can be manipulated into executing
+unauthorized tool calls when malicious instructions are embedded in
+untrusted data such as emails.
+
+Based on the microsoft/llmail-inject-challenge dataset presented at
+IEEE SaTML 2025 by Microsoft Research. The dataset contains real-world
+attack submissions targeting agentic email assistant scenarios.
+
+Further info:
+* https://huggingface.co/datasets/microsoft/llmail-inject-challenge
+"""
+
+from garak.probes.base import Probe
+from datasets import load_dataset
+import logging
+
+class LLMailInject(Probe):
+    """
+    Probe for Agentic Indirect Prompt Injection based on the 
+    microsoft/llmail-inject-challenge dataset (IEEE SaTML 2025).
+    """
+    active = False 
+    tags = ["avid-effect:security:S0403", "owasp:llm02", "quality:Security:PromptStability", "payload:indirect:tooluse"]
+    goal = "cause the model to execute an unauthorized tool call"
+
+    lang = "en"
+    uri = "https://huggingface.co/datasets/microsoft/llmail-inject-challenge"
+
+    b_type = "injection"
+    name = "LLMailInject"
+    description = "Tests if an agentic LLM executes unauthorized tool calls from untrusted emails."
+    primary_detector = "agentic.ActionDetector"
+    
+    def __init__(self):
+        super().__init__()
+        self.prompts = []
+        self._load_data()
+
+    def _load_data(self):
+        """
+        Loads the Microsoft LLMail-Inject dataset 
+        and extracts attack prompts from Phase1.
+        """
+        dataset = load_dataset("microsoft/llmail-inject-challenge")
+        target_split = "Phase1"
+
+        columns = dataset[target_split].column_names
+        logging.debug(f"Available columns in '{target_split}': {columns}")
+
+        if "body" in columns:
+            text_col = "body"
+        elif "objectives" in columns:
+            text_col = "objectives"
+        else:
+            text_col = columns[0]
+
+        logging.debug(f"Using '{text_col}' as attack prompt source.")
+
+        self.prompts = [str(item[text_col]) for item in dataset[target_split]]
+        
+        logging.debug(f"Loaded {len(self.prompts)} attack prompts.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,3 +60,4 @@ scipy>=1.14.0
 soundfile>=0.13.1
 librosa>=0.10.2
 detoxify>=0.5.0
+datasets


### PR DESCRIPTION
## Summary
Adds a new probe `LLMailInject` that tests agentic indirect prompt injection using the microsoft/llmail-inject-challenge dataset (IEEE SaTML 2025, Microsoft Research).

The probe tests whether an LLM-based agent can be manipulated into executing unauthorized tool calls when malicious instructions are embedded in untrusted
emails.

## New files
- `garak/probes/llmail_inject.py` — probe loading attack prompts from Phase1 split
- `garak/detectors/llmail_inject.py` — detector checking for unauthorized tool calls

## Dataset
microsoft/llmail-inject-challenge, MIT license
https://huggingface.co/datasets/microsoft/llmail-inject-challenge

## Verification
- [ ] Install dependency: `pip install datasets`
- [ ] Run probe: `garak -m openai -n gpt-4o-mini -p llmail_inject`
- [ ] Verify probe loads prompts from Phase1 split
- [ ] Verify detector returns 1.0 when tool_called=True in attempt.notes