### PR TITLE
fix: clearer error when probespec module has only inactive plugins

### DIFF
--- a/garak/cli.py
+++ b/garak/cli.py
@@ -628,6 +628,21 @@ def main(arguments=None) -> None:
                 )
                 parsed_specs[spec_type] = names
                 if rejected is not None and len(rejected) > 0:
+                    # separate rejected clauses that refer to a module whose
+                    # plugins are all marked inactive from clauses that name
+                    # nothing recognised at all - see issue #830
+                    inactive_only_modules = []
+                    truly_unknown = []
+                    all_plugins = _plugins.enumerate_plugins(category=spec_namespace)
+                    for clause in rejected:
+                        if "." not in clause and any(
+                            p.startswith(f"{spec_namespace}.{clause}.")
+                            for p, _active in all_plugins
+                        ):
+                            inactive_only_modules.append(clause)
+                        else:
+                            truly_unknown.append(clause)
+
                     if hasattr(args, "skip_unknown"):  # attribute only set when True
                         header = f"Unknown {spec_namespace}:"
                         skip_msg = Fore.LIGHTYELLOW_EX + "SKIP" + Style.RESET_ALL
@@ -636,9 +651,26 @@ def main(arguments=None) -> None:
                         )
                         logging.warning(f"{header} " + ",".join(rejected))
                         print(msg)
+                    elif inactive_only_modules and not truly_unknown:
+                        module_list = ",".join(inactive_only_modules)
+                        raise ValueError(
+                            f"❌ all {spec_namespace} in '{module_list}' are marked "
+                            f"inactive; select one or more by name "
+                            f"(e.g. --{spec_namespace} {inactive_only_modules[0]}.SomeName) to continue"
+                        )
                     else:
-                        msg_list = ",".join(rejected)
-                        raise ValueError(f"❌Unknown {spec_namespace}❌: {msg_list}")
+                        msg_parts = []
+                        if truly_unknown:
+                            msg_parts.append(
+                                f"❌Unknown {spec_namespace}❌: " + ",".join(truly_unknown)
+                            )
+                        if inactive_only_modules:
+                            module_list = ",".join(inactive_only_modules)
+                            msg_parts.append(
+                                f"all {spec_namespace} in '{module_list}' are marked "
+                                f"inactive; select one or more by name to continue"
+                            )
+                        raise ValueError("; ".join(msg_parts))
 
             evaluator = garak.evaluators.ThresholdEvaluator(_config.run.eval_threshold)
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -65,6 +65,17 @@ def test_run_all_active_probes(capsys):
     assert re.match("^✔️  garak run complete in [0-9]+\\.[0-9]+s$", last_line)
 
 
+def test_module_with_only_inactive_probes_gives_clear_message(capsys):
+    # issue #830: -p test names a module whose probes are all marked inactive,
+    # so the user should get a clear "all inactive" message rather than the
+    # generic "Unknown probes" error
+    cli.main(["-m", "test", "-p", "test", "-g", "1", "--narrow_output"])
+    result = capsys.readouterr()
+    output = ANSI_ESCAPE.sub("", result.out)
+    assert "inactive" in output
+    assert "Unknown probes" not in output
+
+
 def test_run_all_active_detectors(capsys):
     cli.main(
         [


### PR DESCRIPTION


When a user passes a module-name spec (e.g. `-p test`) that maps only to plugins marked `active = False`, `parse_plugin_spec` returns the clause in the rejected list and the CLI raises `Unknown probes: test`. That message is misleading: the module exists, but every plugin in it is inactive.

Detect this case at the CLI rejection site by re-enumerating plugins and checking whether any inactive entries share the rejected clause as a namespace prefix. When they do, surface a message that names the module and points the user at calling specific plugins by name. Mixed rejections (some inactive-only, some truly unknown) still report both.

The change is contained to `garak/cli.py` so `parse_plugin_spec` keeps its existing `(found, rejected)` signature and `--list_probes` callers are unaffected. A regression test exercises `-p test` and asserts the new wording.

## Verification

List the steps needed to make sure this thing works

- [x] `garak -t <target_type> -n <model_name>`
- [x] Run the tests and ensure they pass `python -m pytest tests/`
