### PR TITLE
Implement OpenAIResponsesGenerator

### DIFF
--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -431,4 +431,171 @@ class OpenAIReasoningGenerator(OpenAIGenerator):
     }
 
 
+class OpenAIResponsesGenerator(Generator):
+    """Generator using the OpenAI Responses API with server-side tool orchestration.
+
+    Supports MCP servers and function tools via the ``tools`` parameter.
+    Unlike the chat-completions generators, the Responses API runs the full
+    agentic loop (tool calls → execution → follow-up) on the server side,
+    returning only the final text to garak.
+    """
+
+    ENV_VAR = "OPENAI_API_KEY"
+    active = True
+    generator_family_name = "OpenAIResponses"
+    supports_multiple_generations = False
+
+    DEFAULT_PARAMS = Generator.DEFAULT_PARAMS | {
+        "uri": None,
+        "instructions": None,
+        "tools": [],
+        "max_output_tokens": 1024,
+        "extra_params": {},
+        # response.output item types to collect into the final text.
+        # "message" captures standard assistant text; "reasoning" captures
+        # the model's reasoning summary (ResponseReasoningItem).
+        "output_types": ["message"],
+    }
+
+    _unsafe_attributes = ["client"]
+
+    def _load_unsafe(self):
+        kwargs = {"api_key": getattr(self, "api_key", None)}
+        if getattr(self, "uri", None):
+            kwargs["base_url"] = self.uri
+        self.client = openai.OpenAI(**kwargs)
+
+    def __init__(self, name="", config_root=_config):
+        self.name = name
+        self._load_config(config_root)
+        self.fullname = f"{self.generator_family_name} {self.name}"
+        self.key_env_var = self.ENV_VAR
+        self._load_unsafe()
+        super().__init__(self.name, config_root=config_root)
+
+    @staticmethod
+    def _build_input(prompt: Union[Conversation, str]):
+        """Convert a Conversation (or raw string) to the Responses API input format.
+
+        System turns are excluded — callers should promote them to ``instructions``
+        via :meth:`_extract_system_prompt` before calling this method.
+        """
+        if isinstance(prompt, str):
+            return prompt
+        non_system = [t for t in prompt.turns if t.role != "system"]
+        if len(non_system) == 1:
+            return non_system[0].content.text
+        items = []
+        for turn in non_system:
+            content_type = "output_text" if turn.role == "assistant" else "input_text"
+            items.append(
+                {
+                    "type": "message",
+                    "role": turn.role,
+                    "content": [{"type": content_type, "text": turn.content.text}],
+                }
+            )
+        return items
+
+    @staticmethod
+    def _extract_system_prompt(prompt: Union[Conversation, str]) -> Union[str, None]:
+        """Return system turn text from a Conversation as a single string, or None.
+
+        Multiple system turns are joined with a newline so no content is lost.
+        """
+        if not isinstance(prompt, Conversation):
+            return None
+        system_texts = [t.content.text for t in prompt.turns if t.role == "system"]
+        return "\n".join(system_texts) if system_texts else None
+
+    @backoff.on_exception(
+        backoff.fibo,
+        (
+            openai.RateLimitError,
+            openai.InternalServerError,
+            openai.APITimeoutError,
+            openai.APIConnectionError,
+            garak.exception.GeneratorBackoffTrigger,
+        ),
+        max_value=70,
+    )
+    def _call_model(
+        self, prompt: Union[Conversation, str], generations_this_call: int = 1
+    ) -> List[Union[Message, None]]:
+        if self.client is None:
+            self._load_unsafe()
+
+        instructions = self.instructions or self._extract_system_prompt(prompt)
+        create_args = {
+            "model": self.name,
+            "input": self._build_input(prompt),
+            "max_output_tokens": self.max_output_tokens,
+        }
+        if instructions:
+            create_args["instructions"] = instructions
+        if self.tools:
+            create_args["tools"] = self.tools
+        for k, v in self.extra_params.items():
+            create_args[k] = v
+
+        try:
+            response = self.client.responses.create(**create_args)
+        except openai.BadRequestError as e:
+            logging.exception(e)
+            logging.error("Bad request: %s", repr(prompt))
+            return [None]
+        except json.decoder.JSONDecodeError as e:
+            logging.exception(e)
+            raise garak.exception.GeneratorBackoffTrigger from e
+
+        text_parts = []
+        tool_calls = []
+
+        # Manually iterate response.output rather than using response.output_text so
+        # that output_types can include non-message items such as reasoning summaries.
+        _TOOL_CALL_ATTRS = (
+            "call_id", "name", "arguments", "input", "output",
+            "error", "status", "server_label",
+        )
+        for item in response.output:
+            item_type = getattr(item, "type", None)
+            # Any item whose type ends with "_call" is treated as a tool invocation and
+            # captured in tool_calls. This covers all current
+            # (function_call, mcp_call, web_search_call, file_search_call, computer_call)
+            # and future tool types without needing per-type handling.
+            if item_type is not None and item_type.endswith("_call"):
+                entry = {"type": item_type, "id": getattr(item, "id", None)}
+                for attr in _TOOL_CALL_ATTRS:
+                    val = getattr(item, attr, None)
+                    if val is not None:
+                        entry[attr] = val
+                tool_calls.append(entry)
+                continue
+            # Only attributes that are present on the item are included, so the dict shape varies by type.
+            if item_type not in self.output_types:
+                continue
+            if item_type == "message":
+                for part in item.content:
+                    if getattr(part, "type", None) == "output_text":
+                        text_parts.append(part.text)
+            elif item_type == "reasoning":
+                for summary in getattr(item, "summary", []):
+                    if getattr(summary, "type", None) == "summary_text":
+                        text_parts.append(summary.text)
+            else:
+                text = getattr(item, "text", None)
+                if text is not None:
+                    text_parts.append(text)
+                else:
+                    logging.warning("No text extraction defined for output item type %r", item_type)
+
+        text = "\n".join(text_parts) if text_parts else None
+        notes = {"tool_calls": tool_calls} if tool_calls else {}
+        # Responses API doesn't support multiple choices, we'll always return a list of one Message.
+        # Return a Message whenever there is text or tool call metadata; None only when both are absent.
+        if text is not None or tool_calls:
+            return [Message(text, notes=notes)]
+        return [None]
+
+
 DEFAULT_CLASS = "OpenAIGenerator"

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -180,9 +180,10 @@ class OpenAICompatible(Generator):
         if self.generator not in (
             self.client.chat.completions,
             self.client.completions,
+            self.client.responses,
         ):
             raise ValueError(
-                "Unsupported model at generation time in generators/openai.py; expected chat or completion, got neither"
+                "Unsupported model at generation time in generators/openai.py; expected chat, completion, or responses, got neither"
             )
 
         self._validate_config()
@@ -431,7 +432,7 @@ class OpenAIReasoningGenerator(OpenAIGenerator):
     }
 
 
