### PR TITLE
test(probes): add unit tests for lmrc probe module

### DIFF
--- a/tests/probes/test_probes_lmrc.py
+++ b/tests/probes/test_probes_lmrc.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Portions Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import garak._plugins
+
+
+def test_deadnaming_triggers_parallel_to_prompts():
+    probe = garak._plugins.load_plugin("probes.lmrc.Deadnaming")
+    assert len(probe.triggers) == len(probe.prompts), (
+        "Deadnaming triggers must be parallel to prompts for _attempt_prestore_hook"
+    )
+
+
+def test_deadnaming_triggers_are_nonempty_lists():
+    probe = garak._plugins.load_plugin("probes.lmrc.Deadnaming")
+    for trigger_set in probe.triggers:
+        assert isinstance(trigger_set, list) and len(trigger_set) > 0, (
+            "Each Deadnaming trigger entry must be a non-empty list"
+        )
+
+
+def test_anthropomorphisation_inactive_but_instantiable():
+    probe = garak._plugins.load_plugin("probes.lmrc.Anthropomorphisation")
+    assert probe.active is False
+    assert len(probe.prompts) > 0, "Inactive Anthropomorphisation must still have prompts"
+
+
+def test_quackmedicine_uses_module_detector():
+    probe = garak._plugins.load_plugin("probes.lmrc.QuackMedicine")
+    assert probe.primary_detector.startswith("lmrc."), (
+        "QuackMedicine must use an lmrc-module detector, not a generic one"
+    )
+
+
+def test_bullying_prompts_are_about_harm():
+    probe = garak._plugins.load_plugin("probes.lmrc.Bullying")
+    combined = " ".join(probe.prompts).lower()
+    assert any(word in combined for word in ("hurt", "scare", "afraid", "wedgie", "pay", "fired")), (
+        "Bullying prompts must contain harm-related language"
+    )


### PR DESCRIPTION
Add probe-unique tests for `garak/probes/lmrc.py`.

## Verification

- [x] `python -m pytest tests/probes/test_probes_lmrc.py -v` — all 5 tests pass

## What is tested

**Deadnaming**
- `triggers` list is parallel to `prompts` — required for `_attempt_prestore_hook` to correctly assign per-attempt trigger lists
- Each trigger entry is a non-empty list (not a bare string or empty list)

**Anthropomorphisation** (`active=False`)
- Can be instantiated and has non-empty `prompts` even though the probe is inactive

**QuackMedicine**
- `primary_detector` is in the `lmrc.*` namespace — distinguishes it from probes that delegate to generic `unsafe_content.*` detectors

**Bullying**
- Prompts contain harm-related language (sanity-checks the prompt content matches the probe intent)

Generic checks (instantiation, isinstance, non-empty prompts, metadata, active flags) are covered by `tests/plugins/test_plugin_load.py`.