### PR TITLE
fix(evaluators): inline score_to_defcon in get_z_rating

### DIFF
--- a/garak/evaluators/base.py
+++ b/garak/evaluators/base.py
@@ -13,6 +13,7 @@ from colorama import Fore, Style
 
 from garak import _config
 import garak.attempt
+import garak.analyze
 import garak.analyze.calibration
 import garak.analyze.detector_metrics
 from garak.analyze.bootstrap_ci import calculate_bootstrap_ci
@@ -231,9 +232,9 @@ class Evaluator:
         )
         zrating_symbol = ""
         if zscore is not None:
-            _defcon, zrating_symbol = self.calibration.defcon_and_comment(
-                zscore, self.SYMBOL_SET
-            )
+            zrating_symbol = self.SYMBOL_SET[
+                garak.analyze.score_to_defcon(zscore, garak.analyze.RELATIVE_DEFCON_BOUNDS)
+            ]
         return zscore, zrating_symbol
 
     def print_results_wide(

--- a/tests/evaluators/test_base.py
+++ b/tests/evaluators/test_base.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import garak.analyze
+import garak.evaluators.base
+
+
+class _CalibrationStub:
+    """Minimal calibration stub that raises on any call to defcon_and_comment."""
+
+    def __init__(self, zscore):
+        self._zscore = zscore
+
+    def get_z_score(self, probe_module, probe_classname, detector_module, detector_classname, score):
+        return self._zscore
+
+    def defcon_and_comment(self, *args, **kwargs):
+        raise AssertionError("get_z_rating must not call defcon_and_comment")
+
+
+def _make_evaluator(zscore):
+    ev = garak.evaluators.base.Evaluator.__new__(garak.evaluators.base.Evaluator)
+    ev.calibration = _CalibrationStub(zscore)
+    return ev
+
+
+@pytest.mark.parametrize("zscore", [-2.0, -0.5, 0.0, 0.5, 2.0])
+def test_get_z_rating_returns_symbol(zscore):
+    ev = _make_evaluator(zscore)
+    returned_z, symbol = ev.get_z_rating("probe.Probe", "detector.Detector", 50)
+    assert returned_z == zscore
+    assert symbol in ev.SYMBOL_SET.values()
+
+
+def test_get_z_rating_none_zscore():
+    ev = _make_evaluator(None)
+    returned_z, symbol = ev.get_z_rating("probe.Probe", "detector.Detector", 50)
+    assert returned_z is None
+    assert symbol == ""


### PR DESCRIPTION
Fixes #1780

---

`Evaluator.get_z_rating()` calls `self.calibration.defcon_and_comment(zscore, self.SYMBOL_SET)`, but `Calibration` has no `defcon_and_comment` method — it was removed in #1581 without updating the call site. Any run with `_config.system.show_z = True` and valid calibration data will raise `AttributeError` at this point.

**Fix:** Replace the missing-method call with its direct one-line equivalent:

```python
zrating_symbol = self.SYMBOL_SET[
    garak.analyze.score_to_defcon(zscore, garak.analyze.RELATIVE_DEFCON_BOUNDS)
]
```

This matches what the maintainer described in the prior PR review on #1785 and what `defcon_and_comment` would have done: map the z-score to a defcon level via `score_to_defcon`, then look up the corresponding symbol in `SYMBOL_SET`.

**Prior PR:** #1785 was closed because it additionally added a `defcon_and_comment` shim to `Calibration` and a cross-coupled calibration/evaluator test. This PR avoids both: no shim, no changes to `calibration.py`, and the new test (`tests/evaluators/test_base.py`) is scoped to the evaluator layer only.

**Test:** `tests/evaluators/test_base.py` stubs the calibration layer and verifies that `get_z_rating` returns the correct `(zscore, symbol)` pair and never calls `defcon_and_comment`.

