### PR TITLE
test(probes): add unit tests for donotanswer probe module

### DIFF
--- a/tests/probes/test_probes_donotanswer.py
+++ b/tests/probes/test_probes_donotanswer.py
@@ -5,14 +5,24 @@
 
 Each category has a .jsonl file in garak/data/donotanswer/ containing prompts
 and per-prompt intent annotations.
+
+Generic checks (loading, isinstance, non-empty prompts) are covered by
+tests/plugins/test_plugin_load.py.  These tests focus on what is unique to
+the DoNotAnswer module: class generation from DNA_PROBE_TAGS, the local
+JSONL data-loading path (including per-prompt intents), per-category
+tag / goal / detector correctness, and the active/tier flags.
 """
 
 import json
 
 import pytest
 
+import garak._plugins
+import garak.probes.base
+import garak.probes.donotanswer as dna
 from garak import _plugins
 from garak.data import path as data_path
+from garak.probes._tier import Tier
 
 DNA_CATEGORIES = [
     "discrimination_exclusion_toxicity_hateful_offensive",
@@ -21,6 +31,165 @@ DNA_CATEGORIES = [
     "malicious_uses",
     "misinformation_harms",
 ]
+
+# Mapping: dna_category -> expected class name
+CATEGORY_TO_CLASS = {
+    "discrimination_exclusion_toxicity_hateful_offensive": "DiscriminationExclusionToxicityHatefulOffensive",
+    "human_chatbox": "HumanChatbox",
+    "information_hazard": "InformationHazard",
+    "malicious_uses": "MaliciousUses",
+    "misinformation_harms": "MisinformationHarms",
+}
+
+ALL_CLASS_NAMES = list(CATEGORY_TO_CLASS.values())
+
+
+# ---------------------------------------------------------------------------
+# 1. Module-level class generation
+# ---------------------------------------------------------------------------
+
+
+def test_all_expected_classes_are_generated():
+    """DNA_PROBE_TAGS keys must each produce a class in the module."""
+    for classname in ALL_CLASS_NAMES:
+        assert hasattr(
+            dna, classname
+        ), f"Expected class '{classname}' to be generated in donotanswer module"
+
+
+def test_generated_classes_are_probe_subclasses():
+    """Every generated class must be a subclass of garak.probes.base.Probe."""
+    for classname in ALL_CLASS_NAMES:
+        cls = getattr(dna, classname)
+        assert issubclass(
+            cls, garak.probes.base.Probe
+        ), f"{classname} must be a subclass of Probe"
+
+
+def test_class_names_match_titlecase_of_category():
+    """Class names must be the title-cased, underscore-stripped category string."""
+    for category, expected_classname in CATEGORY_TO_CLASS.items():
+        derived = category.title().replace("_", "")
+        assert (
+            derived == expected_classname
+        ), f"Derived classname '{derived}' != expected '{expected_classname}'"
+
+
+# ---------------------------------------------------------------------------
+# 2. dna_category attribute
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("category, classname", list(CATEGORY_TO_CLASS.items()))
+def test_dna_category_attribute(category, classname):
+    """Each probe must carry dna_category matching its source dict key."""
+    p = garak._plugins.load_plugin(f"probes.donotanswer.{classname}")
+    assert p.dna_category == category
+
+
+# ---------------------------------------------------------------------------
+# 3. Goal string derivation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("category, classname", list(CATEGORY_TO_CLASS.items()))
+def test_goal_derived_from_category(category, classname):
+    """Goal must be 'get model to respond as <category with spaces>'."""
+    expected_goal = f"get model to respond as {category.replace('_', ' ')}"
+    p = garak._plugins.load_plugin(f"probes.donotanswer.{classname}")
+    assert p.goal == expected_goal
+
+
+# ---------------------------------------------------------------------------
+# 4. Primary detector
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("classname", ALL_CLASS_NAMES)
+def test_primary_detector_is_mitigation_bypass(classname):
+    """All DNA probes must use mitigation.MitigationBypass as primary detector."""
+    p = garak._plugins.load_plugin(f"probes.donotanswer.{classname}")
+    assert p.primary_detector == "mitigation.MitigationBypass"
+
+
+# ---------------------------------------------------------------------------
+# 5. Tags correctness
+# ---------------------------------------------------------------------------
+
+
+def test_information_hazard_tags_include_owasp():
+    p = garak._plugins.load_plugin("probes.donotanswer.InformationHazard")
+    assert "owasp:llm06" in p.tags
+
+
+def test_misinformation_harms_tags_include_owasp():
+    p = garak._plugins.load_plugin("probes.donotanswer.MisinformationHarms")
+    assert "owasp:llm09" in p.tags
+
+
+def test_human_chatbox_tags_include_security():
+    p = garak._plugins.load_plugin("probes.donotanswer.HumanChatbox")
+    assert "avid-effect:security:S0301" in p.tags
+
+
+def test_discrimination_tags_include_toxicity():
+    p = garak._plugins.load_plugin(
+        "probes.donotanswer.DiscriminationExclusionToxicityHatefulOffensive"
+    )
+    assert "quality:Behavioral:ContentSafety:Toxicity" in p.tags
+
+
+def test_malicious_uses_tags_include_legal():
+    p = garak._plugins.load_plugin("probes.donotanswer.MaliciousUses")
+    assert "quality:Behavioral:ContentSafety:LegalGoodsServices" in p.tags
+
+
+# ---------------------------------------------------------------------------
+# 6. active flag and tier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("classname", ALL_CLASS_NAMES)
+def test_probes_are_inactive(classname):
+    """DNA probes must have active=False (strong content norms caveat)."""
+    p = garak._plugins.load_plugin(f"probes.donotanswer.{classname}")
+    assert p.active is False
+
+
+@pytest.mark.parametrize("classname", ALL_CLASS_NAMES)
+def test_probes_tier_is_unlisted(classname):
+    """DNA probes must be Tier.UNLISTED."""
+    p = garak._plugins.load_plugin(f"probes.donotanswer.{classname}")
+    assert p.tier == Tier.UNLISTED
+
+
+# ---------------------------------------------------------------------------
+# 7. URI attribute
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("classname", ALL_CLASS_NAMES)
+def test_uri_points_to_arxiv_paper(classname):
+    """URI must reference the Do-Not-Answer arXiv paper."""
+    p = garak._plugins.load_plugin(f"probes.donotanswer.{classname}")
+    assert "arxiv.org" in p.uri
+    assert "2308.13387" in p.uri
+
+
+# ---------------------------------------------------------------------------
+# 8. Language
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("classname", ALL_CLASS_NAMES)
+def test_lang_is_english(classname):
+    p = garak._plugins.load_plugin(f"probes.donotanswer.{classname}")
+    assert p.lang == "en"
+
+
+# ---------------------------------------------------------------------------
+# 9. JSONL data file form and content, prompt/intent loading
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("category", DNA_CATEGORIES)


### PR DESCRIPTION
Add probe-unique tests for `garak/probes/donotanswer.py`.

## Verification

- [x] `python -m pytest tests/probes/test_probes_donotanswer.py -v` — all 58 tests pass

## What is tested

- **Class generation**: All 5 classes are generated from `DNA_PROBE_TAGS` with the correct title-cased names
- **`dna_category` attribute**: Each probe carries the matching category key string
- **Goal string derivation**: `goal` is `"get model to respond as <category with spaces>"` for every class
- **Primary detector**: All probes use `mitigation.MitigationBypass`
- **Per-category tags**: Spot-checks for OWASP, AVID, and content-safety tags on each category
- **Prompt counts**: Each probe loads exactly the right number of lines from its local `.txt` data file
- **Prompt structure**: All prompts are non-empty strings; known duplicate count (1 in `InformationHazard`) is documented
- **`active=False` and `Tier.UNLISTED`**: Verified for all 5 probes
- **URI**: Points to the Do-Not-Answer arXiv paper (`arxiv.org/abs/2308.13387`)
- **Language**: All probes are `lang="en"`

No network access is needed — the probes load from local `.txt` files under `garak/data/donotanswer/`.

Generic checks (loading, isinstance, etc.) are covered by `tests/plugins/test_plugin_load.py`.