### PR TITLE
fix: improve data_path escape protections

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -179,5 +179,5 @@ redirects = {
 import os
 import sys
 
-sys.path.insert(0, "../..")
+sys.path.insert(0, os.path.abspath("../.."))
 sys.path.append(os.path.abspath("./_ext"))

--- a/garak/data/__init__.py
+++ b/garak/data/__init__.py
@@ -40,6 +40,7 @@ class LocalDataPath(type(pathlib.Path())):
                 return self.relative_to(path)
 
     def _eval_paths(self, segment, next_call, relative):
+        msg = "The requested resource does not refer to a valid path"
         if self in self.ORDERED_SEARCH_PATHS and segment == relative:
             raise GarakException(
                 f"The requested resource does not refer to a valid path"
@@ -48,20 +49,26 @@ class LocalDataPath(type(pathlib.Path())):
         prefix_removed = self._determine_suffix()
         if prefix_removed is None:
             # if LocalDataPath is instantiated using a path not in ORDERED_SEARCH_PATHS
-            raise GarakException(
-                f"The requested resource does not refer to a valid path: {self}"
-            )
+            raise GarakException(f"{msg}: {self}")
         for path in self.ORDERED_SEARCH_PATHS:
             if segment == relative:
                 projected = (path / prefix_removed).parent
             else:
                 current_path = path / prefix_removed
                 projected = getattr(current_path, next_call)(segment)
-            if projected.exists():
-                return LocalDataPath(projected)
+            if projected.exists() and projected.resolve().is_relative_to(path):
+                return LocalDataPath(projected.resolve())
 
         if projected in self.ORDERED_SEARCH_PATHS:
             return LocalDataPath(projected)
+
+        if not any(
+            [
+                projected.resolve().is_relative_to(path)
+                for path in self.ORDERED_SEARCH_PATHS
+            ]
+        ):
+            raise GarakException(msg)
 
         raise GarakException(f"The resource requested does not exist {segment}")
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -31,16 +31,23 @@ def random_resource_filename(request) -> None:
     return os.path.basename(tmpfile.name)
 
 
-def test_no_relative_escape():
+@pytest.mark.parametrize(
+    "test_paths",
+    [
+        [".."],  # parent of data_path
+        ["autodan", "..", "..", "configs"],  # exists but outside allowed paths
+        [
+            "autodan",
+            "../../configs",
+        ],  # exists outside allowed paths using concatenated segment
+        ["../.."],  # outside data_path using concatenated segment
+    ],
+)
+def test_no_relative_escape_joined_path(test_paths):
+    target_path = data_path
     with pytest.raises(GarakException) as exc_info:
-        data_path / ".."
-    assert "does not refer to a valid path" in str(exc_info.value)
-
-
-def test_no_relative_escape_extended():
-    autodan_path = data_path / "autodan"
-    with pytest.raises(GarakException) as exc_info:
-        autodan_path / ".." / ".." / "configs"
+        for p in test_paths:
+            target_path / p
     assert "does not refer to a valid path" in str(exc_info.value)
 
 


### PR DESCRIPTION
When provided a consolidated string to join the path must still resolve to be inside the allowed `ORDERED_SEARCH_PATHS`

## Verification

List the steps needed to make sure this thing works

- [ ] Run the tests and ensure they pass `python -m pytest tests/`
