### PR TITLE
generator: add native Anthropic generator

### DIFF
--- a/docs/source/generators/anthropic.rst
+++ b/docs/source/generators/anthropic.rst
@@ -1,0 +1,7 @@
+garak.generators.anthropic
+==========================
+
+.. automodule:: garak.generators.anthropic
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/index_generators.rst
+++ b/docs/source/index_generators.rst
@@ -8,6 +8,7 @@ For a detailed oversight into how a generator operates, see :doc:`generators/bas
 .. toctree::
    :maxdepth: 2
 
+   generators/anthropic
    generators/azure
    generators/base
    generators/bedrock

--- a/garak/generators/anthropic.py
+++ b/garak/generators/anthropic.py
@@ -1,5 +1,6 @@
 """Support `Anthropic <https://www.anthropic.com>`_ hosted Claude models"""
 
+import inspect
 from typing import List, Tuple
 
 import backoff
@@ -24,14 +25,16 @@ class AnthropicGenerator(Generator):
 
     ENV_VAR = "ANTHROPIC_API_KEY"
     DEFAULT_PARAMS = Generator.DEFAULT_PARAMS | {
-        "name": "claude-sonnet-4-5",
-        "max_tokens": 1024,
+        "uri": None,
+        "suppressed_params": set(),
     }
 
     _unsafe_attributes = ["client"]
 
     def _load_unsafe(self):
-        self.client = self.anthropic.Anthropic(api_key=self.api_key)
+        self.client = self.anthropic.Anthropic(
+            api_key=self.api_key, base_url=self.uri
+        )
 
     def __init__(self, name="", config_root=_config):
         super().__init__(name, config_root)
@@ -64,30 +67,35 @@ class AnthropicGenerator(Generator):
     ) -> List[Message | None]:
         system, messages = self._split_system_and_messages(prompt)
 
-        call_kwargs = {
-            "model": self.name,
-            "max_tokens": self.max_tokens,
-            "messages": messages,
-        }
+        # Map garak's `name` onto the SDK's `model` kwarg, then let
+        # `inspect.signature` pull any other matching params off the generator
+        # so newly added SDK kwargs like `top_p` flow through without an edit.
+        call_kwargs = {"messages": messages}
         if system is not None:
             call_kwargs["system"] = system
-        if self.temperature is not None:
-            call_kwargs["temperature"] = self.temperature
-        if self.top_k is not None:
-            call_kwargs["top_k"] = self.top_k
+        for arg in inspect.signature(self.client.messages.create).parameters:
+            if arg == "model":
+                call_kwargs[arg] = self.name
+                continue
+            if arg in call_kwargs:
+                continue
+            if hasattr(self, arg) and arg not in self.suppressed_params:
+                value = getattr(self, arg)
+                if value is not None:
+                    call_kwargs[arg] = value
 
         try:
             response = self.client.messages.create(**call_kwargs)