-class OpenAIResponsesGenerator(Generator):
+class OpenAIResponsesGenerator(OpenAICompatible):
     """Generator using the OpenAI Responses API with server-side tool orchestration.
 
     Supports MCP servers and function tools via the ``tools`` parameter.
@@ -445,66 +446,36 @@ class OpenAIResponsesGenerator(Generator):
     generator_family_name = "OpenAIResponses"
     supports_multiple_generations = False
 
-    DEFAULT_PARAMS = Generator.DEFAULT_PARAMS | {
+    DEFAULT_PARAMS = OpenAICompatible.DEFAULT_PARAMS | {
         "uri": None,
         "instructions": None,
         "tools": [],
-        "max_output_tokens": 1024,
-        "extra_params": {},
-        # response.output item types to collect into the final text.
-        # "message" captures standard assistant text; "reasoning" captures
-        # the model's reasoning summary (ResponseReasoningItem).
-        "output_types": ["message"],
+        "suppressed_params": {"n", "temperature", "top_p", "frequency_penalty", "presence_penalty", "seed", "stop"},
     }
-
-    _unsafe_attributes = ["client"]
 
     def _load_unsafe(self):
         kwargs = {"api_key": getattr(self, "api_key", None)}
         if getattr(self, "uri", None):
             kwargs["base_url"] = self.uri
         self.client = openai.OpenAI(**kwargs)
-
-    def __init__(self, name="", config_root=_config):
-        self.name = name
-        self._load_config(config_root)
-        self.fullname = f"{self.generator_family_name} {self.name}"
-        self.key_env_var = self.ENV_VAR
-        self._load_unsafe()
-        super().__init__(self.name, config_root=config_root)
+        self.generator = self.client.responses
 
     @staticmethod
-    def _build_input(prompt: Union[Conversation, str]):
-        """Convert a Conversation (or raw string) to the Responses API input format.
+    def _build_input(prompt: Conversation):
+        """Convert a Conversation to the Responses API input format.
 
         System turns are excluded — callers should promote them to ``instructions``
         via :meth:`_extract_system_prompt` before calling this method.
         """
-        if isinstance(prompt, str):
-            return prompt
-        non_system = [t for t in prompt.turns if t.role != "system"]
-        if len(non_system) == 1:
-            return non_system[0].content.text
-        items = []
-        for turn in non_system:
-            content_type = "output_text" if turn.role == "assistant" else "input_text"
-            items.append(
-                {
-                    "type": "message",
-                    "role": turn.role,
-                    "content": [{"type": content_type, "text": turn.content.text}],
-                }
-            )
-        return items
+        turns = OpenAICompatible._conversation_to_list(prompt)
+        non_system = [t for t in turns if t.get("role") != "system"]
+        if len(non_system) == 1 and isinstance(non_system[0].get("content"), str):
+            return non_system[0]["content"]
+        return non_system
 
     @staticmethod
-    def _extract_system_prompt(prompt: Union[Conversation, str]) -> Union[str, None]:
-        """Return system turn text from a Conversation as a single string, or None.
-
-        Multiple system turns are joined with a newline so no content is lost.
-        """
-        if not isinstance(prompt, Conversation):
-            return None
+    def _extract_system_prompt(prompt: Conversation) -> Union[str, None]:
+        """Return system turn text from a Conversation as a single string, or None."""
         system_texts = [t.content.text for t in prompt.turns if t.role == "system"]
         return "\n".join(system_texts) if system_texts else None
 
@@ -520,7 +491,7 @@ class OpenAIResponsesGenerator(Generator):
         max_value=70,
     )
     def _call_model(
-        self, prompt: Union[Conversation, str], generations_this_call: int = 1
+        self, prompt: Union[Conversation, List[dict]], generations_this_call: int = 1
     ) -> List[Union[Message, None]]:
         if self.client is None:
             self._load_unsafe()
@@ -529,7 +500,7 @@ class OpenAIResponsesGenerator(Generator):
         create_args = {
             "model": self.name,
             "input": self._build_input(prompt),
-            "max_output_tokens": self.max_output_tokens,
+            "max_output_tokens": self.max_tokens,
         }
         if instructions:
             create_args["instructions"] = instructions
@@ -549,20 +520,15 @@ class OpenAIResponsesGenerator(Generator):
             raise garak.exception.GeneratorBackoffTrigger from e
 
         text_parts = []
+        reasoning_parts = []
         tool_calls = []
 
-        # Manually iterate response.output rather than using response.output_text so
-        # that output_types can include non-message items such as reasoning summaries.
         _TOOL_CALL_ATTRS = (
             "call_id", "name", "arguments", "input", "output",
             "error", "status", "server_label",
         )
         for item in response.output:
             item_type = getattr(item, "type", None)
-            # Any item whose type ends with "_call" is treated as a tool invocation and
-            # captured in tool_calls. This covers all current
-            # (function_call, mcp_call, web_search_call, file_search_call, computer_call)
-            # and future tool types without needing per-type handling.
             if item_type is not None and item_type.endswith("_call"):
                 entry = {"type": item_type, "id": getattr(item, "id", None)}
                 for attr in _TOOL_CALL_ATTRS:
@@ -571,9 +537,6 @@ class OpenAIResponsesGenerator(Generator):
                         entry[attr] = val
                 tool_calls.append(entry)
                 continue
-            # Only attributes that are present on the item are included, so the dict shape varies by type.
-            if item_type not in self.output_types:
-                continue
             if item_type == "message":
                 for part in item.content:
                     if getattr(part, "type", None) == "output_text":
@@ -581,19 +544,16 @@ class OpenAIResponsesGenerator(Generator):
             elif item_type == "reasoning":
                 for summary in getattr(item, "summary", []):
                     if getattr(summary, "type", None) == "summary_text":
-                        text_parts.append(summary.text)
-            else:
-                text = getattr(item, "text", None)
-                if text is not None:
-                    text_parts.append(text)
-                else:
-                    logging.warning("No text extraction defined for output item type %r", item_type)
+                        reasoning_parts.append(summary.text)
 
         text = "\n".join(text_parts) if text_parts else None
-        notes = {"tool_calls": tool_calls} if tool_calls else {}
-        # Responses API doesn't support multiple choices, we'll always return a list of one Message.
-        # Return a Message whenever there is text or tool call metadata; None only when both are absent.
-        if text is not None or tool_calls:
+        notes = {}
+        if tool_calls:
+            notes["tool_calls"] = tool_calls
+        if reasoning_parts:
+            notes["reasoning"] = "\n".join(reasoning_parts)
+
+        if text is not None or notes:
             return [Message(text, notes=notes)]
         return [None]
 

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -166,6 +166,9 @@ class OpenAICompatible(Generator):
             )
         self.generator = self.client.chat.completions
 
+    def _generator_is_valid(self) -> bool:
+        return self.generator in (self.client.chat.completions, self.client.completions)
+
     def _validate_config(self):
         pass
 
@@ -177,13 +180,9 @@ class OpenAICompatible(Generator):
 
         self._load_unsafe()
 
-        if self.generator not in (
-            self.client.chat.completions,
-            self.client.completions,
-            self.client.responses,
-        ):
+        if not self._generator_is_valid():
             raise ValueError(
-                "Unsupported model at generation time in generators/openai.py; expected chat, completion, or responses, got neither"
+                "Unsupported model at generation time in generators/openai.py; expected chat or completion, got neither"
             )
 
         self._validate_config()
