### PR TITLE
fix: close prior httpx client before reload to stop FD leak in long fitd runs

### DIFF
--- a/garak/generators/nim.py
+++ b/garak/generators/nim.py
@@ -54,7 +54,6 @@ class NVOpenAIChat(OpenAICompatible):
     timeout = 60
 
     def _load_unsafe(self):
-        self._close_client()
         self.client = openai.OpenAI(base_url=self.uri, api_key=self.api_key)
         if self.name in ("", None):
             raise ValueError(
@@ -133,7 +132,6 @@ class NVOpenAICompletion(NVOpenAIChat):
     """
 
     def _load_unsafe(self):
-        self._close_client()
         self.client = openai.OpenAI(base_url=self.uri, api_key=self.api_key)
         self.generator = self.client.completions
 

--- a/garak/generators/nim.py
+++ b/garak/generators/nim.py
@@ -54,6 +54,7 @@ class NVOpenAIChat(OpenAICompatible):
     timeout = 60
 
     def _load_unsafe(self):
+        self._close_client()
         self.client = openai.OpenAI(base_url=self.uri, api_key=self.api_key)
         if self.name in ("", None):
             raise ValueError(
@@ -132,6 +133,7 @@ class NVOpenAICompletion(NVOpenAIChat):
     """
 
     def _load_unsafe(self):
+        self._close_client()
         self.client = openai.OpenAI(base_url=self.uri, api_key=self.api_key)
         self.generator = self.client.completions
 

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -156,12 +156,8 @@ class OpenAICompatible(Generator):
 
     _unsafe_attributes = ["client", "generator"]
 
-    def _close_client(self):
+    def close(self):
         client = getattr(self, "client", None)
-        if client is None:
-            generator = getattr(self, "generator", None)
-            client = getattr(generator, "_client", None)
-
         if client is None:
             return
 
@@ -170,22 +166,15 @@ class OpenAICompatible(Generator):
         except (AttributeError, OSError, RuntimeError, ValueError):
             logging.debug("OpenAI-compatible client teardown failed", exc_info=True)
         finally:
-            if getattr(self, "client", None) is client:
-                self.client = None
-            generator = getattr(self, "generator", None)
-            if getattr(generator, "_client", None) is client:
-                self.generator = None
-
-    def close(self):
-        self._close_client()
+            self.client = None
+            self.generator = None
 
     def __del__(self):
-        self._close_client()
+        self.close()
 
     def _load_unsafe(self):
         # When extending `OpenAICompatible` this method is a likely location for target application specific
         # customization and must populate self.generator with an openai api compliant object
-        self._close_client()
         self.client = openai.OpenAI(base_url=self.uri, api_key=self.api_key)
         if self.name in ("", None):
             raise ValueError(
@@ -287,7 +276,6 @@ class OpenAICompatible(Generator):
         self, prompt: Union[Conversation, List[dict]], generations_this_call: int = 1
     ) -> List[Union[Message, None]]:
         if self.client is None:
-            self._close_client()
             # reload client once when consuming the generator
             self._load_unsafe()
 
@@ -402,7 +390,6 @@ class OpenAIGenerator(OpenAICompatible):
     }
 
     def _load_unsafe(self):
-        self._close_client()
         self.client = openai.OpenAI(api_key=self.api_key)
 
         if self.name == "":

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -156,9 +156,36 @@ class OpenAICompatible(Generator):
 
     _unsafe_attributes = ["client", "generator"]
 
+    def _close_client(self):
+        client = getattr(self, "client", None)
+        if client is None:
+            generator = getattr(self, "generator", None)
+            client = getattr(generator, "_client", None)
+
+        if client is None:
+            return
+
+        try:
+            client.close()
+        except (AttributeError, OSError, RuntimeError, ValueError):
+            logging.debug("OpenAI-compatible client teardown failed", exc_info=True)
+        finally:
+            if getattr(self, "client", None) is client:
+                self.client = None
+            generator = getattr(self, "generator", None)
+            if getattr(generator, "_client", None) is client:
+                self.generator = None
+
+    def close(self):
+        self._close_client()
+
+    def __del__(self):
+        self._close_client()
+
     def _load_unsafe(self):
         # When extending `OpenAICompatible` this method is a likely location for target application specific
         # customization and must populate self.generator with an openai api compliant object
+        self._close_client()
         self.client = openai.OpenAI(base_url=self.uri, api_key=self.api_key)
         if self.name in ("", None):
             raise ValueError(
@@ -260,6 +287,7 @@ class OpenAICompatible(Generator):
         self, prompt: Union[Conversation, List[dict]], generations_this_call: int = 1
     ) -> List[Union[Message, None]]:
         if self.client is None:
