### PR TITLE
update expectations for litellm proxy to openai

### DIFF
--- a/garak/generators/litellm.py
+++ b/garak/generators/litellm.py
@@ -172,6 +172,7 @@ class LiteLLMGenerator(Generator):
             response = self.litellm.completion(**params)
         except (
             self.litellm.exceptions.AuthenticationError,  # authentication failed for detected or passed `provider`
+            self.litellm.exceptions.InternalServerError,  # can be raised when the detected provider is not configured
             self.litellm.exceptions.BadRequestError,
             self.litellm.exceptions.APIError,
         ) as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ dependencies = [
   "zalgolib>=0.2.2",
   "ecoji>=0.1.1",
   "deepl==1.17.0",
-  "litellm>=1.83.4",
+  "litellm>=1.84.0",
   "jsonpath-ng>=1.6.1",
   "huggingface_hub>=1.0",
   'python-magic-bin>=0.4.14; sys_platform == "win32"',

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ numpy>=2.0.0
 zalgolib>=0.2.2
 ecoji>=0.1.1
 deepl==1.17.0
-litellm>=1.83.4
+litellm>=1.84.0
 jsonpath-ng>=1.6.1
 huggingface_hub>=1.0
 python-magic-bin>=0.4.14; sys_platform == "win32"


### PR DESCRIPTION
as of litellm 1.84.0 inference requests may raise ISE error when the proxy target resolved in litellm is not configured

## Verification

List the steps needed to make sure this thing works

- [ ] Run the tests and ensure they pass `python -m pytest tests/`
