### PR TITLE
Fix malformed MISP tag on snowball detectors

### DIFF
--- a/garak/detectors/snowball.py
+++ b/garak/detectors/snowball.py
@@ -15,7 +15,7 @@ class DontStartNo(Detector):
     """Response should start no, or contain a negation, to pass"""
 
     lang_spec = "en"
-    tags = ["avid:performance:P0204"]
+    tags = ["avid-effect:performance:P0204"]
     hit_desc = "Response incorrectly affirms false premise"
     pass_desc = "Response correctly negates the false premise"
 
@@ -41,7 +41,7 @@ class DontStartYes(Detector):
     """Response should start yes, or contain an affirmation, to pass"""
 
     lang_spec = "en"
-    tags = ["avid:performance:P0204"]
+    tags = ["avid-effect:performance:P0204"]
     hit_desc = "Response incorrectly denies true statement"
     pass_desc = "Response correctly affirms the true statement"
 

--- a/garak/resources/plugin_cache.json
+++ b/garak/resources/plugin_cache.json
@@ -7527,7 +7527,7 @@
       },
       "pass_desc": "Response correctly negates the false premise",
       "tags": [
-        "avid:performance:P0204"
+        "avid-effect:performance:P0204"
       ],
       "mod_time": "2026-02-03 21:20:37 +0000"
     },
@@ -7548,7 +7548,7 @@
       },
       "pass_desc": "Response correctly affirms the true statement",
       "tags": [
-        "avid:performance:P0204"
+        "avid-effect:performance:P0204"
       ],
       "mod_time": "2026-02-03 21:20:37 +0000"
     },

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -3,12 +3,13 @@
 
 import importlib
 import inspect
+import re
 import pytest
 import types
 
 import langcodes
 
-from garak import _plugins
+from garak import _config, _plugins
 from garak.attempt import Attempt, Message
 from garak.configurable import Configurable
 from garak.detectors.base import Detector
@@ -17,6 +18,13 @@ import garak.detectors.base
 
 DEFAULT_GENERATOR_NAME = "garak test"
 DEFAULT_PROMPT_TEXT = "especially the lies"
+
+with open(
+    _config.transient.package_dir / "data" / "tags.misp.tsv",
+    "r",
+    encoding="utf-8",
+) as misp_data:
+    MISP_TAGS = [line.split("\t")[0] for line in misp_data.read().split("\n")]
 
 
 DETECTORS = [
@@ -143,3 +151,15 @@ def test_detector_metadata(classname):
         assert d.doc_uri.lower().startswith(
             "http"
         ), "doc uris should be fully-specified absolute HTTP addresses"
+
+
+@pytest.mark.parametrize("classname", DETECTORS)
+def test_detector_tag_format(classname):
+    m = importlib.import_module("garak." + ".".join(classname.split(".")[:-1]))
+    cls = getattr(m, classname.split(".")[-1])
+    for tag in cls.tags:  # should be MISP format
+        assert isinstance(tag, str)
+        for part in tag.split(":"):
+            assert re.match(r"^[A-Za-z0-9_\-]+$", part)
+        if tag.split(":")[0] != "payload":
+            assert tag in MISP_TAGS, f"{classname} tag {tag} not in MISP taxonomy"


### PR DESCRIPTION
`snowball.DontStartNo` and `snowball.DontStartYes` are tagged `avid:performance:P0204`. That string is not a valid MISP tag. `garak/data/tags.misp.tsv` only has `avid-effect:performance:P0204`, and that is the form the matching snowball probes (`snowball.GraphConnectivity`, `snowball.Primes`, `snowball.Senators`) already use, so the detector tags should match.

This went unnoticed because the probe tests already validate tags against the MISP file (`test_tag_format` in `tests/probes/test_probes.py`), but the detector tests had no equivalent check. I added `test_detector_tag_format` mirroring the probe one so detector tags are held to the same taxonomy.

Repro on `main`:

```python
from garak import _config
with open(_config.transient.package_dir / "data" / "tags.misp.tsv", encoding="utf-8") as f:
    MISP_TAGS = [line.split("\t")[0] for line in f.read().split("\n")]
from garak.detectors import snowball
print(snowball.DontStartNo.tags[0] in MISP_TAGS)   # False on main
```

The `plugin_cache.json` entries for the two detectors are updated to match.

## Verification

- [x] Run the tests and ensure they pass `python -m pytest tests/detectors/test_detectors.py` (440 passed, 28 skipped)
- [x] **Verify** the new `test_detector_tag_format` fails on the old tag and passes after the fix
- [x] **Verify** no other detector or probe carries a malformed `avid:` tag (`grep -rn "['\"]avid:" garak/` is empty)
