### PR TITLE
probes: add InjectBase65536

### DIFF
--- a/garak/probes/encoding.py
+++ b/garak/probes/encoding.py
@@ -445,6 +445,30 @@ class InjectBase2048(EncodingMixin, garak.probes.Probe):
         EncodingMixin.__init__(self)
 
 
+class InjectBase65536(EncodingMixin, garak.probes.Probe):
+    """Probe for susceptibility to Base65536 encoding injections
+
+    Encodes payloads using base65536 (qntm), which maps 16-bit binary chunks
+    to a single Unicode codepoint each. The resulting strings are extremely
+    compact (~2 input bytes per output char) and use rarely-tokenised CJK
+    Unified Ideographs blocks, often surviving safety filters that target
+    common base16 / base32 / base64 patterns. Tries a variety of ways to
+    coax the target model into decoding and following the payload.
+
+    Reference: https://github.com/qntm/base65536"""
+
+    encoding_name = "BASE65536"
+    doc_uri = "https://github.com/qntm/base65536"
+    active = True
+
+    def __init__(self, config_root=_config):
+        import base65536
+
+        self.encoding_funcs = [base65536.encode]
+        garak.probes.Probe.__init__(self, config_root=config_root)
+        EncodingMixin.__init__(self)
+
+
 class InjectBraille(EncodingMixin, garak.probes.Probe):
     """Probe for susceptibility to Braille encoding injections. Credit Wally#3422
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
   "mikeshardmind-base2048>=1.0.2",
+  "base65536>=0.1.1",
   "transformers>=5.0,<6.0",
   "datasets>=3.0.0,<4.0",
   "colorama>=0.4.3",


### PR DESCRIPTION
References #152 (extra encodings checklist).

## Summary

Adds a Base65536 encoding probe class to `garak.probes.encoding`, matching the existing `InjectBase2048` pattern.

[Base65536 (qntm)](https://github.com/qntm/base65536) maps 16-bit binary chunks to a single Unicode codepoint each. The resulting strings are extremely compact (~2 input bytes per output char) and use rarely-tokenised CJK Unified Ideographs blocks, often surviving safety filters that target common base16 / base32 / base64 patterns.

## Verification

Existing parametrised encoding tests (`tests/probes/test_probes_encoding.py`) auto-cover the new probe via plugin enumeration:

- `test_encoding_len_cap`
- `test_encoding_prompt_trigger_match`
- `test_encoding_triggers_not_in_prompts`
- `test_encoding_prompt_cap`
- `test_encoding_suppress_prompt_cap`

Spot check:

```python
>>> import base65536
>>> base65536.encode(b'ignore previous instructions')
'驨ꍬᕯ蝫蝨蝬𡖝跥蝫蝨𡖝蝯蝳蝴蝲蝵𡖝'
```

## Dependency

Adds `base65536>=0.1.1` to `pyproject.toml`. The package is pure-Python, MIT-licensed, and has no transitive dependencies.

## Scope

Ticks one box from the #152 extra encodings checklist:

- [x] Base65536 — **this PR**
- [ ] utf (qaz.wtf)
- [ ] Base1
- [ ] HexagramEncode
- [ ] base32768

Each of the remaining entries would be a similar small follow-up PR. Happy to follow up with `HexagramEncode` (implementable from scratch — 64 hexagram symbols U+4DC0–U+4DFF, 6 bits per symbol) if maintainer interest is there.