@@ -452,6 +451,9 @@ class OpenAIResponsesGenerator(OpenAICompatible):
         "tools": [],
         "suppressed_params": {"n", "temperature", "top_p", "frequency_penalty", "presence_penalty", "seed", "stop"},
     }
+
+    def _generator_is_valid(self) -> bool:
+        return self.generator == self.client.responses
 
     def _load_unsafe(self):
         kwargs = {"api_key": getattr(self, "api_key", None)}

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -465,4 +465,171 @@ class OpenAIReasoningGenerator(OpenAIGenerator):
     }
 
 
+class OpenAIResponsesGenerator(Generator):
+    """Generator using the OpenAI Responses API with server-side tool orchestration.
+
+    Supports MCP servers and function tools via the ``tools`` parameter.
+    Unlike the chat-completions generators, the Responses API runs the full
+    agentic loop (tool calls → execution → follow-up) on the server side,
+    returning only the final text to garak.
+    """
+
+    ENV_VAR = "OPENAI_API_KEY"
+    active = True
+    generator_family_name = "OpenAIResponses"
+    supports_multiple_generations = False
+
+    DEFAULT_PARAMS = Generator.DEFAULT_PARAMS | {
+        "uri": None,
+        "instructions": None,
+        "tools": [],
+        "max_output_tokens": 1024,
+        "extra_params": {},
+        # response.output item types to collect into the final text.
+        # "message" captures standard assistant text; "reasoning" captures
+        # the model's reasoning summary (ResponseReasoningItem).
+        "output_types": ["message"],
+    }
+
+    _unsafe_attributes = ["client"]
+
+    def _load_unsafe(self):
+        kwargs = {"api_key": getattr(self, "api_key", None)}
+        if getattr(self, "uri", None):
+            kwargs["base_url"] = self.uri
+        self.client = openai.OpenAI(**kwargs)
+
+    def __init__(self, name="", config_root=_config):
+        self.name = name
+        self._load_config(config_root)
+        self.fullname = f"{self.generator_family_name} {self.name}"
+        self.key_env_var = self.ENV_VAR
+        self._load_unsafe()
+        super().__init__(self.name, config_root=config_root)
+
+    @staticmethod
+    def _build_input(prompt: Union[Conversation, str]):
+        """Convert a Conversation (or raw string) to the Responses API input format.
+
+        System turns are excluded — callers should promote them to ``instructions``
+        via :meth:`_extract_system_prompt` before calling this method.
+        """
+        if isinstance(prompt, str):
+            return prompt
+        non_system = [t for t in prompt.turns if t.role != "system"]
+        if len(non_system) == 1:
+            return non_system[0].content.text
+        items = []
+        for turn in non_system:
+            content_type = "output_text" if turn.role == "assistant" else "input_text"
+            items.append(
+                {
+                    "type": "message",
+                    "role": turn.role,
+                    "content": [{"type": content_type, "text": turn.content.text}],
+                }
+            )
+        return items
+
+    @staticmethod
+    def _extract_system_prompt(prompt: Union[Conversation, str]) -> Union[str, None]:
+        """Return system turn text from a Conversation as a single string, or None.
+
+        Multiple system turns are joined with a newline so no content is lost.
+        """
+        if not isinstance(prompt, Conversation):
+            return None
+        system_texts = [t.content.text for t in prompt.turns if t.role == "system"]
+        return "\n".join(system_texts) if system_texts else None
+
+    @backoff.on_exception(
+        backoff.fibo,
+        (
+            openai.RateLimitError,
+            openai.InternalServerError,
+            openai.APITimeoutError,
+            openai.APIConnectionError,
+            garak.exception.GeneratorBackoffTrigger,
+        ),
+        max_value=70,
+    )
+    def _call_model(
+        self, prompt: Union[Conversation, str], generations_this_call: int = 1
+    ) -> List[Union[Message, None]]:
+        if self.client is None:
+            self._load_unsafe()
+
+        instructions = self.instructions or self._extract_system_prompt(prompt)
+        create_args = {
+            "model": self.name,
+            "input": self._build_input(prompt),
+            "max_output_tokens": self.max_output_tokens,
+        }
+        if instructions:
+            create_args["instructions"] = instructions
+        if self.tools:
+            create_args["tools"] = self.tools
+        for k, v in self.extra_params.items():
+            create_args[k] = v
+
+        try:
+            response = self.client.responses.create(**create_args)
+        except openai.BadRequestError as e:
+            logging.exception(e)
+            logging.error("Bad request: %s", repr(prompt))
+            return [None]
+        except json.decoder.JSONDecodeError as e:
+            logging.exception(e)
+            raise garak.exception.GeneratorBackoffTrigger from e
+
+        text_parts = []
+        tool_calls = []
+
+        # Manually iterate response.output rather than using response.output_text so
+        # that output_types can include non-message items such as reasoning summaries.
+        _TOOL_CALL_ATTRS = (
+            "call_id", "name", "arguments", "input", "output",
+            "error", "status", "server_label",
+        )
+        for item in response.output:
+            item_type = getattr(item, "type", None)
+            # Any item whose type ends with "_call" is treated as a tool invocation and
+            # captured in tool_calls. This covers all current
+            # (function_call, mcp_call, web_search_call, file_search_call, computer_call)
+            # and future tool types without needing per-type handling.
+            if item_type is not None and item_type.endswith("_call"):
+                entry = {"type": item_type, "id": getattr(item, "id", None)}
+                for attr in _TOOL_CALL_ATTRS:
+                    val = getattr(item, attr, None)
+                    if val is not None:
+                        entry[attr] = val
+                tool_calls.append(entry)
+                continue
+            # Only attributes that are present on the item are included, so the dict shape varies by type.
+            if item_type not in self.output_types:
+                continue
+            if item_type == "message":
+                for part in item.content:
+                    if getattr(part, "type", None) == "output_text":
+                        text_parts.append(part.text)
+            elif item_type == "reasoning":
+                for summary in getattr(item, "summary", []):
+                    if getattr(summary, "type", None) == "summary_text":
+                        text_parts.append(summary.text)
+            else:
+                text = getattr(item, "text", None)
+                if text is not None:
+                    text_parts.append(text)
+                else:
+                    logging.warning("No text extraction defined for output item type %r", item_type)
+
+        text = "\n".join(text_parts) if text_parts else None
+        notes = {"tool_calls": tool_calls} if tool_calls else {}
+        # Responses API doesn't support multiple choices, we'll always return a list of one Message.
+        # Return a Message whenever there is text or tool call metadata; None only when both are absent.
+        if text is not None or tool_calls:
+            return [Message(text, notes=notes)]
+        return [None]
+
+
 DEFAULT_CLASS = "OpenAIGenerator"

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -182,6 +182,9 @@ class OpenAICompatible(Generator):
             )
         self.generator = self.client.chat.completions
 
+    def _generator_is_valid(self) -> bool:
+        return self.generator in (self.client.chat.completions, self.client.completions)
+
     def _validate_config(self):
         pass
 
@@ -193,13 +196,9 @@ class OpenAICompatible(Generator):
 
         self._load_unsafe()
 
