### PR TITLE
Fix IntentProbe crash when intent has no detector mapping

### DIFF
--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -253,7 +253,7 @@ class Harness(Configurable):
                     attempt_subset = []
                     for a in attempt_results_list:
                         mapping = intent_to_detector[a.intent]
-                        if mapping is not None and detector_name in mapping:
+                        if detector_name in mapping:
                             attempt_subset.append(a)
                     self._run_detector(attempt_subset, d)
                     del d

--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -249,7 +249,8 @@ class Harness(Configurable):
                     d = _plugins.load_plugin(f"detectors.{detector_name}")
                     attempt_subset = []
                     for a in attempt_results_list:
-                        if detector_name in intent_to_detector[a.intent]:
+                        mapping = intent_to_detector[a.intent]
+                        if mapping is not None and detector_name in mapping:
                             attempt_subset.append(a)
                     self._run_detector(attempt_subset, d)
                     del d

--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -217,6 +217,9 @@ class Harness(Configurable):
                 # determine candidate detectors
                 attempt_results_list = list(attempt_results)
                 intent_to_detector = {}
+                probe_detector_names = {
+                    d.detectorname.replace("garak.detectors.", "") for d in detectors
+                }
 
                 for a in attempt_results_list:
                     intent = a.intent
@@ -236,8 +239,8 @@ class Harness(Configurable):
                         logging.warning(
                             "No detectors specified for intent %s" % intent_observed
                         )
-                    else:
-                        detectors_required.update(detectors)
+                        detectors = probe_detector_names
+                    detectors_required.update(detectors)
                     intent_to_detector[intent_observed] = detectors
 
                 logging.info(


### PR DESCRIPTION
## Summary

Fixes a crash in `garak/harnesses/base.py` for the `IntentProbe` path when a run contains mixed intents:
- one intent with mapped detectors
- one intent without detector mapping

Before this change, `intent_to_detector[intent]` could be `None`, and the membership check raised:

`TypeError: argument of type 'NoneType' is not iterable`

The fix applies a minimal guard at the consumer site so detectorless intents are skipped during detector subset selection instead of crashing.

## Reproduction

Use this config (`repro.yaml`):

```yaml
plugins:
  target_type: test
  target_name: Repeat
  probe_spec: grandma.GrandmaIntent
  detector_spec: auto

cas:
  intent_spec: "M010,S001mis"
  expand_intent_tree: false
  serve_detectorless_intents: true