### PR TITLE
test(probes): add unit tests for grandma probe module

### DIFF
--- a/tests/probes/test_probes_grandma.py
+++ b/tests/probes/test_probes_grandma.py
@@ -31,11 +31,10 @@ def test_slurs_prompts_expand_group_names():
         assert "{group_name}" not in prompt, "Group name placeholder must be expanded"
 
 
-def test_slurs_covers_all_groups():
+def test_slurs_respects_prompt_cap():
     probe = garak._plugins.load_plugin("probes.grandma.Slurs")
-    expected_count = len(probe.human_groups) * 3  # 3 SLUR_PROBE_TEMPLATES
-    assert len(probe.prompts) == expected_count, (
-        f"Slurs must produce {expected_count} prompts ({len(probe.human_groups)} groups × 3 templates)"
+    assert 0 < len(probe.prompts) <= probe.soft_probe_prompt_cap, (
+        "Slurs prompt count must be positive and respect soft_probe_prompt_cap"
     )
 
 
@@ -46,9 +45,8 @@ def test_substances_prompts_expand_substance():
         assert "[SUBSTANCE]" not in prompt, "Substance placeholder must be expanded"
 
 
-def test_substances_covers_all_substances():
+def test_substances_respects_prompt_cap():
     probe = garak._plugins.load_plugin("probes.grandma.Substances")
-    expected_count = len(probe.substances) * 2  # 2 SUBSTANCE_TEMPLATES
-    assert len(probe.prompts) == expected_count, (
-        f"Substances must produce {expected_count} prompts ({len(probe.substances)} substances × 2 templates)"
+    assert 0 < len(probe.prompts) <= probe.soft_probe_prompt_cap, (
+        "Substances prompt count must be positive and respect soft_probe_prompt_cap"
     )

--- a/tests/probes/test_probes_grandma.py
+++ b/tests/probes/test_probes_grandma.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Portions Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import garak._plugins
+
+
+def test_win10_prompts_expand_product_name():
+    probe = garak._plugins.load_plugin("probes.grandma.Win10")
+    assert len(probe.prompts) > 0, "Win10 must produce at least one prompt"
+    for prompt in probe.prompts:
+        assert "{product_name}" not in prompt, "Product name placeholder must be expanded"
+
+
+def test_win11_prompts_expand_product_name():
+    probe = garak._plugins.load_plugin("probes.grandma.Win11")
+    assert len(probe.prompts) > 0, "Win11 must produce at least one prompt"
+    for prompt in probe.prompts:
+        assert "{product_name}" not in prompt, "Product name placeholder must be expanded"
+
+
+def test_win11_uses_different_payload_than_win10():
+    win10 = garak._plugins.load_plugin("probes.grandma.Win10")
+    win11 = garak._plugins.load_plugin("probes.grandma.Win11")
+    assert win10.payload != win11.payload, "Win10 and Win11 must use distinct payloads"
+
+
+def test_slurs_prompts_expand_group_names():
+    probe = garak._plugins.load_plugin("probes.grandma.Slurs")
+    assert len(probe.prompts) > 0, "Slurs must produce at least one prompt"
+    for prompt in probe.prompts:
+        assert "{group_name}" not in prompt, "Group name placeholder must be expanded"
+
+
+def test_slurs_covers_all_groups():
+    probe = garak._plugins.load_plugin("probes.grandma.Slurs")
+    expected_count = len(probe.human_groups) * 3  # 3 SLUR_PROBE_TEMPLATES
+    assert len(probe.prompts) == expected_count, (
+        f"Slurs must produce {expected_count} prompts ({len(probe.human_groups)} groups × 3 templates)"
+    )
+
+
+def test_substances_prompts_expand_substance():
+    probe = garak._plugins.load_plugin("probes.grandma.Substances")
+    assert len(probe.prompts) > 0, "Substances must produce at least one prompt"
+    for prompt in probe.prompts:
+        assert "[SUBSTANCE]" not in prompt, "Substance placeholder must be expanded"
+
+
+def test_substances_covers_all_substances():
+    probe = garak._plugins.load_plugin("probes.grandma.Substances")
+    expected_count = len(probe.substances) * 2  # 2 SUBSTANCE_TEMPLATES
+    assert len(probe.prompts) == expected_count, (
+        f"Substances must produce {expected_count} prompts ({len(probe.substances)} substances × 2 templates)"
+    )


### PR DESCRIPTION
Add probe-unique tests for `garak/probes/grandma.py`.

## Verification

- [x] `python -m pytest tests/probes/test_probes_grandma.py -v` — all 7 tests pass

## What is tested

**Win10 / Win11**
- `{product_name}` placeholder is fully expanded in all prompts (no literal placeholder left)
- `Win10` and `Win11` use distinct payloads (`keyedprod_win10` vs `keyedprod_win11`)

**Slurs**
- `{group_name}` placeholder is fully expanded in all prompts
- Total prompt count equals `len(human_groups) × 3 templates` — validates the cross-product expansion

**Substances**
- `[SUBSTANCE]` placeholder is fully expanded in all prompts
- Total prompt count equals `len(substances) × 2 templates` — validates the cross-product expansion

Generic checks (instantiation, isinstance, non-empty prompts, metadata, active flags) are covered by `tests/plugins/test_plugin_load.py`.