-        if self.generator not in (
-            self.client.chat.completions,
-            self.client.completions,
-            self.client.responses,
-        ):
+        if not self._generator_is_valid():
             raise ValueError(
-                "Unsupported model at generation time in generators/openai.py; expected chat, completion, or responses, got neither"
+                "Unsupported model at generation time in generators/openai.py; expected chat or completion, got neither"
             )
 
         self._validate_config()
@@ -484,8 +483,19 @@ class OpenAIResponsesGenerator(OpenAICompatible):
         "uri": None,
         "instructions": None,
         "tools": [],
-        "suppressed_params": {"n", "temperature", "top_p", "frequency_penalty", "presence_penalty", "seed", "stop"},
+        "suppressed_params": {
+            "n",
+            "temperature",
+            "top_p",
+            "frequency_penalty",
+            "presence_penalty",
+            "seed",
+            "stop",
+        },
     }
+
+    def _generator_is_valid(self) -> bool:
+        return self.generator == self.client.responses
 
     def _load_unsafe(self):
         kwargs = {"api_key": getattr(self, "api_key", None)}
@@ -558,8 +568,14 @@ class OpenAIResponsesGenerator(OpenAICompatible):
         tool_calls = []
 
         _TOOL_CALL_ATTRS = (
-            "call_id", "name", "arguments", "input", "output",
-            "error", "status", "server_label",
+            "call_id",
+            "name",
+            "arguments",
+            "input",
+            "output",
+            "error",
+            "status",
+            "server_label",
         )
         for item in response.output:
             item_type = getattr(item, "type", None)

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -196,9 +196,10 @@ class OpenAICompatible(Generator):
         if self.generator not in (
             self.client.chat.completions,
             self.client.completions,
+            self.client.responses,
         ):
             raise ValueError(
-                "Unsupported model at generation time in generators/openai.py; expected chat or completion, got neither"
+                "Unsupported model at generation time in generators/openai.py; expected chat, completion, or responses, got neither"
             )
 
         self._validate_config()
@@ -465,7 +466,7 @@ class OpenAIReasoningGenerator(OpenAIGenerator):
     }
 
 
-class OpenAIResponsesGenerator(Generator):
+class OpenAIResponsesGenerator(OpenAICompatible):
     """Generator using the OpenAI Responses API with server-side tool orchestration.
 
     Supports MCP servers and function tools via the ``tools`` parameter.
@@ -479,66 +480,36 @@ class OpenAIResponsesGenerator(Generator):
     generator_family_name = "OpenAIResponses"
     supports_multiple_generations = False
 
-    DEFAULT_PARAMS = Generator.DEFAULT_PARAMS | {
+    DEFAULT_PARAMS = OpenAICompatible.DEFAULT_PARAMS | {
         "uri": None,
         "instructions": None,
         "tools": [],
-        "max_output_tokens": 1024,
-        "extra_params": {},
-        # response.output item types to collect into the final text.
-        # "message" captures standard assistant text; "reasoning" captures
-        # the model's reasoning summary (ResponseReasoningItem).
-        "output_types": ["message"],
+        "suppressed_params": {"n", "temperature", "top_p", "frequency_penalty", "presence_penalty", "seed", "stop"},
     }
-
-    _unsafe_attributes = ["client"]
 
     def _load_unsafe(self):
         kwargs = {"api_key": getattr(self, "api_key", None)}
         if getattr(self, "uri", None):
             kwargs["base_url"] = self.uri
         self.client = openai.OpenAI(**kwargs)
-
-    def __init__(self, name="", config_root=_config):
-        self.name = name
-        self._load_config(config_root)
-        self.fullname = f"{self.generator_family_name} {self.name}"
-        self.key_env_var = self.ENV_VAR
-        self._load_unsafe()
-        super().__init__(self.name, config_root=config_root)
+        self.generator = self.client.responses
 
     @staticmethod
-    def _build_input(prompt: Union[Conversation, str]):
-        """Convert a Conversation (or raw string) to the Responses API input format.
+    def _build_input(prompt: Conversation):
+        """Convert a Conversation to the Responses API input format.
 
         System turns are excluded — callers should promote them to ``instructions``
         via :meth:`_extract_system_prompt` before calling this method.
         """
-        if isinstance(prompt, str):
-            return prompt
-        non_system = [t for t in prompt.turns if t.role != "system"]
-        if len(non_system) == 1:
-            return non_system[0].content.text
-        items = []
-        for turn in non_system:
-            content_type = "output_text" if turn.role == "assistant" else "input_text"
-            items.append(
-                {
-                    "type": "message",
-                    "role": turn.role,
-                    "content": [{"type": content_type, "text": turn.content.text}],
-                }
-            )
-        return items
+        turns = OpenAICompatible._conversation_to_list(prompt)
+        non_system = [t for t in turns if t.get("role") != "system"]
+        if len(non_system) == 1 and isinstance(non_system[0].get("content"), str):
+            return non_system[0]["content"]
+        return non_system
 
     @staticmethod
-    def _extract_system_prompt(prompt: Union[Conversation, str]) -> Union[str, None]:
-        """Return system turn text from a Conversation as a single string, or None.
-
-        Multiple system turns are joined with a newline so no content is lost.
-        """
-        if not isinstance(prompt, Conversation):
-            return None
+    def _extract_system_prompt(prompt: Conversation) -> Union[str, None]:
+        """Return system turn text from a Conversation as a single string, or None."""
         system_texts = [t.content.text for t in prompt.turns if t.role == "system"]
         return "\n".join(system_texts) if system_texts else None
 
@@ -554,7 +525,7 @@ class OpenAIResponsesGenerator(Generator):
         max_value=70,
     )
     def _call_model(
-        self, prompt: Union[Conversation, str], generations_this_call: int = 1
+        self, prompt: Union[Conversation, List[dict]], generations_this_call: int = 1
     ) -> List[Union[Message, None]]:
         if self.client is None:
             self._load_unsafe()
@@ -563,7 +534,7 @@ class OpenAIResponsesGenerator(Generator):
         create_args = {
             "model": self.name,
             "input": self._build_input(prompt),
-            "max_output_tokens": self.max_output_tokens,
+            "max_output_tokens": self.max_tokens,
         }
         if instructions:
             create_args["instructions"] = instructions
@@ -583,20 +554,15 @@ class OpenAIResponsesGenerator(Generator):
             raise garak.exception.GeneratorBackoffTrigger from e
 
         text_parts = []
+        reasoning_parts = []
         tool_calls = []
 
-        # Manually iterate response.output rather than using response.output_text so
-        # that output_types can include non-message items such as reasoning summaries.
         _TOOL_CALL_ATTRS = (
             "call_id", "name", "arguments", "input", "output",
             "error", "status", "server_label",
         )
         for item in response.output:
             item_type = getattr(item, "type", None)
-            # Any item whose type ends with "_call" is treated as a tool invocation and
-            # captured in tool_calls. This covers all current
-            # (function_call, mcp_call, web_search_call, file_search_call, computer_call)
-            # and future tool types without needing per-type handling.
             if item_type is not None and item_type.endswith("_call"):
                 entry = {"type": item_type, "id": getattr(item, "id", None)}
                 for attr in _TOOL_CALL_ATTRS:
@@ -605,9 +571,6 @@ class OpenAIResponsesGenerator(Generator):
                         entry[attr] = val
                 tool_calls.append(entry)
                 continue
