### PR TITLE
feat(cli): exit with distinct codes on abnormal termination

### DIFF
--- a/garak/cli.py
+++ b/garak/cli.py
@@ -42,7 +42,14 @@ def main(arguments=None) -> None:
 
     from garak import __description__
     from garak import _config, _plugins
-    from garak.exception import GarakException
+    from garak import exception
+    from garak.exception import (
+        BadGeneratorException,
+        ConfigFailure,
+        GarakException,
+        PluginConfigurationError,
+        ReportIncompatibleError,
+    )
 
     _config.transient.starttime = datetime.datetime.now()
     _config.transient.starttime_iso = _config.transient.starttime.isoformat()
@@ -491,7 +498,7 @@ def main(arguments=None) -> None:
             except Exception as e:
                 logging.error(e)
                 print(e)
-                sys.exit(1)
+                sys.exit(exception.EXIT_UNSPECIFIED)
             finally:
                 command.end_run()
 
@@ -687,8 +694,26 @@ def main(arguments=None) -> None:
         logging.exception(e)
         logging.info(msg)
         print(msg)
-    except (ValueError, GarakException) as e:
+        sys.exit(exception.EXIT_INTERRUPTED)
+    except ReportIncompatibleError as e:
         logging.exception(e)
         print(e)
+        sys.exit(exception.EXIT_REPORTING_ERROR)
+    except BadGeneratorException as e:
+        logging.exception(e)
+        print(e)
+        sys.exit(exception.EXIT_GENERATOR_ERROR)
+    except (ConfigFailure, PluginConfigurationError) as e:
+        logging.exception(e)
+        print(e)
+        sys.exit(exception.EXIT_CONFIG_ERROR)
+    except GarakException as e:
+        logging.exception(e)
+        print(e)
+        sys.exit(exception.EXIT_UNSPECIFIED)
+    except ValueError as e:
+        logging.exception(e)
+        print(e)
+        sys.exit(exception.EXIT_UNSPECIFIED)
 
     _config.set_http_lib_agents(prior_user_agents)

--- a/garak/exception.py
+++ b/garak/exception.py
@@ -40,3 +40,22 @@ class PayloadFailure(GarakException):
 
 class ReportIncompatibleError(GarakException):
     """Report references plugins unknown to the current garak install; the report is not compatible with this version"""
+
+
+# Exit codes used by the CLI on abnormal termination. The bucket layout
+# follows the proposal in https://github.com/NVIDIA/garak/issues/1221.
+# The negatives in that proposal are flattened to positive ints here because
+# shells wrap process exit codes to an unsigned 8-bit value.
+EXIT_OK = 0
+EXIT_INTERRUPTED = 1
+EXIT_PROBE_ERROR = 2
+EXIT_GENERATOR_ERROR = 3
+EXIT_DETECTOR_ERROR = 4
+EXIT_BUFF_ERROR = 5
+EXIT_EVALUATOR_ERROR = 6
+EXIT_HARNESS_ERROR = 7
+EXIT_LANGPROVIDER_ERROR = 8
+EXIT_REPORTING_ERROR = 9
+EXIT_OUT_OF_LOCAL_RESOURCES = 10
+EXIT_CONFIG_ERROR = 11
+EXIT_UNSPECIFIED = 127

