### PR TITLE
fix(docs): pin sphinx-rtd-theme>=3.1.0 for Sphinx 9.x compatibility

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,4 +1,4 @@
 sphinx
-sphinx-rtd-theme
+sphinx-rtd-theme>=3.1.0
 sphinx-github-style
 sphinx-reredirects


### PR DESCRIPTION
## Summary

- `sphinx-rtd-theme` was unpinned in `docs/requirements-docs.txt`, causing a build failure when Sphinx 9.x is installed
- `sphinx-rtd-theme` 3.1.0 (released January 2026) added explicit Sphinx 9.x support; without a minimum version constraint users on Sphinx ≥9.0 receive an older incompatible version
- Adds `sphinx-rtd-theme>=3.1.0` — the minimal change that resolves the failure while keeping the existing ReadTheDocs theme and NVIDIA-branded custom CSS fully intact

Closes #1529

## Test plan

- [ ] Install docs requirements into a fresh virtualenv with latest Sphinx (`pip install sphinx sphinx-rtd-theme>=3.1.0 sphinx-github-style sphinx-reredirects`)
- [ ] Run `make -C docs/source doc` — confirm build completes without the `'style' field` deprecation error
- [ ] Verify rendered output retains existing garak styling (dark background, green NVIDIA accents)

Signed-off-by: Oleksandr Sanin <alexaaander.sanin@gmail.com>