-            # Only attributes that are present on the item are included, so the dict shape varies by type.
-            if item_type not in self.output_types:
-                continue
             if item_type == "message":
                 for part in item.content:
                     if getattr(part, "type", None) == "output_text":
@@ -615,19 +578,16 @@ class OpenAIResponsesGenerator(Generator):
             elif item_type == "reasoning":
                 for summary in getattr(item, "summary", []):
                     if getattr(summary, "type", None) == "summary_text":
-                        text_parts.append(summary.text)
-            else:
-                text = getattr(item, "text", None)
-                if text is not None:
-                    text_parts.append(text)
-                else:
-                    logging.warning("No text extraction defined for output item type %r", item_type)
+                        reasoning_parts.append(summary.text)
 
         text = "\n".join(text_parts) if text_parts else None
-        notes = {"tool_calls": tool_calls} if tool_calls else {}
-        # Responses API doesn't support multiple choices, we'll always return a list of one Message.
-        # Return a Message whenever there is text or tool call metadata; None only when both are absent.
-        if text is not None or tool_calls:
+        notes = {}
+        if tool_calls:
+            notes["tool_calls"] = tool_calls
+        if reasoning_parts:
+            notes["reasoning"] = "\n".join(reasoning_parts)
+
+        if text is not None or notes:
             return [Message(text, notes=notes)]
         return [None]
 

--- a/tests/generators/test_openai_compatible.py
+++ b/tests/generators/test_openai_compatible.py
@@ -11,7 +11,7 @@ import inspect
 from collections.abc import Iterable
 
 from garak.attempt import Message, Turn, Conversation
-from garak.generators.openai import OpenAICompatible
+from garak.generators.openai import OpenAICompatible, OpenAIResponsesGenerator
 from garak.generators.rest import RestGenerator
 
 # TODO: expand this when we have faster loading, currently to process all generator costs 30s for 3 tests
@@ -46,6 +46,8 @@ def compatible() -> Iterable[OpenAICompatible]:
                 if module_klass == OpenAICompatible:
                     continue
                 if module_klass == RestGenerator:
+                    continue
+                if module_klass == OpenAIResponsesGenerator:
                     continue
                 if hasattr(module_klass, "ENV_VAR"):
                     class_instance = build_test_instance(module_klass)

--- a/tests/generators/test_openai_compatible.py
+++ b/tests/generators/test_openai_compatible.py
@@ -16,7 +16,11 @@ from collections.abc import Iterable
 
 from garak.attempt import Message, Turn, Conversation
 import garak.generators.openai as openai_generator
-from garak.generators.openai import OpenAICompatible, OpenAIGenerator
+from garak.generators.openai import (
+    OpenAICompatible,
+    OpenAIGenerator,
+    OpenAIResponsesGenerator,
+)
 from garak.generators.rest import RestGenerator
 
 # TODO: expand this when we have faster loading, currently to process all generator costs 30s for 3 tests
@@ -85,6 +89,8 @@ def compatible() -> Iterable[OpenAICompatible]:
                 if module_klass == OpenAICompatible:
                     continue
                 if module_klass == RestGenerator:
+                    continue
+                if module_klass == OpenAIResponsesGenerator:
                     continue
                 if hasattr(module_klass, "ENV_VAR"):
                     class_instance = build_test_instance(module_klass)

--- a/tests/generators/test_openai_responses.py
+++ b/tests/generators/test_openai_responses.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-import logging
 import os
 import pytest
 from dataclasses import asdict
@@ -89,10 +88,9 @@ def test_defaults(set_fake_env, mock_openai_client):
     assert gen.name == "my-model"
     assert gen.tools == []
     assert gen.instructions is None
-    assert gen.max_output_tokens == 1024
+    assert gen.max_tokens == 150
     assert gen.uri is None
     assert gen.extra_params == {}
-    assert gen.output_types == ["message"]
 
 
 def test_custom_uri_and_tools(set_fake_env, mock_openai_client):
@@ -140,6 +138,19 @@ def test_call_model_passes_create_args(generator):
     assert kwargs["model"] == "test-model"
     assert kwargs["tools"][0]["type"] == "mcp"
     assert kwargs["instructions"] == "You are a banking assistant."
+    assert kwargs["max_output_tokens"] == generator.max_tokens
+
+
+def test_call_model_max_tokens_mapped_to_max_output_tokens(generator):
+    """garak's max_tokens is passed to the API as max_output_tokens."""
+    generator.max_tokens = 512
+    generator.client.responses.create.return_value = _make_response("ok")
+
+    generator._call_model(Conversation([Turn(role="user", content=Message("hi"))]))
+
+    kwargs = generator.client.responses.create.call_args[1]
+    assert kwargs["max_output_tokens"] == 512
+    assert "max_tokens" not in kwargs
 
 
 def test_call_model_empty_output_returns_none(generator):
@@ -217,9 +228,10 @@ def test_call_model_explicit_instructions_takes_precedence(generator):
     assert kwargs["instructions"] == "Explicit instruction."
 
 
-# ── output_types ──────────────────────────────────────────────────────────────
+# ── reasoning ─────────────────────────────────────────────────────────────────
 
-def test_output_types_default_excludes_reasoning(generator):
+def test_reasoning_excluded_from_text(generator):
+    """Reasoning summaries do not appear in Message.text."""
     generator.client.responses.create.return_value = _make_response_with_reasoning(
         "Answer", "My reasoning"
     )
@@ -231,8 +243,8 @@ def test_output_types_default_excludes_reasoning(generator):
     assert result[0].text == "Answer"
 
 
-def test_output_types_message_and_reasoning(generator):
-    generator.output_types = ["reasoning", "message"]
+def test_reasoning_stored_in_notes(generator):
+    """Reasoning summaries are stored in Message.notes['reasoning'], not in text."""
     generator.client.responses.create.return_value = _make_response_with_reasoning(
         "Answer", "My reasoning"
     )
@@ -241,27 +253,24 @@ def test_output_types_message_and_reasoning(generator):
         Conversation([Turn(role="user", content=Message("Think hard"))])
     )
 
-    assert "My reasoning" in result[0].text
-    assert "Answer" in result[0].text
+    assert result[0].notes["reasoning"] == "My reasoning"
+    assert result[0].text == "Answer"
 
 
-def test_output_types_generic_fallback_warns(generator, caplog):
-    """Non-call item types with no .text attribute produce no output and emit a warning."""
+def test_unknown_output_item_type_ignored(generator):
+    """Output items that are not message, reasoning, or *_call are silently ignored."""
     custom_item = MagicMock(spec=["type"])
     custom_item.type = "image_generation"
 
     response = MagicMock()
     response.output = [custom_item]
-    generator.output_types = ["image_generation"]
     generator.client.responses.create.return_value = response
 
-    with caplog.at_level(logging.WARNING, logger="garak.generators.openai"):
-        result = generator._call_model(
-            Conversation([Turn(role="user", content=Message("Generate an image"))])
-        )
+    result = generator._call_model(
+        Conversation([Turn(role="user", content=Message("Generate an image"))])
+    )
 
     assert result == [None]