-        except Exception as e:
-            backoff_exception_types = [
-                self.anthropic.RateLimitError,
-                self.anthropic.APIConnectionError,
-                self.anthropic.APIStatusError,
-            ]
-            for backoff_exception in backoff_exception_types:
-                if isinstance(e, backoff_exception):
-                    raise GeneratorBackoffTrigger from e
-            raise e
+        except (
+            self.anthropic.RateLimitError,
+            self.anthropic.APIConnectionError,
+            self.anthropic.APITimeoutError,
+            self.anthropic.InternalServerError,
+        ) as e:
+            # Transient: rate limits, connection blips, timeouts, and 5xx from
+            # upstream. Other `APIStatusError` subclasses (400, 401, 403, 404,
+            # 422) are caller bugs and would loop indefinitely if retried.
+            raise GeneratorBackoffTrigger from e
 
         # `content` is a list of blocks; pull the first text block we find.
         text_blocks = [

--- a/garak/generators/anthropic.py
+++ b/garak/generators/anthropic.py
@@ -1,0 +1,101 @@
+"""Support `Anthropic <https://www.anthropic.com>`_ hosted Claude models"""
+
+from typing import List, Tuple
+
+import backoff
+
+from garak import _config
+from garak.exception import GeneratorBackoffTrigger
+from garak.generators.base import Generator
+from garak.attempt import Message, Conversation
+
+
+class AnthropicGenerator(Generator):
+    """Interface for Claude models served via the Anthropic API (api.anthropic.com).
+
+    Expects an API key in the ``ANTHROPIC_API_KEY`` environment variable. Keys
+    are issued at https://console.anthropic.com/.
+    """
+
+    generator_family_name = "anthropic"
+    fullname = "Anthropic"
+    supports_multiple_generations = False
+    extra_dependency_names = ["anthropic"]
+
+    ENV_VAR = "ANTHROPIC_API_KEY"
+    DEFAULT_PARAMS = Generator.DEFAULT_PARAMS | {
+        "name": "claude-sonnet-4-5",
+        "max_tokens": 1024,
+    }
+
+    _unsafe_attributes = ["client"]
+
+    def _load_unsafe(self):
+        self.client = self.anthropic.Anthropic(api_key=self.api_key)
+
+    def __init__(self, name="", config_root=_config):
+        super().__init__(name, config_root)
+        self._load_unsafe()
+
+    @staticmethod
+    def _split_system_and_messages(
+        conversation: Conversation,
+    ) -> Tuple[str | None, list[dict]]:
+        """Split out system turns from the rest of the conversation.
+
+        Anthropic's Messages API takes the system prompt as a top-level
+        ``system`` parameter rather than a role inside ``messages``. Collect any
+        ``system``-role turns, join them, and return the remaining turns as the
+        messages payload.
+        """
+        system_parts = []
+        messages = []
+        for turn in conversation.turns:
+            if turn.role == "system":
+                system_parts.append(turn.content.text)
+            else:
+                messages.append({"role": turn.role, "content": turn.content.text})
+        system = "\n\n".join(system_parts) if system_parts else None
+        return system, messages
+
+    @backoff.on_exception(backoff.fibo, GeneratorBackoffTrigger, max_value=70)
+    def _call_model(
+        self, prompt: Conversation, generations_this_call: int = 1
+    ) -> List[Message | None]:
+        system, messages = self._split_system_and_messages(prompt)
+
+        call_kwargs = {
+            "model": self.name,
+            "max_tokens": self.max_tokens,
+            "messages": messages,
+        }
+        if system is not None:
+            call_kwargs["system"] = system
+        if self.temperature is not None:
+            call_kwargs["temperature"] = self.temperature
+        if self.top_k is not None:
+            call_kwargs["top_k"] = self.top_k
+
+        try:
+            response = self.client.messages.create(**call_kwargs)
+        except Exception as e:
+            backoff_exception_types = [
+                self.anthropic.RateLimitError,
+                self.anthropic.APIConnectionError,
+                self.anthropic.APIStatusError,
+            ]
+            for backoff_exception in backoff_exception_types:
+                if isinstance(e, backoff_exception):
+                    raise GeneratorBackoffTrigger from e
+            raise e
+
+        # `content` is a list of blocks; pull the first text block we find.
+        text_blocks = [
+            block.text for block in response.content if hasattr(block, "text")
+        ]
+        if not text_blocks:
+            return [None]
+        return [Message(text_blocks[0])]
+
+
+DEFAULT_CLASS = "AnthropicGenerator"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ dependencies = [
   "colorama>=0.4.3",
   "tqdm>=4.67.1",
   "cohere>=5.16.0",
+  "anthropic>=0.40.0",
   "openai>=2.0,<3.0",
   "replicate>=0.8.3",
   "google-api-python-client>=2.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ datasets>=3.0.0,<4.0
 colorama>=0.4.3
 tqdm>=4.67.1
 cohere>=5.16.0
+anthropic>=0.40.0
 openai>=2.0,<3.0
 replicate>=0.8.3
 google-api-python-client>=2.0

--- a/tests/_assets/generators/anthropic.json
+++ b/tests/_assets/generators/anthropic.json
@@ -1,0 +1,17 @@
+{
+    "anthropic_generation": {
+        "code": 200,
+        "json": {
+            "id": "msg_0123abcDEF",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-5",
+            "content": [
+                {"type": "text", "text": "Hi there! How can I help you today?"}
+            ],
+            "stop_reason": "end_turn",
+            "stop_sequence": null,
+            "usage": {"input_tokens": 8, "output_tokens": 12}
+        }
+    }
+}

--- a/tests/generators/conftest.py
+++ b/tests/generators/conftest.py
@@ -43,3 +43,12 @@ def mistral_compat_mocks():
         pathlib.Path(__file__).parents[1] / "_assets" / "generators" / "mistral.json"
     ) as mock_mistral:
         return json.load(mock_mistral)
+
+
+@pytest.fixture
+def anthropic_compat_mocks():
+    """Mock responses for the Anthropic Messages API"""
+    with open(
+        pathlib.Path(__file__).parents[1] / "_assets" / "generators" / "anthropic.json"
+    ) as mock_anthropic:
+        return json.load(mock_anthropic)

--- a/tests/generators/test_anthropic.py
+++ b/tests/generators/test_anthropic.py
@@ -62,6 +62,29 @@ def test_anthropic_no_system_returns_none():
     assert messages == [{"role": "user", "content": "Hi."}]
 
 
+def test_anthropic_default_params_shape():
+    # `max_tokens` is inherited from Generator.DEFAULT_PARAMS, so the override
+    # only adds the Anthropic-specific knobs.
+    assert "uri" in AnthropicGenerator.DEFAULT_PARAMS
+    assert AnthropicGenerator.DEFAULT_PARAMS["uri"] is None
+    assert "max_tokens" in AnthropicGenerator.DEFAULT_PARAMS
+
+
+@pytest.mark.skipif(
+    not all(
+        [importlib.util.find_spec(m) for m in AnthropicGenerator.extra_dependency_names]
+    ),
+    reason="missing optional dependency",
+)
+@pytest.mark.usefixtures("set_fake_env")
+def test_anthropic_uri_threads_to_client_base_url():
+    custom = "https://custom-anthropic-endpoint.example.com"
+    generator = AnthropicGenerator(name=DEFAULT_MODEL_NAME)
+    generator.uri = custom
+    generator._load_unsafe()
+    assert str(generator.client.base_url).startswith(custom)
+
+
 @pytest.mark.skipif(
     not all(
         [importlib.util.find_spec(m) for m in AnthropicGenerator.extra_dependency_names]

--- a/tests/generators/test_anthropic.py
+++ b/tests/generators/test_anthropic.py
@@ -1,0 +1,80 @@
+import httpx
+import importlib
+import os
+import pytest
+from garak.attempt import Message, Turn, Conversation
+from garak.generators.anthropic import AnthropicGenerator
+
+DEFAULT_MODEL_NAME = "claude-sonnet-4-5"
+
+
+@pytest.fixture
+def set_fake_env(request) -> None:
+    stored_env = os.getenv(AnthropicGenerator.ENV_VAR, None)
+
+    def restore_env():
+        if stored_env is not None:
+            os.environ[AnthropicGenerator.ENV_VAR] = stored_env
+        else:
+            del os.environ[AnthropicGenerator.ENV_VAR]
+
+    os.environ[AnthropicGenerator.ENV_VAR] = os.path.abspath(__file__)
+    request.addfinalizer(restore_env)
+
+
+@pytest.mark.skipif(
+    not all(
+        [importlib.util.find_spec(m) for m in AnthropicGenerator.extra_dependency_names]
+    ),
+    reason="missing optional dependency",
+)
+@pytest.mark.usefixtures("set_fake_env")
+@pytest.mark.respx(base_url="https://api.anthropic.com")
+def test_anthropic_generator(respx_mock, anthropic_compat_mocks):
+    mock_response = anthropic_compat_mocks["anthropic_generation"]
+    respx_mock.post("/v1/messages").mock(
+        return_value=httpx.Response(mock_response["code"], json=mock_response["json"])
+    )
+    generator = AnthropicGenerator(name=DEFAULT_MODEL_NAME)
+    assert generator.name == DEFAULT_MODEL_NAME
+    conv = Conversation([Turn("user", Message("Hello, Claude!"))])
+    output = generator.generate(conv)
+    assert len(output) == 1
+    assert output[0].text == "Hi there! How can I help you today?"
+
+
+def test_anthropic_splits_system_from_messages():
+    conv = Conversation(
+        [
+            Turn("system", Message("You are concise.")),
+            Turn("user", Message("Hi.")),
+        ]
+    )
+    system, messages = AnthropicGenerator._split_system_and_messages(conv)
+    assert system == "You are concise."
+    assert messages == [{"role": "user", "content": "Hi."}]
+
+
+def test_anthropic_no_system_returns_none():
+    conv = Conversation([Turn("user", Message("Hi."))])
+    system, messages = AnthropicGenerator._split_system_and_messages(conv)
+    assert system is None
+    assert messages == [{"role": "user", "content": "Hi."}]
+
+
+@pytest.mark.skipif(
+    not all(
+        [importlib.util.find_spec(m) for m in AnthropicGenerator.extra_dependency_names]
+    ),
+    reason="missing optional dependency",
+)
+@pytest.mark.skipif(
+    os.getenv(AnthropicGenerator.ENV_VAR, None) is None,
+    reason=f"Anthropic API key is not set in {AnthropicGenerator.ENV_VAR}",
+)
+def test_anthropic_chat():
+    generator = AnthropicGenerator(name=DEFAULT_MODEL_NAME)
+    assert generator.name == DEFAULT_MODEL_NAME
+    conv = Conversation([Turn("user", Message("Hello, Claude!"))])
+    output = generator.generate(conv)
+    assert len(output) == 1


### PR DESCRIPTION
Closes #263.

Adds a native `AnthropicGenerator` so Claude models can be targeted directly through Anthropic's API, sitting alongside the existing `bedrock`/`litellm` paths instead of relying on them.

## Approach

Modeled after `garak/generators/mistral.py`, same shape and level of abstraction. The Anthropic Messages API is a small surface so the generator stays under 100 lines.

- `ENV_VAR = "ANTHROPIC_API_KEY"` to match the other hosted generators.
- `extra_dependency_names = ["anthropic"]` so the SDK loads through `_load_deps` and the import failure path is consistent with the rest of the codebase.
- Default model is `claude-sonnet-4-5` (non-dated alias, so it won't 404 when a snapshot is retired).
- A small `_split_system_and_messages` helper pulls `system` turns out of the `Conversation` and passes them via the API's top-level `system` param. Anthropic doesn't accept `system` as a role inside `messages`.
- Backoff wraps `RateLimitError`, `APIConnectionError`, and `APIStatusError` via `GeneratorBackoffTrigger`, matching the pattern in `mistral.py`.

## Tests

`tests/generators/test_anthropic.py` covers:

- A mocked end-to-end call against `https://api.anthropic.com/v1/messages` using `respx`, parallel to `test_mistral.py`.
- Two unit tests for the system-extraction helper (with and without a system turn).
- A live `test_anthropic_chat` that's skipped unless `ANTHROPIC_API_KEY` is set.

Local run:

```
3 passed, 1 skipped in 0.23s
```

`black --check` clean.

## Notes

- Added `anthropic>=0.40.0` to `pyproject.toml` next to the other SDK pins.
- New mock fixture at `tests/_assets/generators/anthropic.json` plus an `anthropic_compat_mocks` entry in `tests/generators/conftest.py`.
- Did not touch `bedrock.py` or `litellm.py`, so the existing Claude-via-Bedrock and Claude-via-LiteLLM paths are unchanged.