### PR TITLE
fix(probes): download wordnet lexicon when it is missing from the database

### DIFF
--- a/garak/probes/topic.py
+++ b/garak/probes/topic.py
@@ -109,7 +109,9 @@ class WordnetBlockedWords(garak.probes.TreeSearchProbe):
         self.w = None
         try:
             self.w = wn.Wordnet(self.lexicon)
-        except sqlite3.OperationalError:
+        except (sqlite3.OperationalError, wn.Error):
+            # sqlite3.OperationalError: the wordnet database has not been created yet
+            # wn.Error: the database exists but the requested lexicon is not installed
             logging.debug("Downloading wordnet lexicon: %s", self.lexicon)
             download_tempfile_path = wn.download(self.lexicon)
             self.w = wn.Wordnet(self.lexicon)

--- a/tests/probes/test_probes_topic.py
+++ b/tests/probes/test_probes_topic.py
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import pathlib
+import sqlite3
+from unittest.mock import MagicMock, patch
+
 import pytest
 import wn
 
@@ -71,3 +75,40 @@ def test_topic_wordnet_blocklist_get_initial_nodes(sysnet):
         wn.synset("oewn-00231342-n"),
         wn.synset("oewn-00232028-n"),
     ]
+
+
+@pytest.mark.parametrize(
+    "first_call_error",
+    [
+        sqlite3.OperationalError("no such table: lexicons"),
+        wn.Error("no lexicon found with lang=None and lexicon='oewn:2023'"),
+    ],
+    ids=["sqlite_missing_database", "wn_missing_lexicon"],
+)
+def test_topic_wordnet_downloads_missing_lexicon(first_call_error):
+    # when the lexicon cannot be opened the probe should download it and retry,
+    # rather than letting the underlying error propagate and fail to load.
+    # wn.Error covers the case where the database exists but the requested
+    # lexicon is not installed, see https://github.com/NVIDIA/garak/issues/1230
+    loaded_wordnet = MagicMock(name="wn.Wordnet")
+    download_path = MagicMock(name="download_tempfile_path")
+
+    with (
+        patch.object(
+            wn, "Wordnet", side_effect=[first_call_error, loaded_wordnet]
+        ) as mock_wordnet,
+        patch.object(wn, "download", return_value=download_path) as mock_download,
+        patch.object(pathlib.Path, "rmdir"),
+    ):
+        probe = garak.probes.topic.WordnetBlockedWords()
+
+    assert (
+        mock_download.call_count == 1
+    ), "a missing lexicon should trigger exactly one download"
+    assert (
+        mock_wordnet.call_count == 2
+    ), "the lexicon should be reloaded after downloading it"
+    assert (
+        probe.w is loaded_wordnet
+    ), "the probe should keep the reloaded wordnet after recovery"
+    download_path.unlink.assert_called_once()

--- a/tests/probes/test_probes_topic.py
+++ b/tests/probes/test_probes_topic.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pathlib
+import pytest
 import sqlite3
 from unittest.mock import MagicMock, patch
 
-import pytest
 import wn
 
 import garak._plugins
@@ -80,16 +80,18 @@ def test_topic_wordnet_blocklist_get_initial_nodes(sysnet):
 @pytest.mark.parametrize(
     "first_call_error",
     [
-        sqlite3.OperationalError("no such table: lexicons"),
-        wn.Error("no lexicon found with lang=None and lexicon='oewn:2023'"),
+        sqlite3.OperationalError("database not initialised"),
+        wn.Error("requested lexicon is not installed"),
     ],
     ids=["sqlite_missing_database", "wn_missing_lexicon"],
 )
 def test_topic_wordnet_downloads_missing_lexicon(first_call_error):
     # when the lexicon cannot be opened the probe should download it and retry,
     # rather than letting the underlying error propagate and fail to load.
