### PR TITLE
test(detectors): mock data to manage avoid HF Hub 5xx instead of failing

### DIFF
--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -16,6 +16,8 @@ from garak.detectors.base import Detector
 from garak.exception import APIKeyMissingError
 import garak.detectors.base
 
+from huggingface_hub.errors import HfHubHTTPError
+
 DEFAULT_GENERATOR_NAME = "garak test"
 DEFAULT_PROMPT_TEXT = "especially the lies"
 
@@ -79,6 +81,10 @@ def test_detector_detect(classname):
         di.__init__()
     except APIKeyMissingError:
         pytest.skip(f"API key unavailable for {classname}")
+    except HfHubHTTPError as exc:
+        if exc.response is not None and exc.response.status_code >= 500:
+            pytest.skip(f"HF Hub server error for {classname}: {exc}")
+        raise
 
     assert isinstance(di, Detector), "detectors must eventually inherit from Detector"
     assert isinstance(di, Configurable), "detectors must be configurable"
@@ -98,6 +104,10 @@ def test_detector_detect(classname):
         results = di.detect(a)
     except APIKeyMissingError:
         pytest.skip(f"API key unavailable for {classname}")
+    except HfHubHTTPError as exc:
+        if exc.response is not None and exc.response.status_code >= 500:
+            pytest.skip(f"HF Hub server error for {classname}: {exc}")
+        raise
 
     assert isinstance(
         results, (list, types.GeneratorType)

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -4,6 +4,7 @@
 import importlib
 import inspect
 import re
+from unittest.mock import Mock
 import pytest
 import types
 
@@ -16,8 +17,6 @@ from garak.detectors.base import Detector
 from garak.exception import APIKeyMissingError
 import garak.detectors.base
 
-from huggingface_hub.errors import HfHubHTTPError
-
 DEFAULT_GENERATOR_NAME = "garak test"
 DEFAULT_PROMPT_TEXT = "especially the lies"
 
@@ -27,6 +26,15 @@ with open(
     encoding="utf-8",
 ) as misp_data:
     MISP_TAGS = [line.split("\t")[0] for line in misp_data.read().split("\n")]
+
+
+class _MockDataset:
+    column_names = ["text"]
+
+    def __getitem__(self, key):
+        if key == "text":
+            return ["some_package"]
+        raise KeyError(key)
 
 
 DETECTORS = [
@@ -72,7 +80,8 @@ def test_detector_structure(classname):
 
 
 @pytest.mark.parametrize("classname", DETECTORS)
-def test_detector_detect(classname):
+def test_detector_detect(classname, monkeypatch):
+    monkeypatch.setattr("datasets.load_dataset", Mock(return_value=_MockDataset()))
 
     m = importlib.import_module("garak." + ".".join(classname.split(".")[:-1]))
     dc = getattr(m, classname.split(".")[-1])
@@ -81,10 +90,6 @@ def test_detector_detect(classname):
         di.__init__()
     except APIKeyMissingError:
         pytest.skip(f"API key unavailable for {classname}")
-    except HfHubHTTPError as exc:
-        if exc.response is not None and exc.response.status_code >= 500:
-            pytest.skip(f"HF Hub server error for {classname}: {exc}")
-        raise
 
     assert isinstance(di, Detector), "detectors must eventually inherit from Detector"
     assert isinstance(di, Configurable), "detectors must be configurable"
@@ -104,10 +109,6 @@ def test_detector_detect(classname):
         results = di.detect(a)
     except APIKeyMissingError:
         pytest.skip(f"API key unavailable for {classname}")
-    except HfHubHTTPError as exc:
-        if exc.response is not None and exc.response.status_code >= 500:
-            pytest.skip(f"HF Hub server error for {classname}: {exc}")
-        raise
 
     assert isinstance(
         results, (list, types.GeneratorType)

--- a/tests/detectors/test_detectors_packagehallucination.py
+++ b/tests/detectors/test_detectors_packagehallucination.py
@@ -1,5 +1,7 @@
 import pytest
 
+from huggingface_hub.errors import HfHubHTTPError
+
 from garak.attempt import Attempt, Message
 import garak.detectors.base
 import garak.detectors.packagehallucination
@@ -372,12 +374,22 @@ def test_perl_known_package():
 
 
 def test_dart_detector_init():
-    d = garak.detectors.packagehallucination.Dart()
+    try:
+        d = garak.detectors.packagehallucination.Dart()
+    except HfHubHTTPError as exc:
+        if exc.response is not None and exc.response.status_code >= 500:
+            pytest.skip(f"HF Hub server error instantiating Dart: {exc}")
+        raise
     assert isinstance(d, garak.detectors.base.Detector)
 
 
 def test_dart_known_package():
-    detector = garak.detectors.packagehallucination.Dart()
+    try:
+        detector = garak.detectors.packagehallucination.Dart()
+    except HfHubHTTPError as exc:
+        if exc.response is not None and exc.response.status_code >= 500:
+            pytest.skip(f"HF Hub server error instantiating Dart: {exc}")
+        raise
     attempt = Attempt(prompt=Message(text="Importing http"))
     attempt.outputs = ["import 'package:http/http.dart';"]
     assert detector.detect(attempt) == [
@@ -386,7 +398,12 @@ def test_dart_known_package():
 
 
 def test_dart_hallucinated_package():
-    detector = garak.detectors.packagehallucination.Dart()
+    try:
+        detector = garak.detectors.packagehallucination.Dart()
+    except HfHubHTTPError as exc:
+        if exc.response is not None and exc.response.status_code >= 500:
+            pytest.skip(f"HF Hub server error instantiating Dart: {exc}")
+        raise
     attempt = Attempt(prompt=Message(text="Importing fake package"))
     attempt.outputs = ["import 'package:unicorn_ai/agent.dart';"]
     assert detector.detect(attempt) == [

--- a/tests/detectors/test_detectors_packagehallucination.py
+++ b/tests/detectors/test_detectors_packagehallucination.py
@@ -1,6 +1,5 @@
 import pytest
-
-from huggingface_hub.errors import HfHubHTTPError
+from unittest.mock import Mock
 
 from garak.attempt import Attempt, Message
 import garak.detectors.base
@@ -373,23 +372,27 @@ def test_perl_known_package():
     assert result == [0.0], f"Expected no hallucination detection for: {known_module}"
 
 
-def test_dart_detector_init():
-    try:
-        d = garak.detectors.packagehallucination.Dart()
-    except HfHubHTTPError as exc:
-        if exc.response is not None and exc.response.status_code >= 500:
-            pytest.skip(f"HF Hub server error instantiating Dart: {exc}")
-        raise
+class _MockDartDataset:
+    column_names = ["text"]
+
+    def __getitem__(self, key):
+        if key == "text":
+            return ["http", "flutter", "provider", "dio"]
+        raise KeyError(key)
+
+
+@pytest.fixture
+def mock_dart_dataset(monkeypatch):
+    monkeypatch.setattr("datasets.load_dataset", Mock(return_value=_MockDartDataset()))
+
+
+def test_dart_detector_init(mock_dart_dataset):
+    d = garak.detectors.packagehallucination.Dart()
     assert isinstance(d, garak.detectors.base.Detector)
 
 
-def test_dart_known_package():
-    try:
-        detector = garak.detectors.packagehallucination.Dart()
-    except HfHubHTTPError as exc:
-        if exc.response is not None and exc.response.status_code >= 500:
-            pytest.skip(f"HF Hub server error instantiating Dart: {exc}")
-        raise
+def test_dart_known_package(mock_dart_dataset):
+    detector = garak.detectors.packagehallucination.Dart()
     attempt = Attempt(prompt=Message(text="Importing http"))
     attempt.outputs = ["import 'package:http/http.dart';"]
     assert detector.detect(attempt) == [
@@ -397,13 +400,8 @@ def test_dart_known_package():
     ], "Expected no hallucination for known package"
 
 
-def test_dart_hallucinated_package():
-    try:
-        detector = garak.detectors.packagehallucination.Dart()
-    except HfHubHTTPError as exc:
-        if exc.response is not None and exc.response.status_code >= 500:
-            pytest.skip(f"HF Hub server error instantiating Dart: {exc}")
-        raise
+def test_dart_hallucinated_package(mock_dart_dataset):
+    detector = garak.detectors.packagehallucination.Dart()
     attempt = Attempt(prompt=Message(text="Importing fake package"))
     attempt.outputs = ["import 'package:unicorn_ai/agent.dart';"]
     assert detector.detect(attempt) == [


### PR DESCRIPTION
Tests that directly instantiate detectors with Hugging Face Hub dependencies have no guard against transient server-side errors. When HF Hub returns a 5xx (e.g. 504 Gateway Time-out), pytest marks the test FAILED and blocks unrelated PRs. This PR catches HfHubHTTPError on status codes ≥ 500 and converts them to pytest.skip(), consistent with the maintainer intent already documented in issues #1033 and #1479.

## Problem

In CI run [2931](https://github.com/NVIDIA/garak/actions/runs/25991990512/job/79178386303), the build (ubuntu-latest, 3.12) failed on a test unrelated to the PR under review:

```
FAILED tests/detectors/test_detectors.py::test_detector_detect[detectors.packagehallucination.Dart]
huggingface_hub.errors.HfHubHTTPError: Server error '504 Gateway Time-out'
for url 'https://huggingface.co/api/datasets/garak-llm/dart-20250811/tree/...'
The failure originates in garak/detectors/packagehallucination.py:_load_package_list(), which calls datasets.load_dataset() during __init__. The HF Hub API returned a transient 504. The exception propagated unhandled through test_detector_detect, which wraps di.__init__() and di.detect() but only catches APIKeyMissingError.
```

The same pattern also affects test_dart_detector_init, test_dart_known_package, and test_dart_hallucinated_package in tests/detectors/test_detectors_packagehallucination.py, all of which call Dart() with no network-error guard.

### Related

Issue #1479 ("detectors: back off when HF model unavail") tracks this exact failure mode. The issue was opened after CI runs showed HF Hub returning 503 during test_detectors.py. @leondz: "An alternative is to 'SKIP' for the detector." This PR implements that intent at the test layer.

Issue #1033 ("Fall back when online services can't be reached") tracks the broader runtime case. @leondz's response there: "in the very worst case skip that detector."

PR #1736 ("gracefully skip probes whose detectors are unreachable") addresses the same root cause at the runtime layer. However, #1736 does not fix the CI failure: the test suite instantiates detectors directly via dc.__new__(dc); di.__init__(), bypassing _plugins.load_plugin(break_on_fail=False) entirely. #1736 and this PR are complementary and do not overlap.

## Changes

Original implemented skipping on network issue: The issue with the approach is that `pytest.skip` on network error gives a false green: if the HF call were broken by a code change rather than a server error, CI would still skip rather than fail.

**`tests/detectors/test_detectors.py`**
- Remove `HfHubHTTPError` import and both `except HfHubHTTPError` skip blocks
- Add `_MockDataset` (columns: `["text"]`, returns `["some_package"]`) and patch `datasets.load_dataset` via `monkeypatch` at the top of `test_detector_detect`

**`tests/detectors/test_detectors_packagehallucination.py`**
- Remove `HfHubHTTPError` import and all three try/except/skip blocks around `Dart()` instantiation
- Add `_MockDartDataset` and a `mock_dart_dataset` fixture; the three Dart test functions receive it as a parameter

## Mock vs source data

The mocked datasets are minimal stubs that satisfy the `_load_package_list()` contract (`column_names`, `dataset["text"]`). The table below compares each mock against its real HF dataset.

| Detector | HF Dataset | Real rows | Real columns | Real sample (first 3) | Mock `column_names` | Mock `text` values |
|---|---|---|---|---|---|---|
| **Dart** | `garak-llm/dart-20250811` | 67.3k | `text` | `Autolinker`, `Babylon`, `DartDemoCLI` | `text` | `http`, `flutter`, `provider`, `dio` |
| **PythonPypi** | `garak-llm/pypi-20241031` | 555k | `text`, `package_first_seen` | `3defficientnet`, `4to5`, `3color-press` | `text` | `some_package` |
| **JavaScriptNpm** | `garak-llm/npm-20241031` | 3,3M | `text`, `package_first_seen` | `000demo`, `006wordcounter`, `0038_currencies_convertor` | `text` | `some_package` |
| **RustCrates** | `garak-llm/crates-20250307` | 156k | `text`, `package_first_seen` | `std`, `peekable`, `madara` | `text` | `some_package` |
| **RubyGems** | `garak-llm/rubygems-20241031` | 181k | `text`, `package_first_seen` | `88miles`, `0xfacet-uniswap`, `19cah` | `text` | `some_package` |
| **RakuLand** | `garak-llm/raku-20250811` | 2.14k | `text` | `ABC`, `ACME::Fez`, `ADT` | `text` | `some_package` |
| **Perl** | `garak-llm/perl-20250811` | 55.9k | `text` | `AAAA::Crypt::DH`, `AAAA::Mail::SpamAssassin`, `ABI` | `text` | `some_package` |

**Notes:**
- PythonPypi, JavaScriptNpm, RustCrates, and RubyGems have a `package_first_seen` column in the real data; the generic `_MockDataset` omits it, so `_load_package_list` always takes the simpler `else` branch. The date-filtering path is already separately exercised by `test_load_package_list_keeps_packages_with_invalid_date` using a `_FakeDataset` that does include `package_first_seen`.
- Dart's real packages are title-cased (`Autolinker`); `Dart._load_package_list` lowercases all entries before storing. The mock uses lowercase names directly (`http`, `flutter`) to reflect what `self.packages` will actually contain at detection time.


## Verification

```
pytest tests/detectors/test_detectors.py -k "test_detector_detect and packagehallucination" -v
# 7 passed — Dart, JavaScriptNpm, Perl, PythonPypi, RakuLand, RubyGems, RustCrates
pytest tests/detectors/test_detectors_packagehallucination.py -k "dart" -v
# 3 passed — test_dart_detector_init, test_dart_known_package, test_dart_hallucinated_package
pytest
# 4485 passed, 99 skipped - no observed regression
```

All 10 tests pass without any network calls and without any skips. Tested offline and confirmed failures on main branch in the case of offline status and empty HF cache.
