### PR TITLE
test(probes): add unit tests for goodside probe module

### DIFF
--- a/tests/probes/test_probes_goodside.py
+++ b/tests/probes/test_probes_goodside.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Portions Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import garak._plugins
+
+
+def test_whoisriley_prompts_mention_riley_goodside():
+    probe = garak._plugins.load_plugin("probes.goodside.WhoIsRiley")
+    for prompt in probe.prompts:
+        assert "Riley Goodside" in prompt, "Every WhoIsRiley prompt must mention Riley Goodside"
+
+
+def test_whoisriley_primary_detector():
+    probe = garak._plugins.load_plugin("probes.goodside.WhoIsRiley")
+    assert probe.primary_detector == "goodside.RileyIsnt"
+
+
+def test_threatenjson_single_prompt_with_threat():
+    probe = garak._plugins.load_plugin("probes.goodside.ThreatenJSON")
+    assert len(probe.prompts) == 1, "ThreatenJSON must have exactly one prompt"
+    assert "JSON" in probe.prompts[0], "ThreatenJSON prompt must contain JSON instructions"
+    assert "innocent man" in probe.prompts[0], "ThreatenJSON prompt must contain the threat clause"
+
+
+def test_threatenjson_primary_detector():
+    probe = garak._plugins.load_plugin("probes.goodside.ThreatenJSON")
+    assert probe.primary_detector == "goodside.PlainJSON"
+
+
+def test_davidjl_triggers_parallel_to_prompts():
+    probe = garak._plugins.load_plugin("probes.goodside.Davidjl")
+    assert len(probe.triggers) == len(probe.prompts), (
+        "Davidjl triggers list must be parallel to prompts list"
+    )
+
+
+def test_davidjl_inactive():
+    probe = garak._plugins.load_plugin("probes.goodside.Davidjl")
+    assert probe.active is False, "Davidjl must be inactive (experimental glitch token probe)"


### PR DESCRIPTION
Add probe-unique tests for `garak/probes/goodside.py`.

## Verification

- [x] `python -m pytest tests/probes/test_probes_goodside.py -v` — all 6 tests pass

## What is tested

**WhoIsRiley**
- Every prompt mentions "Riley Goodside" (validates the hallucination-check intent)
- `primary_detector` is `goodside.RileyIsnt`

**ThreatenJSON**
- Exactly one prompt is generated
- Prompt contains the JSON instruction and the threat clause ("innocent man") — the threatening language is the unique mechanism of this probe
- `primary_detector` is `goodside.PlainJSON`

**Davidjl**
- `triggers` list is parallel to `prompts` list (required for `_attempt_prestore_hook` to assign per-attempt triggers correctly)
- `active` is `False` (glitch-token probe is intentionally inactive)

Generic checks (instantiation, isinstance, non-empty prompts, metadata, active flags) are covered by `tests/plugins/test_plugin_load.py`.