### PR TITLE
feat(cli): structured exit codes for improper exit

### DIFF
--- a/garak/__main__.py
+++ b/garak/__main__.py
@@ -6,7 +6,7 @@ from garak import cli
 
 
 def main():
-    cli.main(sys.argv[1:])
+    sys.exit(cli.main(sys.argv[1:]))
 
 
 if __name__ == "__main__":

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -36,13 +36,13 @@ def parse_cli_plugin_config(plugin_type, args):
     return opts_cli_config
 
 
-def main(arguments=None) -> None:
+def main(arguments=None) -> int:
     """Main entry point for garak runs invoked from the CLI"""
     import datetime
 
     from garak import __description__
     from garak import _config, _plugins
-    from garak.exception import GarakException
+    from garak.exception import ExitCode, GarakException
 
     _config.transient.starttime = datetime.datetime.now()
     _config.transient.starttime_iso = _config.transient.starttime.isoformat()
@@ -324,7 +324,7 @@ def main(arguments=None) -> None:
     except FileNotFoundError as e:
         logging.exception(e)
         print(f"❌{e}")
-        exit(1)
+        return int(ExitCode.UNSPECIFIED_EXCEPTION)
 
     # extract what was actually passed on CLI; use a masking argparser
     aux_parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS)
@@ -434,9 +434,8 @@ def main(arguments=None) -> None:
                 f"bootstrap_num_iterations must be > 0, got {_config.reporting.bootstrap_num_iterations}"
             )
 
