### PR TITLE
Enhance error handling for Mistral API responses

### DIFF
--- a/garak/generators/mistral.py
+++ b/garak/generators/mistral.py
@@ -1,13 +1,14 @@
 """Support `Mistral <https://mistral.ai>`_ hosted endpoints"""
 
+import logging
 from typing import List
 
 import backoff
 
 from garak import _config
-from garak.exception import GeneratorBackoffTrigger
+from garak.attempt import Conversation, Message
+from garak.exception import BadGeneratorException, GeneratorBackoffTrigger, RateLimitHit
 from garak.generators.base import Generator
-from garak.attempt import Message, Conversation
 
 
 class MistralGenerator(Generator):
@@ -34,7 +35,9 @@ class MistralGenerator(Generator):
         super().__init__(name, config_root)
         self._load_unsafe()
 
-    @backoff.on_exception(backoff.fibo, GeneratorBackoffTrigger, max_value=70)
+    @backoff.on_exception(
+        backoff.fibo, (GeneratorBackoffTrigger, RateLimitHit), max_value=70
+    )
     def _call_model(
         self, prompt: Conversation, generations_this_call=1
     ) -> List[Message | None]:
@@ -45,11 +48,17 @@ class MistralGenerator(Generator):
                 messages=messages,
             )
         except Exception as e:
-            backoff_exception_types = [self.mistralai.models.SDKError]
-            for backoff_exception in backoff_exception_types:
-                if isinstance(e, backoff_exception):
-                    raise GeneratorBackoffTrigger from e
-            raise e
+            if isinstance(e, self.mistralai.models.SDKError):
+                if e.status_code in (401, 403):
+                    msg = f"🛑 Mistral API authentication failed (HTTP {e.status_code}). Check your MISTRAL_API_KEY."
+                    logging.error(msg)
+                    raise BadGeneratorException(msg) from e
+                if e.status_code == 429:
+                    msg = "⚠️ Mistral rate limit hit (HTTP 429)."
+                    logging.warning(msg)
+                    raise RateLimitHit(msg) from e
+                raise GeneratorBackoffTrigger from e
+            raise
 
         return [Message(chat_response.choices[0].message.content)]
 

--- a/tests/generators/test_mistral.py
+++ b/tests/generators/test_mistral.py
@@ -4,6 +4,7 @@ import os
 import pytest
 from unittest.mock import patch
 from garak.attempt import Message, Turn, Conversation
+from garak.exception import BadGeneratorException, RateLimitHit
 from garak.generators.mistral import MistralGenerator
 
 DEFAULT_DEPLOYMENT_NAME = "mistral-small-latest"
@@ -58,5 +59,37 @@ def test_mistral_generator(respx_mock, mistral_compat_mocks):
 def test_mistral_chat():
     generator = MistralGenerator(name=DEFAULT_DEPLOYMENT_NAME)
     assert generator.name == DEFAULT_DEPLOYMENT_NAME
-    output = generator.generate(Message("Hello Mistral!"))
+    output = generator.generate(Conversation([Turn("user", Message("Hello Mistral!"))]))
     assert len(output) == 1  # expect 1 generation by default
+
+
+@pytest.mark.skipif(
+    not all(
+        [importlib.util.find_spec(m) for m in MistralGenerator.extra_dependency_names]
+    ),
+    reason="missing optional dependency",
+)
+@pytest.mark.usefixtures("set_fake_env")
+def test_mistral_403_raises_bad_generator_exception():
+    generator = MistralGenerator(name=DEFAULT_DEPLOYMENT_NAME)
+    conv = Conversation([Turn("user", Message("Hello Mistral!"))])
+    sdk_error = generator.mistralai.models.SDKError("Forbidden", 403, "")
+    with patch.object(generator.client.chat, "complete", side_effect=sdk_error):
+        with pytest.raises(BadGeneratorException):
+            generator.generate(conv)
+
+
+@pytest.mark.skipif(
+    not all(
+        [importlib.util.find_spec(m) for m in MistralGenerator.extra_dependency_names]
+    ),
+    reason="missing optional dependency",
+)
+@pytest.mark.usefixtures("set_fake_env")
+def test_mistral_429_raises_rate_limit_hit():
+    generator = MistralGenerator(name=DEFAULT_DEPLOYMENT_NAME)
+    conv = Conversation([Turn("user", Message("Hello Mistral!"))])
+    sdk_error = generator.mistralai.models.SDKError("Rate Limited", 429, "")
+    with patch.object(generator.client.chat, "complete", side_effect=sdk_error):
+        with pytest.raises(RateLimitHit):
+            generator._call_model.__wrapped__(generator, conv)


### PR DESCRIPTION
## Description

Previously, `MistralGenerator._call_model` treated all `SDKError` exceptions the same way — wrapping them in `GeneratorBackoffTrigger` and retrying indefinitely. This meant auth failures (401/403) would silently retry forever with no actionable feedback, and rate limit errors (429) were not distinguished from other transient failures.

This PR:
- Raises `BadGeneratorException` with a clear message for 401/403 auth failures so runs fail fast instead of retrying
- Raises `RateLimitHit` for 429 responses and adds it to the backoff exception list so rate limits trigger the existing backoff/retry logic
- Falls through to `GeneratorBackoffTrigger` for all other `SDKError` codes (preserving existing retry behavior for 5xx etc.)
- Fixes `test_mistral_chat` which was passing a raw `Message` to `generate()` instead of the required `Conversation` object

#1356 

## Verification

- [x] Set `MISTRAL_API_KEY` to a valid key and run `garak --model_type mistral --model_name mistral-small --probes dan.Ablation_Dan_11_0`
- [x] Set `MISTRAL_API_KEY` to an **invalid** key — confirm the run fails immediately with `BadGeneratorException` and a clear auth error message, rather than retrying
- [x] Run the tests: `python -m pytest tests/generators/test_mistral.py -v`
- [x] Confirm `test_mistral_403_raises_bad_generator_exception` and `test_mistral_429_raises_rate_limit_hit` both pass without a real API key