-    # wn.Error covers the case where the database exists but the requested
-    # lexicon is not installed, see https://github.com/NVIDIA/garak/issues/1230
+    # The recovery path keys off the exception type (sqlite3.OperationalError for
+    # a missing database, wn.Error for a missing lexicon, see
+    # https://github.com/NVIDIA/garak/issues/1230), so the message text here is
+    # only illustrative and does not need to track wn's exact wording.
     loaded_wordnet = MagicMock(name="wn.Wordnet")
     download_path = MagicMock(name="download_tempfile_path")
 
@@ -100,7 +102,7 @@ def test_topic_wordnet_downloads_missing_lexicon(first_call_error):
         patch.object(wn, "download", return_value=download_path) as mock_download,
         patch.object(pathlib.Path, "rmdir"),
     ):
-        probe = garak.probes.topic.WordnetBlockedWords()
+        probe = garak._plugins.load_plugin("probes.topic.WordnetBlockedWords")
 
     assert (
         mock_download.call_count == 1


### PR DESCRIPTION
Fixes #1230

## Root cause

The Wordnet topic probes point `wn` at a garak-specific cache directory (`garak/probes/topic.py:104`). On a clean cache the SQLite database does not exist yet, so `wn.Wordnet(self.lexicon)` raises `sqlite3.OperationalError`, which the constructor catches to trigger a one-off lexicon download and retry.

There is a second failure mode the constructor did not handle. When the database file already exists but the requested lexicon row has never been installed, `wn` raises `wn.Error` instead, for example `no lexicon found with lang=None and lexicon=oewn:2023`. That exception was not caught, so the probe failed to load and the run ended early. This is exactly the traceback reported in the issue. The `wn` maintainer confirmed on the issue thread that the underlying cause is the lexicon being absent from the database, and that reinstalling the package does not rebuild it. Since garak uses a custom data directory, the lexicon is frequently not present, so this path is easy to hit.

## Fix

Widen the `except` clause in `WordnetBlockedWords.__init__` to also catch `wn.Error`, so the same download-and-retry recovery runs whether the database is missing entirely or merely lacks the requested lexicon. A short comment documents which condition each exception represents. This keeps the change to a single, specific exception type as the contribution guide asks, and avoids a broad `except`.

## Why this is not a duplicate

There is no open or closed PR addressing issue #1230. I checked with `gh pr list --repo NVIDIA/garak --state all --search "1230 in:body"`, `gh pr list --search "topic wordnet"`, and `gh pr list --search "wordnet lexicon"`. The two prior cross-references (#1316 and #764) are unrelated merged changes to how `wn` is used and to the topic probe content, neither of which catches `wn.Error`.

## Verification

Reproduced the exact exception against the pinned `wn==0.9.5` by pointing `wn` at an empty data directory and calling `wn.Wordnet("oewn:2023")`, which raises `wn.Error` rather than `sqlite3.OperationalError`, confirming the gap.

Added a parametrized regression test that mocks `wn.Wordnet` to raise each error on first load and asserts the probe downloads the lexicon once, reloads it, and keeps the reloaded handle. The `wn.Error` case fails on current main and passes with this change. The `sqlite3.OperationalError` case passes in both, guarding the existing behaviour.

Commands run, on Python 3.13 with the test extras installed:

```
python -m pytest tests/probes/test_probes_topic.py -k downloads_missing_lexicon -q
  -> 2 passed (1 of the 2 fails on unpatched main, confirming the guard)

python -m pytest tests/probes/test_probes_topic.py -q
  -> 18 passed

python -m black --check garak/probes/topic.py tests/probes/test_probes_topic.py
  -> clean

python -m pylint --disable=all --enable=E garak/probes/topic.py
  -> no new errors (the 9 pre-existing E1101 dynamic-attribute warnings are unchanged from main)
```

## Disclosure

AI assistance was used to help investigate and draft this change. I reviewed every changed line, confirmed the root cause against the pinned `wn` version, and ran the tests and linters above.