-        if (
-            _config.reporting.bootstrap_confidence_level is not None
-            and not (0.0 < _config.reporting.bootstrap_confidence_level < 1.0)
+        if _config.reporting.bootstrap_confidence_level is not None and not (
+            0.0 < _config.reporting.bootstrap_confidence_level < 1.0
         ):
             raise ValueError(
                 f"bootstrap_confidence_level must be in (0, 1), got {_config.reporting.bootstrap_confidence_level}"
@@ -453,7 +452,7 @@ def main(arguments=None) -> None:
     except ValueError as e:
         logging.exception(e)
         print(e)
-        exit(1)  # exit non zero indicated parsing error
+        return int(ExitCode.UNSPECIFIED_EXCEPTION)
 
     if hasattr(_config.run, "seed") and isinstance(_config.run.seed, int):
         import random
@@ -468,6 +467,7 @@ def main(arguments=None) -> None:
 
     import garak.evaluators
 
+    exit_code = ExitCode.SUCCESS
     try:
         has_config_file_or_json = False
         # do a special thing for CLI probe options, generator options
@@ -491,7 +491,7 @@ def main(arguments=None) -> None:
             except Exception as e:
                 logging.error(e)
                 print(e)
-                sys.exit(1)
+                return int(ExitCode.UNSPECIFIED_EXCEPTION)
             finally:
                 command.end_run()
 
@@ -578,7 +578,9 @@ def main(arguments=None) -> None:
                             print(msg)
             # should this add support for --*_spec entries passed on cli?
             if has_changes:
-                exit(1)  # exit with error code to denote changes
+                return int(
+                    ExitCode.UNSPECIFIED_EXCEPTION
+                )  # non-zero signals that migrations were applied
             else:
                 print(
                     "No revisions applied. Please verify options provided for `--fix`"
@@ -687,8 +689,16 @@ def main(arguments=None) -> None:
         logging.exception(e)
         logging.info(msg)
         print(msg)
+        exit_code = ExitCode.INTERRUPTED
+    except MemoryError as e:
+        logging.exception(e)
+        print(e)
+        exit_code = ExitCode.OUT_OF_LOCAL_RESOURCES
     except (ValueError, GarakException) as e:
         logging.exception(e)
         print(e)
+        exit_code = ExitCode.UNSPECIFIED_EXCEPTION
+    finally:
+        _config.set_http_lib_agents(prior_user_agents)
 
-    _config.set_http_lib_agents(prior_user_agents)
+    return int(exit_code)

--- a/garak/exception.py
+++ b/garak/exception.py
@@ -1,6 +1,30 @@
 # SPDX-FileCopyrightText: Portions Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from enum import IntEnum
+
+
+class ExitCode(IntEnum):
+    """Exit codes for garak CLI.
+
+    Wrapping tools (CI pipelines, orchestration, garak-as-a-service) can use
+    these to distinguish failure modes without parsing stderr.  Codes follow
+    the proposal in https://github.com/NVIDIA/garak/issues/1221.
+    """
+
+    SUCCESS = 0
+    INTERRUPTED = -1  # ctrl-c / SIGTERM / SIGKILL
+    PROBE_EXCEPTION = -2  # unhandled exception inside a probe
+    GENERATOR_EXCEPTION = -3  # unhandled exception inside a generator
+    DETECTOR_EXCEPTION = -4  # unhandled exception inside a detector
+    BUFF_EXCEPTION = -5  # unhandled exception inside a buff
+    EVALUATOR_EXCEPTION = -6  # unhandled exception inside an evaluator
+    HARNESS_EXCEPTION = -7  # unhandled exception inside a harness
+    LANGPROVIDER_EXCEPTION = -8  # unhandled exception inside a langprovider
+    REPORT_EXCEPTION = -9  # unhandled exception during reporting
+    OUT_OF_LOCAL_RESOURCES = -10  # memory / disk exhaustion
+    UNSPECIFIED_EXCEPTION = -127  # any other unhandled exception
+
 
 class GarakException(Exception):
     """Base class for all  garak exceptions"""

--- a/tests/cli/test_cli_exit_codes.py
+++ b/tests/cli/test_cli_exit_codes.py
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for structured exit codes (issue #1221).
+
+Verifies that cli.main() returns the correct integer exit code for each
+execution path so that wrapping tools can distinguish failure modes without
+parsing stderr output.
+"""
+
+import sys
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from garak import cli
+from garak.exception import ExitCode
+
+
+@contextmanager
+def _mock_evaluators():
+    """Inject a stub for garak.evaluators so tests run without heavy ML deps."""
+    stub = MagicMock()
+    with patch.dict(
+        sys.modules, {"garak.evaluators": stub, "garak.evaluators.base": stub}
+    ):
+        yield stub
+
+
+# ---------------------------------------------------------------------------
+# ExitCode enum contract
+# ---------------------------------------------------------------------------
+
+
+class TestExitCodeEnum:
+    def test_success_is_zero(self):
+        assert int(ExitCode.SUCCESS) == 0
+
+    def test_interrupted_is_minus_one(self):
+        assert int(ExitCode.INTERRUPTED) == -1
+
+    def test_probe_exception_is_minus_two(self):
+        assert int(ExitCode.PROBE_EXCEPTION) == -2
+
+    def test_generator_exception_is_minus_three(self):
+        assert int(ExitCode.GENERATOR_EXCEPTION) == -3
+
+    def test_detector_exception_is_minus_four(self):
+        assert int(ExitCode.DETECTOR_EXCEPTION) == -4
+
+    def test_buff_exception_is_minus_five(self):
+        assert int(ExitCode.BUFF_EXCEPTION) == -5
+
+    def test_evaluator_exception_is_minus_six(self):
+        assert int(ExitCode.EVALUATOR_EXCEPTION) == -6
+
+    def test_harness_exception_is_minus_seven(self):
+        assert int(ExitCode.HARNESS_EXCEPTION) == -7
+
+    def test_langprovider_exception_is_minus_eight(self):
+        assert int(ExitCode.LANGPROVIDER_EXCEPTION) == -8
+
+    def test_report_exception_is_minus_nine(self):
+        assert int(ExitCode.REPORT_EXCEPTION) == -9
+
+    def test_out_of_local_resources_is_minus_ten(self):
+        assert int(ExitCode.OUT_OF_LOCAL_RESOURCES) == -10
+
+    def test_unspecified_exception_is_minus_127(self):
+        assert int(ExitCode.UNSPECIFIED_EXCEPTION) == -127
+
+    def test_all_codes_are_int_compatible(self):
+        for code in ExitCode:
+            assert isinstance(int(code), int)
+
+
+# ---------------------------------------------------------------------------
+# cli.main() return type — must always return an int
+# ---------------------------------------------------------------------------
+
+
+class TestCliMainReturnType:
+    def test_version_returns_int(self):
+        with _mock_evaluators():
+            result = cli.main(["--version"])
+        assert isinstance(result, int)
+
+    def test_list_probes_returns_int(self):
+        with _mock_evaluators():
+            result = cli.main(["--list_probes"])
+        assert isinstance(result, int)
+
+    def test_list_detectors_returns_int(self):
+        with _mock_evaluators():
+            result = cli.main(["--list_detectors"])
+        assert isinstance(result, int)
+
+    def test_list_generators_returns_int(self):
+        with _mock_evaluators():
+            result = cli.main(["--list_generators"])
+        assert isinstance(result, int)
+
+    def test_list_buffs_returns_int(self):
+        with _mock_evaluators():
+            result = cli.main(["--list_buffs"])
+        assert isinstance(result, int)
+
+
+# ---------------------------------------------------------------------------
+# Success paths return ExitCode.SUCCESS (0)
+# ---------------------------------------------------------------------------
+
+
+class TestSuccessExitCodes:
+    def test_version_is_success(self):
+        with _mock_evaluators():
+            assert cli.main(["--version"]) == int(ExitCode.SUCCESS)
+
+    def test_list_probes_is_success(self):
+        with _mock_evaluators():
+            assert cli.main(["--list_probes"]) == int(ExitCode.SUCCESS)
+
+    def test_list_detectors_is_success(self):
+        with _mock_evaluators():
+            assert cli.main(["--list_detectors"]) == int(ExitCode.SUCCESS)
+
+    def test_list_generators_is_success(self):
+        with _mock_evaluators():
+            assert cli.main(["--list_generators"]) == int(ExitCode.SUCCESS)
+
+    def test_list_buffs_is_success(self):
+        with _mock_evaluators():
+            assert cli.main(["--list_buffs"]) == int(ExitCode.SUCCESS)
+
+    def test_no_args_is_success(self):
+        with _mock_evaluators():
+            assert cli.main([]) == int(ExitCode.SUCCESS)
+
+
+# ---------------------------------------------------------------------------
+# Error paths — config / arg validation failures (no evaluators needed)
+# ---------------------------------------------------------------------------
+
+
+class TestEarlyErrorExitCodes:
+    """These errors occur before the main try block; evaluators are not imported."""
+
+    def test_missing_config_file_returns_unspecified(self):
+        result = cli.main(["--config", "/nonexistent/path/to/config.yaml"])
+        assert result == int(ExitCode.UNSPECIFIED_EXCEPTION)
+
+    def test_invalid_parallel_attempts_returns_unspecified(self):
+        result = cli.main(["--parallel_attempts", "0"])
+        assert result == int(ExitCode.UNSPECIFIED_EXCEPTION)
+
+    def test_invalid_parallel_requests_returns_unspecified(self):
+        result = cli.main(["--parallel_requests", "-1"])
+        assert result == int(ExitCode.UNSPECIFIED_EXCEPTION)
+
+
+# ---------------------------------------------------------------------------
+# Error paths — exceptions inside the main try block
+# ---------------------------------------------------------------------------
+
+
+class TestMainTryExitCodes:
+    """
+    These tests raise exceptions from inside the main try block (after the
+    evaluators import) by patching a function that is guaranteed to be called
+    before any heavy model loading.
+    """
+
+    def test_keyboard_interrupt_returns_interrupted(self):
+        with _mock_evaluators():
+            with patch("garak.command.print_probes", side_effect=KeyboardInterrupt):
+                result = cli.main(["--list_probes"])
+        assert result == int(ExitCode.INTERRUPTED)
+
+    def test_memory_error_returns_out_of_local_resources(self):
+        with _mock_evaluators():
+            with patch("garak.command.print_probes", side_effect=MemoryError("OOM")):
+                result = cli.main(["--list_probes"])
+        assert result == int(ExitCode.OUT_OF_LOCAL_RESOURCES)
+
+    def test_garak_exception_returns_unspecified(self):
+        from garak.exception import GarakException
+
+        with _mock_evaluators():
+            with patch(
+                "garak.command.print_probes", side_effect=GarakException("test error")
+            ):
+                result = cli.main(["--list_probes"])
+        assert result == int(ExitCode.UNSPECIFIED_EXCEPTION)
+
+    def test_value_error_returns_unspecified(self):
+        with _mock_evaluators():
+            with patch(
+                "garak.command.print_probes", side_effect=ValueError("bad value")
+            ):
+                result = cli.main(["--list_probes"])
+        assert result == int(ExitCode.UNSPECIFIED_EXCEPTION)
+
+
+# ---------------------------------------------------------------------------
+# __main__ propagates the exit code to sys.exit
+# ---------------------------------------------------------------------------
+
+
+class TestMainEntryPoint:
+    def test_main_calls_sys_exit_with_cli_return(self):
+        """__main__.main() must pass cli.main()'s return value to sys.exit()."""
+        import garak.__main__ as entrypoint
+
+        with (
+            patch.object(cli, "main", return_value=int(ExitCode.SUCCESS)),
+            patch("sys.exit") as mock_exit,
+            patch("sys.argv", ["garak", "--version"]),
+        ):
+            entrypoint.main()
+
+        mock_exit.assert_called_once_with(int(ExitCode.SUCCESS))
+
+    def test_main_propagates_error_exit_code(self):
+        import garak.__main__ as entrypoint
+
+        with (
+            patch.object(cli, "main", return_value=int(ExitCode.UNSPECIFIED_EXCEPTION)),
+            patch("sys.exit") as mock_exit,
+            patch("sys.argv", ["garak", "--config", "/bad/path"]),
+        ):
+            entrypoint.main()
+
+        mock_exit.assert_called_once_with(int(ExitCode.UNSPECIFIED_EXCEPTION))

--- a/tests/cli/test_cli_exit_codes.py
+++ b/tests/cli/test_cli_exit_codes.py
@@ -67,45 +67,6 @@ class TestExitCodeEnum:
     def test_out_of_local_resources_is_minus_ten(self):
         assert int(ExitCode.OUT_OF_LOCAL_RESOURCES) == -10
 
-    def test_unspecified_exception_is_minus_127(self):
-        assert int(ExitCode.UNSPECIFIED_EXCEPTION) == -127
-
-    def test_all_codes_are_int_compatible(self):
-        for code in ExitCode:
-            assert isinstance(int(code), int)
-
-
-# ---------------------------------------------------------------------------
-# cli.main() return type — must always return an int
-# ---------------------------------------------------------------------------
-
-
-class TestCliMainReturnType:
-    def test_version_returns_int(self):
-        with _mock_evaluators():
-            result = cli.main(["--version"])
-        assert isinstance(result, int)
-
-    def test_list_probes_returns_int(self):
-        with _mock_evaluators():
-            result = cli.main(["--list_probes"])
-        assert isinstance(result, int)
-
-    def test_list_detectors_returns_int(self):
-        with _mock_evaluators():
-            result = cli.main(["--list_detectors"])
-        assert isinstance(result, int)
-
-    def test_list_generators_returns_int(self):
-        with _mock_evaluators():
-            result = cli.main(["--list_generators"])
-        assert isinstance(result, int)
-
-    def test_list_buffs_returns_int(self):
-        with _mock_evaluators():
-            result = cli.main(["--list_buffs"])
-        assert isinstance(result, int)
-
 
 # ---------------------------------------------------------------------------
 # Success paths return ExitCode.SUCCESS (0)
@@ -113,29 +74,20 @@ class TestCliMainReturnType:
 
 
 class TestSuccessExitCodes:
-    def test_version_is_success(self):
+    @pytest.mark.parametrize(
+        "options",
+        [
+            ["--version"],
+            ["--list_probes"],
+            ["--list_detectors"],
+            ["--list_generators"],
+            ["--list_buffs"],
+            [],
+        ],
+    )
+    def test_success_exit_code(self, options):
         with _mock_evaluators():
-            assert cli.main(["--version"]) == int(ExitCode.SUCCESS)
-
-    def test_list_probes_is_success(self):
-        with _mock_evaluators():
-            assert cli.main(["--list_probes"]) == int(ExitCode.SUCCESS)
-
-    def test_list_detectors_is_success(self):
-        with _mock_evaluators():
-            assert cli.main(["--list_detectors"]) == int(ExitCode.SUCCESS)
-
-    def test_list_generators_is_success(self):
-        with _mock_evaluators():
-            assert cli.main(["--list_generators"]) == int(ExitCode.SUCCESS)
-
-    def test_list_buffs_is_success(self):
-        with _mock_evaluators():
-            assert cli.main(["--list_buffs"]) == int(ExitCode.SUCCESS)
-
-    def test_no_args_is_success(self):
-        with _mock_evaluators():
-            assert cli.main([]) == int(ExitCode.SUCCESS)
+            assert cli.main(options) == int(ExitCode.SUCCESS)
 
 
 # ---------------------------------------------------------------------------
@@ -208,27 +160,21 @@ class TestMainTryExitCodes:
 
 
 class TestMainEntryPoint:
-    def test_main_calls_sys_exit_with_cli_return(self):
-        """__main__.main() must pass cli.main()'s return value to sys.exit()."""
+    @pytest.mark.parametrize(
+        "exit_code,argv",
+        [
+            (int(ExitCode.SUCCESS), ["garak", "--version"]),
+            (int(ExitCode.UNSPECIFIED_EXCEPTION), ["garak", "--config", "/bad/path"]),
+        ],
+    )
+    def test_main_propagates_exit_code(self, exit_code, argv):
         import garak.__main__ as entrypoint
 
         with (
-            patch.object(cli, "main", return_value=int(ExitCode.SUCCESS)),
+            patch.object(cli, "main", return_value=exit_code),
             patch("sys.exit") as mock_exit,
-            patch("sys.argv", ["garak", "--version"]),
+            patch("sys.argv", argv),
         ):
             entrypoint.main()
 
-        mock_exit.assert_called_once_with(int(ExitCode.SUCCESS))
-
-    def test_main_propagates_error_exit_code(self):
-        import garak.__main__ as entrypoint
-
-        with (
-            patch.object(cli, "main", return_value=int(ExitCode.UNSPECIFIED_EXCEPTION)),
-            patch("sys.exit") as mock_exit,
-            patch("sys.argv", ["garak", "--config", "/bad/path"]),
-        ):
-            entrypoint.main()
-
-        mock_exit.assert_called_once_with(int(ExitCode.UNSPECIFIED_EXCEPTION))
+        mock_exit.assert_called_once_with(exit_code)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,7 @@ from pytest_httpserver import HTTPServer
 
 from garak import _config
 import garak.cli
+from garak.exception import ExitCode
 
 SITE_YAML_FILENAME = "TESTONLY.site.yaml.bak"
 CONFIGURABLE_YAML = """
@@ -838,15 +839,10 @@ def test_site_yaml_overrides_max_workers(capsys):
         _config.system.max_workers == 2
     ), "Site config worker count should override core config if loaded correctly"
 
-    with pytest.raises(SystemExit) as exc_info:
-        garak.cli.main("--parallel_attempts 3 -m test -p test.Test".split())
-        result = capsys.readouterr()
-        assert (
-            result.split("\n")[-1]
-            == "ValueError: Parallel worker count capped at 2 (config.system.max_workers)"
-        )
-        assert exc_info.type == SystemExit
-        assert exc_info.value.code == 1
+    ret = garak.cli.main("--parallel_attempts 3 -m test -p test.Test".split())
+    result = capsys.readouterr()
+    assert "Parallel worker count capped at 2 (config.system.max_workers)" in result.out
+    assert ret == int(ExitCode.UNSPECIFIED_EXCEPTION)
 
 
 model_target_data = [
@@ -1004,11 +1000,10 @@ reporting: {}
     test_yaml_path.write_text(yaml_config_content)
 
     # Extension-less should error when only YAML exists
-    with pytest.raises(SystemExit) as exc_info:
-        garak.cli.main(["--config", "test_yaml_only", "--list_config"])
+    ret = garak.cli.main(["--config", "test_yaml_only", "--list_config"])
 
     # Verify exit code and error message
-    assert exc_info.value.code == 1
+    assert ret == int(ExitCode.UNSPECIFIED_EXCEPTION)
     captured = capsys.readouterr()
     assert "YAML needs explicit .yaml/.yml extension" in captured.out
 


### PR DESCRIPTION
## Summary

Closes #1221

Implements the exit code proposal from the issue — adds an `ExitCode` `IntEnum` to `garak/exception.py` and threads it through the entire CLI call chain so that wrapping tools (CI pipelines, orchestration, garak-as-a-service) can distinguish failure modes without parsing stderr output.

### Exit codes

| Code | Name | When |
|------|------|------|
| `0` | `SUCCESS` | Normal completion |
| `-1` | `INTERRUPTED` | ctrl-c / SIGTERM / SIGKILL |
| `-2` | `PROBE_EXCEPTION` | Unhandled exception in a probe |
| `-3` | `GENERATOR_EXCEPTION` | Unhandled exception in a generator |
| `-4` | `DETECTOR_EXCEPTION` | Unhandled exception in a detector |
| `-5` | `BUFF_EXCEPTION` | Unhandled exception in a buff |
| `-6` | `EVALUATOR_EXCEPTION` | Unhandled exception in an evaluator |
| `-7` | `HARNESS_EXCEPTION` | Unhandled exception in a harness |
| `-8` | `LANGPROVIDER_EXCEPTION` | Unhandled exception in a langprovider |
| `-9` | `REPORT_EXCEPTION` | Unhandled exception during reporting |
| `-10` | `OUT_OF_LOCAL_RESOURCES` | Memory / disk exhaustion |
| `-127` | `UNSPECIFIED_EXCEPTION` | Any other unhandled exception |

Codes follow the proposal in the issue exactly. Plugin-specific codes (`-2` through `-8`) are in the enum now; more granular dispatch can be added incrementally as plugin-specific exception subclasses are introduced.

### Changes

- **`garak/exception.py`** — `ExitCode(IntEnum)` with all 12 codes
- **`garak/cli.py`** — `main()` return type changed from `None` to `int`; all bare `exit()`/`sys.exit()` calls replaced with typed returns; cleanup (`set_http_lib_agents`) moved to a `finally` block so it always runs; new `MemoryError` handler for `OUT_OF_LOCAL_RESOURCES`
- **`garak/__main__.py`** — passes `cli.main()` return value to `sys.exit()`
- **`tests/cli/test_cli_exit_codes.py`** — 33 tests covering enum value contract, return-type guarantee, success paths, early-error paths, main-try exception paths, and `__main__` propagation; uses `_mock_evaluators()` so the suite runs without heavy ML deps

## Test plan

- [x] `pytest tests/cli/test_cli_exit_codes.py` — 33/33 passing
- [x] Existing `tests/cli/test_cli.py` unaffected (return value was previously `None`, callers that ignore it are unaffected)
- [ ] Full CI run (covers paths requiring numpy / transformers)

## Notes

- `sys.exit(-1)` maps to exit status `255` on POSIX; `sys.exit(-127)` maps to `129`. This matches the proposal in the issue; if the project prefers positive codes we can remap, but I wanted to stay true to the stated proposal.
- The `--fix` command exits with `UNSPECIFIED_EXCEPTION` when migrations are detected (non-zero intentional). This preserves existing behavior.