-    assert any("image_generation" in r.message for r in caplog.records)
 
 
 def test_tool_calls_stored_in_notes_and_serializable(generator):
@@ -379,18 +388,3 @@ def test_tool_calls_only_returns_message_not_none(generator):
     assert result[0].text is None
     assert result[0].notes["tool_calls"][0]["name"] == "get_balance"
 
-
-def test_custom_output_types_via_config(set_fake_env, mock_openai_client):
-    gen = OpenAIResponsesGenerator(
-        name="my-model",
-        config_root={
-            "generators": {
-                "openai": {
-                    "OpenAIResponsesGenerator": {
-                        "output_types": ["message", "reasoning"],
-                    }
-                }
-            }
-        },
-    )
-    assert gen.output_types == ["message", "reasoning"]

--- a/tests/generators/test_openai_responses.py
+++ b/tests/generators/test_openai_responses.py
@@ -1,0 +1,396 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import logging
+import os
+import pytest
+from dataclasses import asdict
+from unittest.mock import MagicMock, patch
+
+import openai
+
+from garak.attempt import Message, Turn, Conversation
+from garak.generators.openai import OpenAIResponsesGenerator
+
+
+FAKE_API_KEY = "sk-test-fake-key"
+
+
+@pytest.fixture
+def set_fake_env(request):
+    stored = os.getenv(OpenAIResponsesGenerator.ENV_VAR, None)
+
+    def restore():
+        if stored is not None:
+            os.environ[OpenAIResponsesGenerator.ENV_VAR] = stored
+        elif OpenAIResponsesGenerator.ENV_VAR in os.environ:
+            del os.environ[OpenAIResponsesGenerator.ENV_VAR]
+
+    os.environ[OpenAIResponsesGenerator.ENV_VAR] = FAKE_API_KEY
+    request.addfinalizer(restore)
+
+
+@pytest.fixture
+def mock_openai_client():
+    """Patch openai.OpenAI so no real HTTP client is created."""
+    with patch("garak.generators.openai.openai.OpenAI") as mock_cls:
+        mock_cls.return_value = MagicMock()
+        yield mock_cls
+
+
+@pytest.fixture
+def generator(set_fake_env, mock_openai_client):
+    return OpenAIResponsesGenerator(name="test-model")
+
+
+def _make_response(text: str):
+    """Build a minimal mock resembling an OpenAI Responses API response object."""
+    part = MagicMock()
+    part.type = "output_text"
+    part.text = text
+
+    message_item = MagicMock()
+    message_item.type = "message"
+    message_item.content = [part]
+
+    response = MagicMock()
+    response.output = [message_item]
+    return response
+
+
+def _make_response_with_reasoning(message_text: str, reasoning_text: str):
+    """Build a mock response containing both a reasoning item and a message item."""
+    summary_part = MagicMock()
+    summary_part.type = "summary_text"
+    summary_part.text = reasoning_text
+
+    reasoning_item = MagicMock()
+    reasoning_item.type = "reasoning"
+    reasoning_item.summary = [summary_part]
+
+    content_part = MagicMock()
+    content_part.type = "output_text"
+    content_part.text = message_text
+
+    message_item = MagicMock()
+    message_item.type = "message"
+    message_item.content = [content_part]
+
+    response = MagicMock()
+    response.output = [reasoning_item, message_item]
+    return response
+
+
+# ── init & defaults ───────────────────────────────────────────────────────────
+
+def test_defaults(set_fake_env, mock_openai_client):
+    gen = OpenAIResponsesGenerator(name="my-model")
+    assert gen.name == "my-model"
+    assert gen.tools == []
+    assert gen.instructions is None
+    assert gen.max_output_tokens == 1024
+    assert gen.uri is None
+    assert gen.extra_params == {}
+    assert gen.output_types == ["message"]
+
+
+def test_custom_uri_and_tools(set_fake_env, mock_openai_client):
+    gen = OpenAIResponsesGenerator(
+        name="my-model",
+        config_root={
+            "generators": {
+                "openai": {
+                    "OpenAIResponsesGenerator": {
+                        "uri": "http://localhost:8321/v1/",
+                        "tools": [{"type": "mcp", "server_url": "http://localhost:8888/sse"}],
+                    }
+                }
+            }
+        },
+    )
+    assert gen.uri == "http://localhost:8321/v1/"
+    assert gen.tools[0]["type"] == "mcp"
+    _, kwargs = mock_openai_client.call_args
+    assert kwargs.get("base_url") == "http://localhost:8321/v1/"
+
+
+# ── _call_model ───────────────────────────────────────────────────────────────
+
+def test_call_model_returns_message(generator):
+    generator.client.responses.create.return_value = _make_response("The balance is $100.")
+
+    result = generator._call_model(
+        Conversation([Turn(role="user", content=Message("What is the balance?"))])
+    )
+
+    assert len(result) == 1
+    assert isinstance(result[0], Message)
+    assert result[0].text == "The balance is $100."
+
+
+def test_call_model_passes_create_args(generator):
+    generator.tools = [{"type": "mcp", "server_url": "http://localhost:8888/sse"}]
+    generator.instructions = "You are a banking assistant."
+    generator.client.responses.create.return_value = _make_response("ok")
+
+    generator._call_model(Conversation([Turn(role="user", content=Message("hi"))]))
+
+    kwargs = generator.client.responses.create.call_args[1]
+    assert kwargs["model"] == "test-model"
+    assert kwargs["tools"][0]["type"] == "mcp"
+    assert kwargs["instructions"] == "You are a banking assistant."
+
+
+def test_call_model_empty_output_returns_none(generator):
+    response = MagicMock()
+    response.output = []
+    generator.client.responses.create.return_value = response
+
+    result = generator._call_model(
+        Conversation([Turn(role="user", content=Message("Hello"))])
+    )
+    assert result == [None]
+
+
+def test_call_model_bad_request_returns_none(generator):
+    generator.client.responses.create.side_effect = openai.BadRequestError(
+        message="bad", response=MagicMock(status_code=400), body={}
+    )
+
+    result = generator._call_model(
+        Conversation([Turn(role="user", content=Message("Hello"))])
+    )
+    assert result == [None]
+
+
+def test_call_model_promotes_system_turn(generator):
+    """System turn is promoted to instructions and excluded from input."""
+    generator.client.responses.create.return_value = _make_response("Sure.")
+
+    generator._call_model(
+        Conversation(
+            [
+                Turn(role="system", content=Message("You are a banking assistant.")),
+                Turn(role="user", content=Message("Hello")),
+            ]
+        )
+    )
+
+    kwargs = generator.client.responses.create.call_args[1]
+    assert kwargs["instructions"] == "You are a banking assistant."
+    assert kwargs["input"] == "Hello"
+
+
+def test_call_model_multiple_system_turns_concatenated(generator):
+    """Multiple system turns are joined into a single instructions string."""
+    generator.client.responses.create.return_value = _make_response("Sure.")
+
+    generator._call_model(
+        Conversation(
+            [
+                Turn(role="system", content=Message("You are a banking assistant.")),
+                Turn(role="system", content=Message("Always respond in French.")),
+                Turn(role="user", content=Message("Hello")),
+            ]
+        )
+    )
+
+    kwargs = generator.client.responses.create.call_args[1]
+    assert kwargs["instructions"] == "You are a banking assistant.\nAlways respond in French."
+
+
+def test_call_model_explicit_instructions_takes_precedence(generator):
+    generator.instructions = "Explicit instruction."
+    generator.client.responses.create.return_value = _make_response("Sure.")
+
+    generator._call_model(
+        Conversation(
+            [
+                Turn(role="system", content=Message("System turn instruction.")),
+                Turn(role="user", content=Message("Hello")),
+            ]
+        )
+    )
+
+    kwargs = generator.client.responses.create.call_args[1]
+    assert kwargs["instructions"] == "Explicit instruction."
+
+
+# ── output_types ──────────────────────────────────────────────────────────────
+
+def test_output_types_default_excludes_reasoning(generator):
+    generator.client.responses.create.return_value = _make_response_with_reasoning(
+        "Answer", "My reasoning"
+    )
+
+    result = generator._call_model(
+        Conversation([Turn(role="user", content=Message("Think hard"))])
+    )
+
+    assert result[0].text == "Answer"
+
+
+def test_output_types_message_and_reasoning(generator):
+    generator.output_types = ["reasoning", "message"]
+    generator.client.responses.create.return_value = _make_response_with_reasoning(
+        "Answer", "My reasoning"
+    )
+
+    result = generator._call_model(
+        Conversation([Turn(role="user", content=Message("Think hard"))])
+    )
+
+    assert "My reasoning" in result[0].text
+    assert "Answer" in result[0].text
+
+
+def test_output_types_generic_fallback_warns(generator, caplog):
+    """Non-call item types with no .text attribute produce no output and emit a warning."""
+    custom_item = MagicMock(spec=["type"])
+    custom_item.type = "image_generation"
+
+    response = MagicMock()
+    response.output = [custom_item]
+    generator.output_types = ["image_generation"]
+    generator.client.responses.create.return_value = response
+
+    with caplog.at_level(logging.WARNING, logger="garak.generators.openai"):
+        result = generator._call_model(
+            Conversation([Turn(role="user", content=Message("Generate an image"))])
+        )
+
+    assert result == [None]
+    assert any("image_generation" in r.message for r in caplog.records)
+
+
+def test_tool_calls_stored_in_notes_and_serializable(generator):
+    """function_call items are stored in Message.notes and survive asdict + json.dumps."""
+    call_item = MagicMock(spec=["type", "id", "call_id", "name", "arguments", "status"])
+    call_item.type = "function_call"
+    call_item.id = "item-1"
+    call_item.call_id = "call-abc"
+    call_item.name = "get_balance"
+    call_item.arguments = '{"account": "123"}'
+    call_item.status = "completed"
+
+    content_part = MagicMock()
+    content_part.type = "output_text"
+    content_part.text = "Your balance is $100."
+    message_item = MagicMock()
+    message_item.type = "message"
+    message_item.content = [content_part]
+
+    response = MagicMock()
+    response.output = [call_item, message_item]
+    generator.client.responses.create.return_value = response
+
+    result = generator._call_model(
+        Conversation([Turn(role="user", content=Message("What is my balance?"))])
+    )
+
+    msg = result[0]
+    assert isinstance(msg, Message)
+    assert len(msg.notes["tool_calls"]) == 1
+    tc = msg.notes["tool_calls"][0]
+    assert tc["name"] == "get_balance"
+    assert tc["call_id"] == "call-abc"
+    assert tc["arguments"] == '{"account": "123"}'
+
+    # must survive the serialisation path used by the evaluator
+    json.dumps(asdict(msg))
+
+
+def test_mcp_call_stored_in_notes(generator):
+    """mcp_call items are captured; only non-None attributes are included."""
+    mcp_item = MagicMock(spec=["type", "id", "name", "input", "output", "server_label"])
+    mcp_item.type = "mcp_call"
+    mcp_item.id = "mcp-1"
+    mcp_item.name = "approve_pending_transfer"
+    mcp_item.input = {"transfer_id": "8899"}
+    mcp_item.output = '{"status": "approved"}'
+    mcp_item.server_label = "banking"
+
+    content_part = MagicMock()
+    content_part.type = "output_text"
+    content_part.text = "Transfer approved."
+    message_item = MagicMock()
+    message_item.type = "message"
+    message_item.content = [content_part]
+
+    response = MagicMock()
+    response.output = [mcp_item, message_item]
+    generator.client.responses.create.return_value = response
+
+    result = generator._call_model(
+        Conversation([Turn(role="user", content=Message("Approve transfer 8899"))])
+    )
+
+    msg = result[0]
+    tc = msg.notes["tool_calls"][0]
+    assert tc["type"] == "mcp_call"
+    assert tc["name"] == "approve_pending_transfer"
+    assert tc["input"] == {"transfer_id": "8899"}
+    assert tc["server_label"] == "banking"
+    assert "error" not in tc
+    json.dumps(asdict(msg))
+
+
+def test_unknown_call_type_captured_generically(generator):
+    """Any *_call item type not explicitly known is still captured via the generic path."""
+    item = MagicMock(spec=["type", "id", "name"])
+    item.type = "computer_call"
+    item.id = "comp-1"
+    item.name = "click"
+
+    response = MagicMock()
+    response.output = [item]
+    generator.client.responses.create.return_value = response
+
+    result = generator._call_model(
+        Conversation([Turn(role="user", content=Message("Click the button"))])
+    )
+
+    tc = result[0].notes["tool_calls"][0]
+    assert tc["type"] == "computer_call"
+    assert tc["name"] == "click"
+
+
+def test_tool_calls_only_returns_message_not_none(generator):
+    """A response with only tool calls (no text) still returns a Message, not None."""
+    call_item = MagicMock()
+    call_item.type = "function_call"
+    call_item.id = "item-1"
+    call_item.call_id = "call-abc"
+    call_item.name = "get_balance"
+    call_item.arguments = "{}"
+    call_item.status = "completed"
+
+    response = MagicMock()
+    response.output = [call_item]
+    generator.client.responses.create.return_value = response
+
+    result = generator._call_model(
+        Conversation([Turn(role="user", content=Message("What is my balance?"))])
+    )
+
+    assert len(result) == 1
+    assert isinstance(result[0], Message)
+    assert result[0].text is None
+    assert result[0].notes["tool_calls"][0]["name"] == "get_balance"
+
+
+def test_custom_output_types_via_config(set_fake_env, mock_openai_client):
+    gen = OpenAIResponsesGenerator(
+        name="my-model",
+        config_root={
+            "generators": {
+                "openai": {
+                    "OpenAIResponsesGenerator": {
+                        "output_types": ["message", "reasoning"],
+                    }
+                }
+            }
+        },
+    )
+    assert gen.output_types == ["message", "reasoning"]