+            self._close_client()
             # reload client once when consuming the generator
             self._load_unsafe()
 
@@ -374,6 +402,7 @@ class OpenAIGenerator(OpenAICompatible):
     }
 
     def _load_unsafe(self):
+        self._close_client()
         self.client = openai.OpenAI(api_key=self.api_key)
 
         if self.name == "":

--- a/tests/generators/test_openai_compatible.py
+++ b/tests/generators/test_openai_compatible.py
@@ -3,14 +3,19 @@
 
 import os
 import httpx
+import logging
 import respx
 import pytest
 import importlib
 import inspect
 
 from collections.abc import Iterable
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 from garak.attempt import Message, Turn, Conversation
+import garak.generators.nim as nim_generator
+import garak.generators.openai as openai_generator
 from garak.generators.openai import OpenAICompatible
 from garak.generators.rest import RestGenerator
 
@@ -28,6 +33,35 @@ MODEL_NAME = "gpt-3.5-turbo-instruct"
 ENV_VAR = os.path.abspath(
     __file__
 )  # use test path as hint encase env changes are missed
+
+
+class FakeCompletions:
+    def __init__(self, client):
+        self._client = client
+
+    def create(self, model, prompt, n=1):
+        return SimpleNamespace(
+            choices=[SimpleNamespace(text="This is indeed a test")]
+        )
+
+
+class FakeChatCompletions:
+    def __init__(self, client):
+        self._client = client
+
+    def create(self, model, messages, n=1):
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(message=SimpleNamespace(content="This is a test!"))
+            ]
+        )
+
+
+class FakeOpenAIClient:
+    def __init__(self):
+        self.close = Mock()
+        self.completions = FakeCompletions(self)
+        self.chat = SimpleNamespace(completions=FakeChatCompletions(self))
 
 
 def compatible() -> Iterable[OpenAICompatible]:
@@ -64,6 +98,19 @@ def build_test_instance(module_klass):
     return class_instance
 
 
+def build_unloaded_compatible():
+    generator = OpenAICompatible.__new__(OpenAICompatible)
+    generator.name = MODEL_NAME
+    generator.uri = "http://localhost:8000/v1/"
+    generator.api_key = ENV_VAR
+    generator.generator_family_name = "OpenAICompatible"
+    generator.supports_multiple_generations = False
+    generator.suppressed_params = set()
+    generator.extra_params = {}
+    generator.retry_json = True
+    return generator
+
+
 # helper method to pass mock config
 def generate_in_subprocess(*args):
     generator, openai_compat_mocks, prompt = args[0]
@@ -83,6 +130,81 @@ def generate_in_subprocess(*args):
         )
 
         return generator.generate(prompt)
+
+
+def test_openai_reload_closes_prior_client(monkeypatch):
+    generator = build_unloaded_compatible()
+    prior_client = Mock()
+    generator.client = None
+    generator.generator = SimpleNamespace(_client=prior_client)
+    new_client = FakeOpenAIClient()
+    monkeypatch.setattr(openai_generator.openai, "OpenAI", lambda **kwargs: new_client)
+
+    result = generator._call_model(
+        Conversation([Turn("user", Message("first testing string"))])
+    )
+
+    prior_client.close.assert_called_once()
+    assert generator.client is new_client, "reload should install the new client"
+    assert result[0].text == "This is a test!", "reload should still call the target"
+
+
+def test_openai_reload_without_prior_client(monkeypatch):
+    generator = build_unloaded_compatible()
+    generator.client = None
+    generator.generator = None
+    new_client = FakeOpenAIClient()
+    monkeypatch.setattr(openai_generator.openai, "OpenAI", lambda **kwargs: new_client)
+
+    result = generator._call_model(
+        Conversation([Turn("user", Message("first testing string"))])
+    )
+
+    new_client.close.assert_not_called()
+    assert result[0].text == "This is a test!", "first reload should call the target"
+
+
+def test_openai_reload_logs_close_failure(monkeypatch, caplog):
+    generator = build_unloaded_compatible()
+    prior_client = Mock()
+    prior_client.close.side_effect = RuntimeError("transport already closed")
+    generator.client = None
+    generator.generator = SimpleNamespace(_client=prior_client)
+    new_client = FakeOpenAIClient()
+    monkeypatch.setattr(openai_generator.openai, "OpenAI", lambda **kwargs: new_client)
+
+    with caplog.at_level(logging.DEBUG):
+        result = generator._call_model(
+            Conversation([Turn("user", Message("first testing string"))])
+        )
+
+    prior_client.close.assert_called_once()
+    assert (
+        "OpenAI-compatible client teardown failed" in caplog.text
+    ), "close failures should be logged at debug level"
+    assert result[0].text == "This is a test!", "reload should continue after close error"
+
+
+def test_nim_load_unsafe_closes_prior_client(monkeypatch):
+    generator = nim_generator.NVOpenAICompletion.__new__(
+        nim_generator.NVOpenAICompletion
+    )
+    prior_client = Mock()
+    generator.client = prior_client
+    generator.generator = None
+    generator.uri = "https://integrate.api.nvidia.com/v1/"
+    generator.api_key = ENV_VAR
+    generator.name = MODEL_NAME
+    new_client = FakeOpenAIClient()
+    monkeypatch.setattr(nim_generator.openai, "OpenAI", lambda **kwargs: new_client)
+
+    generator._load_unsafe()
+
+    prior_client.close.assert_called_once()
+    assert generator.client is new_client, "NIM reload should install the new client"
+    assert (
+        generator.generator is new_client.completions
+    ), "NIM completion reload should update the generator resource"
 
 
 @pytest.mark.parametrize("classname", compatible())

