### PR TITLE
fix: keep Replicate private endpoint output as one Message

### DIFF
--- a/garak/generators/replicate.py
+++ b/garak/generators/replicate.py
@@ -119,7 +119,7 @@ class InferenceEndpoint(ReplicateGenerator):
             raise IOError(
                 "Replicate endpoint didn't generate an Iterable[str]-type response. Make sure the endpoint is active."
             ) from exc
-        return [Message(r) for r in response]
+        return [Message(response)]
 
 
 DEFAULT_CLASS = "ReplicateGenerator"

--- a/tests/generators/test_replicate.py
+++ b/tests/generators/test_replicate.py
@@ -1,0 +1,27 @@
+from unittest.mock import Mock
+
+from garak.attempt import Conversation, Message, Turn
+from garak.generators.replicate import InferenceEndpoint
+
+
+def test_replicate_inference_endpoint_returns_single_message():
+    generator = InferenceEndpoint.__new__(InferenceEndpoint)
+    generator.client = Mock()
+    generator.name = "owner/private-endpoint"
+    generator.max_tokens = 20
+    generator.temperature = 0.7
+    generator.top_p = 0.9
+    generator.repetition_penalty = 1.1
+
+    prediction = Mock()
+    prediction.output = ["hello", " world"]
+    deployment = Mock()
+    deployment.predictions.create.return_value = prediction
+    generator.client.deployments.get.return_value = deployment
+
+    conv = Conversation([Turn("user", Message("test prompt"))])
+
+    output = generator._call_model(conv)
+
+    assert output == [Message("hello world")]
+    prediction.wait.assert_called_once_with()


### PR DESCRIPTION
private Replicate endpoints already join `prediction.output` into one string, but the private endpoint path then iterates that string when building the return value.

so a response like `"hello"` becomes a list of per-character messages instead of a single `Message("hello")`.

this PR:
* returns one `Message` for the joined response
* adds a regression test for chunked `prediction.output`

## verification

* ran `PYTHONPATH=/Users/hoangvu/Code/OSS/garak /tmp/garak-pr-venv/bin/python -m pytest tests/generators/test_replicate.py`
* test passes with this change
* the same test fails against the old behavior because `_call_model()` returns one message per character

I didn't run a live private Replicate endpoint check here, and I didn't run the full `tests/` suite in this local environment.