--- a/tests/generators/test_openai_responses.py
+++ b/tests/generators/test_openai_responses.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-import logging
 import os
 import pytest
 from dataclasses import asdict
@@ -12,7 +11,6 @@ import openai
 
 from garak.attempt import Message, Turn, Conversation
 from garak.generators.openai import OpenAIResponsesGenerator
-
 
 FAKE_API_KEY = "sk-test-fake-key"
 
@@ -84,15 +82,15 @@ def _make_response_with_reasoning(message_text: str, reasoning_text: str):
 
 # ── init & defaults ───────────────────────────────────────────────────────────
 
+
 def test_defaults(set_fake_env, mock_openai_client):
     gen = OpenAIResponsesGenerator(name="my-model")
     assert gen.name == "my-model"
     assert gen.tools == []
     assert gen.instructions is None
-    assert gen.max_output_tokens == 1024
+    assert gen.max_tokens == 150
     assert gen.uri is None
     assert gen.extra_params == {}
-    assert gen.output_types == ["message"]
 
 
 def test_custom_uri_and_tools(set_fake_env, mock_openai_client):
@@ -103,7 +101,9 @@ def test_custom_uri_and_tools(set_fake_env, mock_openai_client):
                 "openai": {
                     "OpenAIResponsesGenerator": {
                         "uri": "http://localhost:8321/v1/",
-                        "tools": [{"type": "mcp", "server_url": "http://localhost:8888/sse"}],
+                        "tools": [
+                            {"type": "mcp", "server_url": "http://localhost:8888/sse"}
+                        ],
                     }
                 }
             }