--- a/tests/cli/test_cli_exit_codes.py
+++ b/tests/cli/test_cli_exit_codes.py
@@ -1,0 +1,95 @@
+"""Exit-code coverage for `garak.cli.main` (issue #1221).
+
+The CLI used to log on error and return 0, which made `garak ms`-style
+wrappers unable to detect failures. These tests pin the mapping between
+the major exception classes raised inside the run pipeline and the exit
+codes defined in `garak.exception`.
+"""
+
+import pytest
+
+from garak import cli, exception
+
+
+def _run_with_injected_exception(monkeypatch, exc: BaseException) -> int:
+    """Drive cli.main with valid args, then raise from inside the run try-block.
+
+    `parse_cli_plugin_config` is the first call inside the wrapping
+    try/except in cli.main, so patching it lets us inject any exception
+    type into the path that the outer handlers are supposed to catch.
+    `--list_probes` keeps the rest of the run cheap and hermetic.
+    """
+
+    def _boom(*_args, **_kwargs):
+        raise exc
+
+    monkeypatch.setattr("garak.cli.parse_cli_plugin_config", _boom)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["--list_probes"])
+    return excinfo.value.code
+
+
+def test_keyboard_interrupt_uses_interrupted_code(monkeypatch):
+    code = _run_with_injected_exception(monkeypatch, KeyboardInterrupt())
+    assert code == exception.EXIT_INTERRUPTED
+
+
+def test_bad_generator_uses_generator_code(monkeypatch):
+    code = _run_with_injected_exception(
+        monkeypatch, exception.BadGeneratorException("nope")
+    )
+    assert code == exception.EXIT_GENERATOR_ERROR
+
+
+def test_config_failure_uses_config_code(monkeypatch):
+    code = _run_with_injected_exception(
+        monkeypatch, exception.ConfigFailure("missing field")
+    )
+    assert code == exception.EXIT_CONFIG_ERROR
+
+
+def test_plugin_configuration_error_uses_config_code(monkeypatch):
+    code = _run_with_injected_exception(
+        monkeypatch, exception.PluginConfigurationError("bad plugin")
+    )
+    assert code == exception.EXIT_CONFIG_ERROR
+
+
+def test_report_incompatible_uses_reporting_code(monkeypatch):
+    code = _run_with_injected_exception(
+        monkeypatch, exception.ReportIncompatibleError("old report")
+    )
+    assert code == exception.EXIT_REPORTING_ERROR
+
+
+def test_generic_garak_exception_uses_unspecified_code(monkeypatch):
+    code = _run_with_injected_exception(monkeypatch, exception.GarakException("?"))
+    assert code == exception.EXIT_UNSPECIFIED
+
+
+def test_value_error_uses_unspecified_code(monkeypatch):
+    code = _run_with_injected_exception(monkeypatch, ValueError("bad value"))
+    assert code == exception.EXIT_UNSPECIFIED
+
+
+def test_exit_code_constants_are_distinct():
+    """Guards against future edits that accidentally collide buckets."""
+    codes = [
+        exception.EXIT_OK,
+        exception.EXIT_INTERRUPTED,
+        exception.EXIT_PROBE_ERROR,
+        exception.EXIT_GENERATOR_ERROR,
+        exception.EXIT_DETECTOR_ERROR,
+        exception.EXIT_BUFF_ERROR,
+        exception.EXIT_EVALUATOR_ERROR,
+        exception.EXIT_HARNESS_ERROR,
+        exception.EXIT_LANGPROVIDER_ERROR,
+        exception.EXIT_REPORTING_ERROR,
+        exception.EXIT_OUT_OF_LOCAL_RESOURCES,
+        exception.EXIT_CONFIG_ERROR,
+        exception.EXIT_UNSPECIFIED,
+    ]
+    assert len(codes) == len(set(codes))
+    # All codes must fit in an 8-bit unsigned int (shells truncate above 255).
+    assert all(0 <= code <= 255 for code in codes)


### PR DESCRIPTION
Closes #1221.

## What

\`cli.main\` used to catch \`KeyboardInterrupt\` and \`(ValueError, GarakException)\` at the bottom, log them, and return silently. The process exited 0 even after a failed run, so wrappers like \`garak ms\` couldn't tell success from failure without re-parsing the log.

This PR:

- Adds \`EXIT_*\` constants to \`garak/exception.py\` following the bucket layout you proposed in #1221, flattened to positive ints (shells truncate exit codes to an unsigned byte).
- Maps the exception classes that already exist to those buckets in \`cli.main\` and calls \`sys.exit\` with the right code.
- Updates the inner \`interactive_mode\` handler to use the new \`EXIT_UNSPECIFIED\` instead of bare \`sys.exit(1)\`.

| Exception                                           | Exit code             |
| --------------------------------------------------- | --------------------- |
| \`KeyboardInterrupt\`                                 | \`EXIT_INTERRUPTED\` (1) |
| \`ReportIncompatibleError\`                           | \`EXIT_REPORTING_ERROR\` (9) |
| \`BadGeneratorException\`                             | \`EXIT_GENERATOR_ERROR\` (3) |
| \`ConfigFailure\`, \`PluginConfigurationError\`        | \`EXIT_CONFIG_ERROR\` (11) |
| Other \`GarakException\`                              | \`EXIT_UNSPECIFIED\` (127) |
| \`ValueError\`                                        | \`EXIT_UNSPECIFIED\` (127) |
| Success                                             | \`EXIT_OK\` (0) |

## What's intentionally _not_ in this PR

The per-layer codes from your proposal — \`EXIT_PROBE_ERROR\`, \`EXIT_DETECTOR_ERROR\`, \`EXIT_BUFF_ERROR\`, \`EXIT_EVALUATOR_ERROR\`, \`EXIT_HARNESS_ERROR\`, \`EXIT_LANGPROVIDER_ERROR\`, \`EXIT_OUT_OF_LOCAL_RESOURCES\` — are defined as constants but not yet wired up. The probe / detector / buff / etc. layers don't raise typed exceptions today, so the CLI can't distinguish them at the catch site. Splitting that into a follow-up keeps this change small and lets us land exit codes for the cases we _can_ classify now. Happy to do the typed-exception refactor as a separate PR if you'd like.

I claimed the issue on the thread; the previous claimer hadn't opened a PR for ~2 months.

## Tests

New \`tests/cli/test_cli_exit_codes.py\` pins the mapping. Injects each exception class from inside the wrapping try-block via a \`parse_cli_plugin_config\` monkeypatch, asserts on \`SystemExit.code\`. Also includes a guard that the constants are distinct and fit in a byte.

\`\`\`
$ uv run pytest tests/cli/test_cli_exit_codes.py -v
======== 8 passed in 1.27s ========

$ uv run pytest tests/cli/ -q
======== 23 passed in 764.65s ========
\`\`\`

The existing \`tests/cli/\` suite stays green. \`ruff check\` on the changed files only reports a pre-existing \`E713\` at \`cli.py:609\` (\`not part in conf_root\`) that's outside this diff.