### PR TITLE
avoid stored probename side-effects in evaluation

### DIFF
--- a/garak/evaluators/base.py
+++ b/garak/evaluators/base.py
@@ -226,6 +226,7 @@ class Evaluator:
 
         detectors_to_eval = set()
         detector_to_attempt_ids = defaultdict(list)
+        self.probename = None  # short term clear on each call to avoid stale state, this should be refactored to avoid stored state
         for idx, attempt in enumerate(attempts):
             if not self.probename:
                 self.probename = attempt.probe_classname


### PR DESCRIPTION
Addresses a regression in terminal output to list results for the probe being evaluated.

Refactor of `evaluators.Base` introduced a stored state side-effect that resulted in every evaluation being reported as for the same probe as the first evaluation preformed during a run.

This can easily be reprodude with a sample test run of active probes:
```
python -m garak -t test --parallel_attempts 64
```

Resulting odd output where all findings are reported as for the `ansiescape.AnsiEscaped` probe which happens to be the first exectued.
```
ansiescape.AnsiEscaped                                                     packagehallucination.Perl: PASS  ok on 1200/1200
ansiescape.AnsiEscaped                                               packagehallucination.PythonPypi: PASS  ok on 1200/1200
ansiescape.AnsiEscaped                                                 packagehallucination.RakuLand: PASS  ok on 1200/1200
ansiescape.AnsiEscaped                                                 packagehallucination.RubyGems: PASS  ok on 1200/1200
ansiescape.AnsiEscaped                                               packagehallucination.RustCrates: PASS  ok on 1200/1200
```

Expected results is:
```
packagehallucination.Perl                                                  packagehallucination.Perl: PASS  ok on 1200/1200
packagehallucination.Python                                          packagehallucination.PythonPypi: PASS  ok on 1200/1200
packagehallucination.RakuLand                                          packagehallucination.RakuLand: PASS  ok on 1200/1200
packagehallucination.Ruby                                              packagehallucination.RubyGems: PASS  ok on 1200/1200
packagehallucination.Rust                                            packagehallucination.RustCrates: PASS  ok on 1200/1200
```

## Verification

List the steps needed to make sure this thing works

- [ ] Reproduction found above