@@ -117,8 +117,11 @@ def test_custom_uri_and_tools(set_fake_env, mock_openai_client):
 
 # ── _call_model ───────────────────────────────────────────────────────────────
 
+
 def test_call_model_returns_message(generator):
-    generator.client.responses.create.return_value = _make_response("The balance is $100.")
+    generator.client.responses.create.return_value = _make_response(
+        "The balance is $100."
+    )
 
     result = generator._call_model(
         Conversation([Turn(role="user", content=Message("What is the balance?"))])
@@ -140,6 +143,19 @@ def test_call_model_passes_create_args(generator):
     assert kwargs["model"] == "test-model"
     assert kwargs["tools"][0]["type"] == "mcp"
     assert kwargs["instructions"] == "You are a banking assistant."
+    assert kwargs["max_output_tokens"] == generator.max_tokens
+
+
+def test_call_model_max_tokens_mapped_to_max_output_tokens(generator):
+    """garak's max_tokens is passed to the API as max_output_tokens."""
+    generator.max_tokens = 512
+    generator.client.responses.create.return_value = _make_response("ok")
+
+    generator._call_model(Conversation([Turn(role="user", content=Message("hi"))]))
+
+    kwargs = generator.client.responses.create.call_args[1]
+    assert kwargs["max_output_tokens"] == 512
+    assert "max_tokens" not in kwargs
 
 
 def test_call_model_empty_output_returns_none(generator):
@@ -197,7 +213,10 @@ def test_call_model_multiple_system_turns_concatenated(generator):
     )
 
     kwargs = generator.client.responses.create.call_args[1]
-    assert kwargs["instructions"] == "You are a banking assistant.\nAlways respond in French."
+    assert (
+        kwargs["instructions"]
+        == "You are a banking assistant.\nAlways respond in French."
+    )
 
 
 def test_call_model_explicit_instructions_takes_precedence(generator):
@@ -217,9 +236,11 @@ def test_call_model_explicit_instructions_takes_precedence(generator):
     assert kwargs["instructions"] == "Explicit instruction."
 
 
-# ── output_types ──────────────────────────────────────────────────────────────
+# ── reasoning ─────────────────────────────────────────────────────────────────
 
-def test_output_types_default_excludes_reasoning(generator):
+
+def test_reasoning_excluded_from_text(generator):
+    """Reasoning summaries do not appear in Message.text."""
     generator.client.responses.create.return_value = _make_response_with_reasoning(
         "Answer", "My reasoning"
     )
@@ -231,8 +252,8 @@ def test_output_types_default_excludes_reasoning(generator):
     assert result[0].text == "Answer"
 
 
-def test_output_types_message_and_reasoning(generator):
-    generator.output_types = ["reasoning", "message"]
+def test_reasoning_stored_in_notes(generator):
+    """Reasoning summaries are stored in Message.notes['reasoning'], not in text."""
     generator.client.responses.create.return_value = _make_response_with_reasoning(
         "Answer", "My reasoning"
     )
@@ -241,27 +262,24 @@ def test_output_types_message_and_reasoning(generator):
         Conversation([Turn(role="user", content=Message("Think hard"))])
     )
 
-    assert "My reasoning" in result[0].text
-    assert "Answer" in result[0].text
+    assert result[0].notes["reasoning"] == "My reasoning"
+    assert result[0].text == "Answer"
 
 
-def test_output_types_generic_fallback_warns(generator, caplog):
-    """Non-call item types with no .text attribute produce no output and emit a warning."""
+def test_unknown_output_item_type_ignored(generator):
+    """Output items that are not message, reasoning, or *_call are silently ignored."""
     custom_item = MagicMock(spec=["type"])
     custom_item.type = "image_generation"
 
     response = MagicMock()
     response.output = [custom_item]
-    generator.output_types = ["image_generation"]
     generator.client.responses.create.return_value = response
 
-    with caplog.at_level(logging.WARNING, logger="garak.generators.openai"):
-        result = generator._call_model(
-            Conversation([Turn(role="user", content=Message("Generate an image"))])
-        )
+    result = generator._call_model(
+        Conversation([Turn(role="user", content=Message("Generate an image"))])
+    )
 
     assert result == [None]
-    assert any("image_generation" in r.message for r in caplog.records)
 
 
 def test_tool_calls_stored_in_notes_and_serializable(generator):
@@ -378,19 +396,3 @@ def test_tool_calls_only_returns_message_not_none(generator):
     assert isinstance(result[0], Message)
     assert result[0].text is None
     assert result[0].notes["tool_calls"][0]["name"] == "get_balance"
-
-
-def test_custom_output_types_via_config(set_fake_env, mock_openai_client):
-    gen = OpenAIResponsesGenerator(
-        name="my-model",
-        config_root={
-            "generators": {
-                "openai": {
-                    "OpenAIResponsesGenerator": {
-                        "output_types": ["message", "reasoning"],
-                    }
-                }
-            }
-        },
-    )
-    assert gen.output_types == ["message", "reasoning"]


### PR DESCRIPTION
Implements a new OpenAI compatible generator `OpenAIResponsesGenerator` that uses the [responses API](https://developers.openai.com/api/reference/responses/overview) instead of `ChatCompletion`.  

This started as way to run [Agent Breaker](https://github.com/NVIDIA/garak/pull/1628) against agents that support the responses API, but I think it's valuable as a standalone `Generator` for any probe.  
I'm currently storing the returned tool calls as `Message` notes, mainly so that I can do manual inspection of the attempts in the `report.jsonl` file. Ideally, I think there should be a generic mechanism for storing those so that detectors can pick those up properly. Probably outside the scope for this PR, just wanted to know if you already have a direction for integrating tool calling into Garak.

## Verification

The new Generator can be used like others OpenAI compatible generators, ex:
```yaml
  generators:
    openai:
      OpenAIResponsesGenerator:
        uri: http://localhost:1234/v1/
        api_key: dummy 
        tools:
          - type: mcp
            server_label: mcp_server
            server_url: http://localhost:8888/sse
            require_approval: "never"
```