--- a/tests/generators/test_openai_compatible.py
+++ b/tests/generators/test_openai_compatible.py
@@ -1,20 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import errno
+import json
 import os
 import httpx
-import logging
 import respx
 import pytest
 import importlib
 import inspect
 
 from collections.abc import Iterable
-from types import SimpleNamespace
-from unittest.mock import Mock
 
 from garak.attempt import Message, Turn, Conversation
-import garak.generators.nim as nim_generator
 import garak.generators.openai as openai_generator
 from garak.generators.openai import OpenAICompatible
 from garak.generators.rest import RestGenerator
@@ -35,33 +33,36 @@ ENV_VAR = os.path.abspath(
 )  # use test path as hint encase env changes are missed
 
 
-class FakeCompletions:
-    def __init__(self, client):
-        self._client = client
-
-    def create(self, model, prompt, n=1):
-        return SimpleNamespace(
-            choices=[SimpleNamespace(text="This is indeed a test")]
-        )
-
-
-class FakeChatCompletions:
-    def __init__(self, client):
-        self._client = client
-
-    def create(self, model, messages, n=1):
-        return SimpleNamespace(
-            choices=[
-                SimpleNamespace(message=SimpleNamespace(content="This is a test!"))
-            ]
-        )
-
-
-class FakeOpenAIClient:
+class FileDescriptorTransport(httpx.BaseTransport):
     def __init__(self):
-        self.close = Mock()
-        self.completions = FakeCompletions(self)
-        self.chat = SimpleNamespace(completions=FakeChatCompletions(self))
+        self.fd = None
+
+    def handle_request(self, request):
+        self.fd = os.open(os.devnull, os.O_RDONLY)
+        payload = {
+            "choices": [
+                {
+                    "message": {"content": "This is a test!", "role": "assistant"},
+                    "finish_reason": "stop",
+                    "index": 0,
+                }
+            ],
+            "created": 0,
+            "id": "test",
+            "model": MODEL_NAME,
+            "object": "chat.completion",
+        }
+        return httpx.Response(
+            200,
+            content=json.dumps(payload).encode(),
+            headers={"Content-Type": "application/json"},
+            request=request,
+        )
+
+    def close(self):
+        if self.fd is not None:
+            os.close(self.fd)
+            self.fd = None
 
 
 def compatible() -> Iterable[OpenAICompatible]:
@@ -104,10 +105,6 @@ def build_unloaded_compatible():
     generator.uri = "http://localhost:8000/v1/"
     generator.api_key = ENV_VAR
     generator.generator_family_name = "OpenAICompatible"
-    generator.supports_multiple_generations = False
-    generator.suppressed_params = set()
-    generator.extra_params = {}
-    generator.retry_json = True
     return generator
 
 
@@ -132,79 +129,38 @@ def generate_in_subprocess(*args):
         return generator.generate(prompt)
 
 
-def test_openai_reload_closes_prior_client(monkeypatch):
-    generator = build_unloaded_compatible()
-    prior_client = Mock()
-    generator.client = None
-    generator.generator = SimpleNamespace(_client=prior_client)
-    new_client = FakeOpenAIClient()
-    monkeypatch.setattr(openai_generator.openai, "OpenAI", lambda **kwargs: new_client)
-
-    result = generator._call_model(
-        Conversation([Turn("user", Message("first testing string"))])
-    )
-
-    prior_client.close.assert_called_once()
-    assert generator.client is new_client, "reload should install the new client"
-    assert result[0].text == "This is a test!", "reload should still call the target"
-
-
-def test_openai_reload_without_prior_client(monkeypatch):
+def test_openai_deserialised_client_closes_when_released(monkeypatch):
     generator = build_unloaded_compatible()
     generator.client = None
     generator.generator = None
