### PR TITLE
tests: cover a completed parallel_attempts run

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -847,6 +847,20 @@ def test_site_yaml_overrides_max_workers(capsys):
         assert exc_info.value.code == 1
 
 
+# a run with parallel_attempts set should complete without error, for both the
+# serial case (1) and a parallel case (>1). uses the cheap CPU-only test
+# generator and the multi-prompt test.Test probe so that the >1 case actually
+# reaches the multiprocessing path in garak.probes.base.Probe._execute_all
+@pytest.mark.parametrize("parallel_attempts", [1, 4])
+def test_parallel_attempts_run_completes(parallel_attempts):
+    args = (
+        f"--parallel_attempts {parallel_attempts} -m test.Blank -p test.Test -g 1"
+    ).split()
+    garak.cli.main(args)
+
+    assert _config.system.parallel_attempts == parallel_attempts
+
+
 model_target_data = [
     ("model_type", "model_name"),
     ("model_type", "target_name"),


### PR DESCRIPTION
This adds a test for the happy path of `parallel_attempts`, which issue #338 asks for.

The only existing run with `--parallel_attempts` is `test_site_yaml_overrides_max_workers` in `tests/test_config.py`, and it deliberately expects a `ValueError` from the `max_workers` cap. So the case the issue cares about, where `parallel_attempts` is greater than 1 and a run finishes successfully, was not tested anywhere.

The new `test_parallel_attempts_run_completes` runs garak end to end through `garak.cli.main` with `--parallel_attempts` set to both 1 and 4. It uses the cheap CPU only `test.Blank` generator and the `test.Test` probe with one generation, then asserts the run finishes without raising and that the parallel worker count landed in config as requested. This matches the test conditions in the issue, namely the test generator, one generation, a continuations style probe, and `parallel_attempts` in both the serial and parallel cases.

I picked `test.Test` rather than `test.Blank` as the probe on purpose. `test.Test` carries 8 prompts, so with one generation the run produces more than one attempt, and the test generator is parallel capable by default. That means the value greater than 1 case actually reaches the multiprocessing path in `garak.probes.base.Probe._execute_all` rather than quietly falling through to the serial branch, so the test exercises the thing it claims to.

Verification. I installed the package into a fresh venv with `uv pip install -e` the tests extra, then ran only this test by node id. Both parameter cases pass. I also ran black on the changed file and my added lines are clean.
