### PR TITLE
fix(logging): prevent log file race condition under parallel attempts

### DIFF
--- a/garak/__init__.py
+++ b/garak/__init__.py
@@ -10,6 +10,30 @@ from garak import _config
 
 GARAK_LOG_FILE_VAR = "GARAK_LOG_FILE"
 
+LOG_FORMAT = "%(asctime)s  %(levelname)s  %(message)s"
+
+
+def setup_logger(filename=None):
+    """Configure the root logger with garak's standard format/level.
+
+    This is the single place the garak log configuration is defined. It is
+    called once on initial import of this module, and may be called again
+    (e.g. by a :mod:`multiprocessing` pool initializer) to re-apply the same
+    configuration after handlers have been reset, such as when a worker
+    process needs to close inherited file descriptors and open its own.
+
+    :param filename: path to the log file. Defaults to the currently
+        configured ``_config.transient.log_filename``.
+    """
+    if filename is None:
+        filename = _config.transient.log_filename
+    logging.basicConfig(
+        filename=filename,
+        level=logging.DEBUG,
+        format=LOG_FORMAT,
+    )
+
+
 # allow for a file path configuration from the ENV and set for child processes
 _log_filename = os.getenv(GARAK_LOG_FILE_VAR, default=None)
 if _log_filename is None:
@@ -18,8 +42,4 @@ if _log_filename is None:
 
 _config.transient.log_filename = _log_filename
 
-logging.basicConfig(
-    filename=_log_filename,
-    level=logging.DEBUG,
-    format="%(asctime)s  %(levelname)s  %(message)s",
-)
+setup_logger(_log_filename)

--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -27,6 +27,37 @@ import garak.attempt
 import garak.resources.theme
 
 
+def _worker_logging_init():
+    """Pool initializer: close inherited log file handles and re-configure logging.
+
+    When :mod:`multiprocessing` spawns or forks worker processes the parent's
+    open :class:`logging.FileHandler` file descriptors are inherited.  Concurrent
+    writes through those shared handles can trigger a reentrant-flush
+    ``RuntimeError`` (see GitHub issue #1355).  This initializer runs once inside
+    each worker, closes every inherited handler, and re-applies the same
+    ``basicConfig`` the main process used, so each worker gets its own private
+    file descriptor pointing at the same log file.
+    """
+    import os
+    import logging
+
+    root = logging.getLogger()
+    for handler in root.handlers[:]:
+        try:
+            handler.close()
+        except Exception:
+            pass
+        root.removeHandler(handler)
+
+    log_filename = os.environ.get("GARAK_LOG_FILE")
+    if log_filename:
+        logging.basicConfig(
+            filename=log_filename,
+            level=logging.DEBUG,
+            format="%(asctime)s  %(levelname)s  %(message)s",
+        )
+
+
 class Probe(Configurable):
     """Base class for objects that define and execute LLM evaluations"""
 
@@ -332,7 +363,7 @@ class Probe(Configurable):
 
             attempt_pool = None
             try:
-                attempt_pool = Pool(pool_size)
+                attempt_pool = Pool(pool_size, initializer=_worker_logging_init)
                 for result in attempt_pool.imap_unordered(
                     self._execute_attempt, attempts
                 ):

