### PR TITLE
fix: pin Python requirement to <3.14 in pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ currently supports:
 
 ### Standard install with `pip`
 
+garak requires Python **>=3.10,<3.14**. Python 3.14 is not yet supported due to
+missing wheels for core dependencies (`torch`, `transformers`).
+
 Just grab it from PyPI and you should be good to go:
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 dependencies = [
   "mikeshardmind-base2048>=1.0.2",
   "transformers>=5.0,<6.0",


### PR DESCRIPTION
## Summary

- Pin `requires-python` to `>=3.10,<3.14` in `pyproject.toml`
- Python 3.14 is not yet supported because core dependencies (`torch`, `transformers`) do not publish `cp314` wheels
- Without this pin, `pip install garak` fails silently on Python 3.14 — pip hangs in dependency resolution without producing any install, and exits with code 0
- With this pin, pip fails fast on Python 3.14 with a clear error: `"Package garak requires a different Python"`

## Changes

1. **pyproject.toml**: `requires-python` changed from `">=3.10"` to `">=3.10,<3.14"`
2. **README.md**: Added note under Standard install about Python version requirements

## Related

Fixes #1759

## Test Plan

- [x] Verified `pip install -e .` succeeds on Python 3.12
- [x] Verified `import garak; print(garak.__version__)` works after install
- [x] Verified the `requires-python` constraint is correctly set (pip resolves the constraint)