-    new_client = FakeOpenAIClient()
-    monkeypatch.setattr(openai_generator.openai, "OpenAI", lambda **kwargs: new_client)
-
-    result = generator._call_model(
-        Conversation([Turn("user", Message("first testing string"))])
+    state = generator.__getstate__()
+    transport = FileDescriptorTransport()
+    openai_client = openai_generator.openai.OpenAI
+    monkeypatch.setattr(
+        openai_generator.openai,
+        "OpenAI",
+        lambda **kwargs: openai_client(
+            **kwargs, http_client=httpx.Client(transport=transport)
+        ),
     )
 
-    new_client.close.assert_not_called()
-    assert result[0].text == "This is a test!", "first reload should call the target"
-
-
-def test_openai_reload_logs_close_failure(monkeypatch, caplog):
-    generator = build_unloaded_compatible()
-    prior_client = Mock()
-    prior_client.close.side_effect = RuntimeError("transport already closed")
-    generator.client = None
-    generator.generator = SimpleNamespace(_client=prior_client)
-    new_client = FakeOpenAIClient()
-    monkeypatch.setattr(openai_generator.openai, "OpenAI", lambda **kwargs: new_client)
-
-    with caplog.at_level(logging.DEBUG):
-        result = generator._call_model(
-            Conversation([Turn("user", Message("first testing string"))])
-        )
-
-    prior_client.close.assert_called_once()
-    assert (
-        "OpenAI-compatible client teardown failed" in caplog.text
-    ), "close failures should be logged at debug level"
-    assert result[0].text == "This is a test!", "reload should continue after close error"
-
-
-def test_nim_load_unsafe_closes_prior_client(monkeypatch):
-    generator = nim_generator.NVOpenAICompletion.__new__(
-        nim_generator.NVOpenAICompletion
+    generator.__setstate__(state)
+    generator.generator.create(
+        model=generator.name,
+        messages=[{"role": "user", "content": "first testing string"}],
     )
-    prior_client = Mock()
-    generator.client = prior_client
-    generator.generator = None
-    generator.uri = "https://integrate.api.nvidia.com/v1/"
-    generator.api_key = ENV_VAR
-    generator.name = MODEL_NAME
-    new_client = FakeOpenAIClient()
-    monkeypatch.setattr(nim_generator.openai, "OpenAI", lambda **kwargs: new_client)
+    leaked_fd = transport.fd
+    assert leaked_fd is not None, "the deserialised client should own an open fd"
 
-    generator._load_unsafe()
-
-    prior_client.close.assert_called_once()
-    assert generator.client is new_client, "NIM reload should install the new client"
-    assert (
-        generator.generator is new_client.completions
-    ), "NIM completion reload should update the generator resource"
+    try:
+        del generator
+        with pytest.raises(OSError) as exc_info:
+            os.fstat(leaked_fd)
+        assert (
+            exc_info.value.errno == errno.EBADF
+        ), "releasing a worker generator should close its client fd"
+    finally:
+        transport.close()
 
 
 @pytest.mark.parametrize("classname", compatible())


### PR DESCRIPTION
## Summary

In `garak/generators/openai.py`, modify `_call_model`'s reload branch to call `self.client.close()` inside a `try/except` before reassigning, and add a `_close_client()` helper that null-checks `self.client` and swallows shutdown errors. In `garak/generators/nim.py`, wire `_load_unsafe` to call `self._close_client()` before instantiating the new `openai.OpenAI(...)`. Add a `__del__` (or `close()`) on `OpenAICompatible` that also closes the client so garbage-collected generators release their httpx pools. Keep the change strictly scoped to client teardown to avoid altering retry/backoff semantics covered by existing tests.

## Why this matters

After roughly 12 hours of an uncapped `fitd` probe run against NIM endpoints, garak crashes with `OSError: [Errno 24] Too many open files`. The traceback (added by maintainer jmartin-tech) traces back through `garak/generators/openai.py:_call_model` -> `nim.py:_load_client` -> `openai.OpenAI(...)` -> httpx `create_ssl_context`, indicating each reload of the OpenAI client opens a new SSL context and httpx pool without closing the prior one. `OpenAICompatible._call_model` reloads the client whenever `self.client is None`, and nothing in the reload path closes the previous transport.

## Testing

- Happy path: instantiating an `OpenAICompatible` generator, setting `self.client = None`, then calling `_call_model` does not leak the previous client (assert `prior_client.close` was called).
- Edge case: when `self.client` is already `None` (first call) the new `_close_client()` is a no-op and the reload still produces a usable client.
- Error path: when `prior_client.close()` raises (e.g. transport already torn down) the reload still succeeds and the failure is logged at debug level rather than propagated.

Fixes #1466

AI was used for assistance.