--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -34,12 +34,14 @@ def _worker_logging_init():
     open :class:`logging.FileHandler` file descriptors are inherited.  Concurrent
     writes through those shared handles can trigger a reentrant-flush
     ``RuntimeError`` (see GitHub issue #1355).  This initializer runs once inside
-    each worker, closes every inherited handler, and re-applies the same
-    ``basicConfig`` the main process used, so each worker gets its own private
-    file descriptor pointing at the same log file.
+    each worker, closes every inherited handler, and re-applies the garak log
+    configuration via :func:`garak.setup_logger`, so each worker gets its own
+    private file descriptor pointing at the same log file.
     """
     import os
     import logging
+
+    import garak
 
     root = logging.getLogger()
     for handler in root.handlers[:]:
@@ -51,11 +53,7 @@ def _worker_logging_init():
 
     log_filename = os.environ.get("GARAK_LOG_FILE")
     if log_filename:
-        logging.basicConfig(
-            filename=log_filename,
-            level=logging.DEBUG,
-            format="%(asctime)s  %(levelname)s  %(message)s",
-        )
+        garak.setup_logger(log_filename)
 
 
 class Probe(Configurable):

--- a/tests/probes/test_probes_base_parallel_logging.py
+++ b/tests/probes/test_probes_base_parallel_logging.py
@@ -5,6 +5,7 @@
 race conditions under parallel probe execution (issue #1355)."""
 
 import logging
+import multiprocessing
 import os
 import tempfile
 from multiprocessing import Pool
@@ -237,12 +238,113 @@ def test_parallel_worker_fds_are_independent():
         valid_fds = [fd for fd in worker_fds if fd != -1]
         if valid_fds:
             assert all(fd != parent_fd for fd in valid_fds), (
-                "Worker file descriptors must differ from the parent's fd — "
+                "Worker file descriptors must differ from the parent's fd - "
                 "shared fds cause the reentrant-flush race condition"
             )
     finally:
         parent_handler.close()
         root.removeHandler(parent_handler)
+        if old_env is None:
+            os.environ.pop("GARAK_LOG_FILE", None)
+        else:
+            os.environ["GARAK_LOG_FILE"] = old_env
+        os.unlink(log_path)
+
+
+# ---------------------------------------------------------------------------
+# Deterministic fork-based regression test: this is the test that actually
+# exercises the bug fixed by this PR. It must FAIL if _worker_logging_init is
+# bypassed (simulating the pre-fix code) and PASS with it wired up.
+# ---------------------------------------------------------------------------
+
+
+_FORK_AVAILABLE = "fork" in multiprocessing.get_all_start_methods()
+
+
+@pytest.mark.skipif(
+    not _FORK_AVAILABLE,
+    reason=(
+        "This test requires the 'fork' multiprocessing start method to "
+        "reproduce fd inheritance; platforms that only support 'spawn' "
+        "(e.g. Windows) never inherit the parent's open file handles, so "
+        "the underlying bug cannot manifest there."
+    ),
+)
+def test_worker_inherits_parent_fd_without_initializer_but_not_with_it():
+    """Demonstrates the actual bug fixed by this PR (issue #1355).
+
+    Root cause: when :mod:`multiprocessing` *forks* worker processes, each
+    worker inherits the parent's exact, shared file descriptor for any open
+    ``logging.FileHandler``. Concurrent writes -- or reentrant flushes
+    triggered by third-party destructors -- on that shared fd can raise
+    ``RuntimeError: reentrant call inside <_io.BufferedWriter>``.
+
+    This test runs the *same* worker function through a fork-context Pool
+    twice:
+
+    1. WITHOUT any initializer (simulating the code before this PR) -- the
+       worker must report the identical fd number as the parent's open
+       FileHandler, proving the dangerous fd-sharing actually happens.
+    2. WITH ``_worker_logging_init`` as the Pool initializer (the fix in
+       this PR) -- the worker must report a *different* fd, proving each
+       worker now owns a private file descriptor.
+
+    If ``_worker_logging_init`` is removed or not passed to ``Pool(...)``,
+    step 2 will report the same (shared) fd as step 1 and this test fails.
+    """
+    ctx = multiprocessing.get_context("fork")
+
+    with tempfile.NamedTemporaryFile(suffix=".log", delete=False) as f:
+        log_path = f.name
+
+    root = logging.getLogger()
+    original_handlers = root.handlers[:]
+    for h in original_handlers:
+        root.removeHandler(h)
+
+    old_env = os.environ.get("GARAK_LOG_FILE")
+    os.environ["GARAK_LOG_FILE"] = log_path
+
+    parent_handler = logging.FileHandler(log_path)
+    root.addHandler(parent_handler)
+    parent_fd = parent_handler.stream.fileno()
+
+    try:
+        # Step 1: no initializer -- forked worker inherits the parent's fd
+        # table, so it must report the SAME fd as the parent. This is the
+        # exact pre-fix condition that allows concurrent/reentrant writes
+        # on a shared underlying file description to race.
+        with ctx.Pool(processes=1) as pool:
+            (fd_without_initializer,) = pool.map(_log_from_worker, [log_path])
+
+        assert fd_without_initializer == parent_fd, (
+            "Sanity check failed: a forked worker without any logging "
+            "initializer was expected to inherit the parent's exact file "
+            f"descriptor ({parent_fd}), but got {fd_without_initializer}. "
+            "If this fails, the fd-inheritance precondition for issue "
+            "#1355 is not being reproduced on this platform/Python version."
+        )
+
+        # Step 2: with _worker_logging_init -- the worker must close the
+        # inherited handler and open its own, so its fd must differ from
+        # the parent's.
+        with ctx.Pool(processes=1, initializer=_worker_logging_init) as pool:
+            (fd_with_initializer,) = pool.map(_log_from_worker, [log_path])
+
+        assert fd_with_initializer != parent_fd, (
+            "Worker process shared the parent's file descriptor "
+            f"({parent_fd}) even though _worker_logging_init was used as "
+            "the Pool initializer. This is the exact race condition from "
+            "issue #1355: without a fresh, private fd per worker, "
+            "concurrent or reentrant flushes on the shared handle can "
+            "raise 'RuntimeError: reentrant call inside "
+            "<_io.BufferedWriter>'."
+        )
+    finally:
+        parent_handler.close()
+        root.removeHandler(parent_handler)
+        for h in original_handlers:
+            root.addHandler(h)
         if old_env is None:
             os.environ.pop("GARAK_LOG_FILE", None)
         else:

--- a/tests/probes/test_probes_base_parallel_logging.py
+++ b/tests/probes/test_probes_base_parallel_logging.py
@@ -8,10 +8,13 @@ import logging
 import os
 import tempfile
 from multiprocessing import Pool
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+import garak._config
+import garak._plugins
+import garak.attempt
 from garak.probes.base import _worker_logging_init
 
 
@@ -245,3 +248,47 @@ def test_parallel_worker_fds_are_independent():
         else:
             os.environ["GARAK_LOG_FILE"] = old_env
         os.unlink(log_path)
+
+
+# ---------------------------------------------------------------------------
+# Regression test: Probe._execute_all must wire up the initializer
+# ---------------------------------------------------------------------------
+
+
+def test_execute_all_passes_logging_initializer_to_pool():
+    """Probe._execute_all must construct its worker Pool with
+    initializer=_worker_logging_init. Without this wiring, forked workers
+    inherit the parent's log FileHandler and share its file descriptor,
+    which can raise a reentrant-flush RuntimeError under concurrent writes
+    (issue #1355). This test fails if the initializer argument is removed."""
+    with open(os.devnull, "w+", encoding="utf-8") as fh:
+        garak._config.load_base_config()
+        garak._config.transient.reportfile = fh
+
+        p = garak._plugins.load_plugin(
+            "probes.test.Test", config_root=garak._config
+        )
+        g = garak._plugins.load_plugin(
+            "generators.test.Repeat", config_root=garak._config
+        )
+        p.generator = g
+        p.parallel_attempts = 2
+
+        attempts = [
+            garak.attempt.Attempt(prompt=garak.attempt.Message("test one")),
+            garak.attempt.Attempt(prompt=garak.attempt.Message("test two")),
+        ]
+
+        real_pool = Pool
+
+        with patch("multiprocessing.Pool", wraps=real_pool) as mock_pool:
+            p._execute_all(attempts)
+
+        garak._config.transient.reportfile = None
+
+        assert mock_pool.called, "Probe._execute_all should use a worker Pool"
+        _, kwargs = mock_pool.call_args
+        assert kwargs.get("initializer") is _worker_logging_init, (
+            "Probe._execute_all must pass _worker_logging_init as the Pool "
+            "initializer to avoid shared log file descriptors in workers"
+        )

--- a/tests/probes/test_probes_base_parallel_logging.py
+++ b/tests/probes/test_probes_base_parallel_logging.py
@@ -1,0 +1,247 @@
+# SPDX-FileCopyrightText: Portions Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the _worker_logging_init pool initializer that prevents log-file
+race conditions under parallel probe execution (issue #1355)."""
+
+import logging
+import os
+import tempfile
+from multiprocessing import Pool
+from unittest.mock import MagicMock
+
+import pytest
+
+from garak.probes.base import _worker_logging_init
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _log_from_worker(log_file: str) -> int:
+    """Target function run inside a Pool worker.
+
+    Returns the file-descriptor number of the root logger's FileHandler so the
+    parent can verify each worker got its own private fd.
+    """
+    for i in range(50):
+        logging.debug("worker log line %d", i)
+    root = logging.getLogger()
+    for h in root.handlers:
+        if isinstance(h, logging.FileHandler):
+            return h.stream.fileno()
+    return -1
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _worker_logging_init
+# ---------------------------------------------------------------------------
+
+
+def test_worker_init_clears_inherited_handlers():
+    """_worker_logging_init must remove all handlers the parent process had."""
+    root = logging.getLogger()
+    original_handlers = root.handlers[:]
+
+    mock_handler = MagicMock(spec=logging.Handler)
+    root.addHandler(mock_handler)
+    assert mock_handler in root.handlers
+
+    try:
+        _worker_logging_init()
+        assert mock_handler not in root.handlers, (
+            "_worker_logging_init should remove all inherited handlers"
+        )
+    finally:
+        # Restore whatever was there before (mock already removed by init)
+        for h in root.handlers[:]:
+            root.removeHandler(h)
+        for h in original_handlers:
+            root.addHandler(h)
+
+
+def test_worker_init_opens_file_handler_when_env_set():
+    """_worker_logging_init must install a FileHandler pointing at GARAK_LOG_FILE."""
+    root = logging.getLogger()
+    original_handlers = root.handlers[:]
+
+    with tempfile.NamedTemporaryFile(suffix=".log", delete=False) as f:
+        log_path = f.name
+
+    old_env = os.environ.get("GARAK_LOG_FILE")
+    os.environ["GARAK_LOG_FILE"] = log_path
+
+    try:
+        # Clear handlers so basicConfig will take effect
+        for h in root.handlers[:]:
+            root.removeHandler(h)
+
+        _worker_logging_init()
+
+        file_handlers = [
+            h for h in root.handlers if isinstance(h, logging.FileHandler)
+        ]
+        assert len(file_handlers) >= 1, (
+            "_worker_logging_init should add a FileHandler when GARAK_LOG_FILE is set"
+        )
+        assert any(h.baseFilename == log_path for h in file_handlers), (
+            "FileHandler should point at GARAK_LOG_FILE"
+        )
+    finally:
+        for h in root.handlers[:]:
+            if isinstance(h, logging.FileHandler):
+                h.close()
+            root.removeHandler(h)
+        for h in original_handlers:
+            root.addHandler(h)
+        if old_env is None:
+            os.environ.pop("GARAK_LOG_FILE", None)
+        else:
+            os.environ["GARAK_LOG_FILE"] = old_env
+        os.unlink(log_path)
+
+
+def test_worker_init_no_file_handler_when_env_unset():
+    """_worker_logging_init must not add a FileHandler when GARAK_LOG_FILE is absent."""
+    root = logging.getLogger()
+    original_handlers = root.handlers[:]
+
+    old_env = os.environ.pop("GARAK_LOG_FILE", None)
+
+    try:
+        for h in root.handlers[:]:
+            root.removeHandler(h)
+
+        _worker_logging_init()
+
+        file_handlers = [
+            h for h in root.handlers if isinstance(h, logging.FileHandler)
+        ]
+        assert file_handlers == [], (
+            "_worker_logging_init should not add a FileHandler when GARAK_LOG_FILE is not set"
+        )
+    finally:
+        for h in root.handlers[:]:
+            if isinstance(h, logging.FileHandler):
+                h.close()
+            root.removeHandler(h)
+        for h in original_handlers:
+            root.addHandler(h)
+        if old_env is not None:
+            os.environ["GARAK_LOG_FILE"] = old_env
+
+
+def test_worker_init_is_idempotent():
+    """Calling _worker_logging_init twice must not accumulate extra handlers."""
+    root = logging.getLogger()
+    original_handlers = root.handlers[:]
+
+    with tempfile.NamedTemporaryFile(suffix=".log", delete=False) as f:
+        log_path = f.name
+
+    old_env = os.environ.get("GARAK_LOG_FILE")
+    os.environ["GARAK_LOG_FILE"] = log_path
+
+    try:
+        for h in root.handlers[:]:
+            root.removeHandler(h)
+
+        _worker_logging_init()
+        count_after_first = len(root.handlers)
+        _worker_logging_init()
+        count_after_second = len(root.handlers)
+
+        assert count_after_second <= count_after_first, (
+            "Calling _worker_logging_init twice must not add duplicate handlers"
+        )
+    finally:
+        for h in root.handlers[:]:
+            if isinstance(h, logging.FileHandler):
+                h.close()
+            root.removeHandler(h)
+        for h in original_handlers:
+            root.addHandler(h)
+        if old_env is None:
+            os.environ.pop("GARAK_LOG_FILE", None)
+        else:
+            os.environ["GARAK_LOG_FILE"] = old_env
+        os.unlink(log_path)
+
+
+# ---------------------------------------------------------------------------
+# Integration test: parallel workers log without RuntimeError
+# ---------------------------------------------------------------------------
+
+
+def test_parallel_workers_log_without_error():
+    """Pool workers initialised with _worker_logging_init must not raise
+    RuntimeError due to shared-fd log writes (regression for issue #1355)."""
+    with tempfile.NamedTemporaryFile(suffix=".log", delete=False) as f:
+        log_path = f.name
+
+    root = logging.getLogger()
+    parent_handler = logging.FileHandler(log_path)
+    root.addHandler(parent_handler)
+
+    old_env = os.environ.get("GARAK_LOG_FILE")
+    os.environ["GARAK_LOG_FILE"] = log_path
+
+    errors = []
+    try:
+        with Pool(processes=4, initializer=_worker_logging_init) as pool:
+            results = pool.map(_log_from_worker, [log_path] * 8)
+        # All workers should have returned a valid fd number
+        assert all(isinstance(r, int) for r in results), (
+            "All worker tasks should complete and return an integer fd"
+        )
+    except RuntimeError as exc:
+        errors.append(str(exc))
+    finally:
+        parent_handler.close()
+        root.removeHandler(parent_handler)
+        if old_env is None:
+            os.environ.pop("GARAK_LOG_FILE", None)
+        else:
+            os.environ["GARAK_LOG_FILE"] = old_env
+        os.unlink(log_path)
+
+    assert not errors, (
+        f"Parallel logging raised RuntimeError (race condition): {errors}"
+    )
+
+
+def test_parallel_worker_fds_are_independent():
+    """Each Pool worker should open its own file descriptor for the log file,
+    not share the parent's inherited fd (regression for issue #1355)."""
+    with tempfile.NamedTemporaryFile(suffix=".log", delete=False) as f:
+        log_path = f.name
+
+    root = logging.getLogger()
+    parent_handler = logging.FileHandler(log_path)
+    root.addHandler(parent_handler)
+    parent_fd = parent_handler.stream.fileno()
+
+    old_env = os.environ.get("GARAK_LOG_FILE")
+    os.environ["GARAK_LOG_FILE"] = log_path
+
+    try:
+        with Pool(processes=2, initializer=_worker_logging_init) as pool:
+            worker_fds = pool.map(_log_from_worker, [log_path] * 2)
+
+        # Workers that got a FileHandler should report a valid fd
+        valid_fds = [fd for fd in worker_fds if fd != -1]
+        if valid_fds:
+            assert all(fd != parent_fd for fd in valid_fds), (
+                "Worker file descriptors must differ from the parent's fd — "
+                "shared fds cause the reentrant-flush race condition"
+            )
+    finally:
+        parent_handler.close()
+        root.removeHandler(parent_handler)
+        if old_env is None:
+            os.environ.pop("GARAK_LOG_FILE", None)
+        else:
+            os.environ["GARAK_LOG_FILE"] = old_env
+        os.unlink(log_path)

--- a/tests/probes/test_probes_base_parallel_logging.py
+++ b/tests/probes/test_probes_base_parallel_logging.py
@@ -13,6 +13,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - fcntl is POSIX-only (no Windows)
+    fcntl = None
+
 import garak._config
 import garak._plugins
 import garak.attempt
@@ -37,6 +42,45 @@ def _log_from_worker(log_file: str) -> int:
         if isinstance(h, logging.FileHandler):
             return h.stream.fileno()
     return -1
+
+
+def _worker_try_exclusive_lock(log_file: str) -> bool:
+    """Target function run inside a Pool worker.
+
+    Attempts to take a non-blocking exclusive ``flock`` on the worker's own
+    FileHandler fd and reports whether the lock was acquired.
+
+    ``flock`` locks are associated with the *open file description*, not
+    with a raw fd number or a process. A fd that is merely inherited from
+    the parent (dup'd via fork, without being closed and reopened) shares
+    the parent's open file description and therefore shares its lock state
+    -- re-acquiring the same exclusive lock from a fd on that same
+    description succeeds trivially. A fd that was closed and freshly
+    reopened (as ``_worker_logging_init`` does) points at an independent
+    open file description; if the parent is already holding an exclusive
+    lock on that file, a non-blocking attempt to lock the new, independent
+    description will conflict and raise ``BlockingIOError``.
+
+    This is a more reliable signal than comparing raw fd *numbers* across
+    processes: the OS is free to reuse a low fd number immediately after
+    it is closed, so two independent open file descriptions can coincidentally
+    end up with the identical fd number in the worker's fd table even when
+    they are genuinely separate resources.
+    """
+    root = logging.getLogger()
+    fd = -1
+    for h in root.handlers:
+        if isinstance(h, logging.FileHandler):
+            fd = h.stream.fileno()
+            break
+    if fd == -1:
+        return False
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        return True
+    except BlockingIOError:
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -290,8 +334,23 @@ def test_worker_inherits_parent_fd_without_initializer_but_not_with_it():
        worker now owns a private file descriptor.
 
     If ``_worker_logging_init`` is removed or not passed to ``Pool(...)``,
-    step 2 will report the same (shared) fd as step 1 and this test fails.
+    step 2's worker will still hold the parent's exact open file
+    description and this test fails.
+
+    Note: step 2 does not compare raw fd *numbers*, because the OS is free
+    to reuse a low fd number immediately after it is closed. When step 1's
+    pool tears down and step 2's pool forks a fresh worker, the freed fd
+    slot can coincidentally be reassigned the same number by
+    ``_worker_logging_init``'s fresh ``open()`` call even though it is a
+    genuinely independent open file description -- this is expected,
+    correct behaviour of a properly-fixed system, not a bug, and was
+    causing spurious failures on some platforms/architectures. Instead,
+    step 2 uses ``flock`` to prove the worker's fd refers to an
+    independent open file description (see ``_worker_try_exclusive_lock``).
     """
+    if fcntl is None:
+        pytest.skip("fcntl is not available on this platform")
+
     ctx = multiprocessing.get_context("fork")
 
     with tempfile.NamedTemporaryFile(suffix=".log", delete=False) as f:
@@ -326,19 +385,34 @@ def test_worker_inherits_parent_fd_without_initializer_but_not_with_it():
         )
 
         # Step 2: with _worker_logging_init -- the worker must close the
-        # inherited handler and open its own, so its fd must differ from
-        # the parent's.
-        with ctx.Pool(processes=1, initializer=_worker_logging_init) as pool:
-            (fd_with_initializer,) = pool.map(_log_from_worker, [log_path])
+        # inherited handler and open its own private file description. We
+        # prove this by holding an exclusive, non-blocking flock on the
+        # parent's fd: if the worker's fd still points at the SAME open
+        # file description (the pre-fix bug), a lock attempt from the
+        # worker succeeds trivially (it's the same lock). If the worker's
+        # fd is a fresh, independent open file description (the fix), the
+        # non-blocking attempt conflicts with the parent's held lock and
+        # fails.
+        fcntl.flock(parent_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            with ctx.Pool(
+                processes=1, initializer=_worker_logging_init
+            ) as pool:
+                (worker_acquired_lock,) = pool.map(
+                    _worker_try_exclusive_lock, [log_path]
+                )
+        finally:
+            fcntl.flock(parent_fd, fcntl.LOCK_UN)
 
-        assert fd_with_initializer != parent_fd, (
-            "Worker process shared the parent's file descriptor "
-            f"({parent_fd}) even though _worker_logging_init was used as "
-            "the Pool initializer. This is the exact race condition from "
-            "issue #1355: without a fresh, private fd per worker, "
-            "concurrent or reentrant flushes on the shared handle can "
-            "raise 'RuntimeError: reentrant call inside "
-            "<_io.BufferedWriter>'."
+        assert not worker_acquired_lock, (
+            "Worker process shared the parent's open file description "
+            "even though _worker_logging_init was used as the Pool "
+            "initializer (proven by the worker being able to acquire a "
+            "lock already exclusively held by the parent). This is the "
+            "exact race condition from issue #1355: without a fresh, "
+            "private file description per worker, concurrent or "
+            "reentrant flushes on the shared handle can raise "
+            "'RuntimeError: reentrant call inside <_io.BufferedWriter>'."
         )
     finally:
         parent_handler.close()


### PR DESCRIPTION
## Summary

Fixes #1355.

When `multiprocessing.Pool` forks worker processes they inherit the parent's open `FileHandler` file descriptor. Concurrent writes — or reentrant flushes triggered by third-party library destructors (e.g. `openai`/`httpcore` closing connections in `__del__`) — on those shared handles cause a `RuntimeError: reentrant call inside <_io.BufferedWriter>` in Python 3.13+.

**Fix:** pass `initializer=_worker_logging_init` to `Pool(...)` in `garak/probes/base.py`. The initializer runs once in each worker process and:
1. Closes and removes every inherited log handler.
2. Re-opens a fresh `FileHandler` via `logging.basicConfig`, using the `GARAK_LOG_FILE` env var that `garak/__init__.py` already sets before any children are spawned.

Each worker then has its own private file descriptor pointing at the same log file, eliminating the shared-handle race.

## Files changed

- `garak/probes/base.py` — add `_worker_logging_init()` and pass it as `initializer` to `Pool`

## Test plan

- [ ] Reproduce with `parallel_attempts: 2` and a multi-probe run (e.g. the config from the issue comments) — confirm no `RuntimeError` appears in the log
- [ ] Existing unit tests pass (pre-existing missing-module failures are unrelated to this change)