### PR TITLE
fix: preserve all turns in NVMultimodal prompt prep

### DIFF
--- a/garak/generators/nim.py
+++ b/garak/generators/nim.py
@@ -218,7 +218,7 @@ class NVMultimodal(NVOpenAIChat):
                 )
             prepared_msg.text = text
 
-        prepared_conv.turns.append(Turn(turn.role, prepared_msg))
+            prepared_conv.turns.append(Turn(turn.role, prepared_msg))
 
         return prepared_conv
 

--- a/tests/generators/test_nim_multimodal.py
+++ b/tests/generators/test_nim_multimodal.py
@@ -1,0 +1,30 @@
+from garak.attempt import Conversation, Message, Turn
+from garak.generators.nim import NVMultimodal
+
+
+def test_nim_multimodal_prepare_prompt_preserves_all_turns():
+    generator = NVMultimodal.__new__(NVMultimodal)
+    generator.max_input_len = 100_000
+    generator.embed_data = True
+
+    conv = Conversation(
+        [
+            Turn("system", Message("system prompt")),
+            Turn("user", Message("first user turn")),
+            Turn(
+                "user",
+                Message(text="second user turn", data_path="tests/_assets/tinytrans.gif"),
+            ),
+        ]
+    )
+
+    prepared = generator._prepare_prompt(conv)
+
+    assert len(prepared.turns) == 3
+    assert [turn.role for turn in prepared.turns] == ["system", "user", "user"]
+    assert prepared.turns[0].content.text == "system prompt"
+    assert prepared.turns[1].content.text == "first user turn"
+    assert (
+        prepared.turns[2].content.text
+        == 'second user turn <img src="data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" />'
+    )


### PR DESCRIPTION
when `embed_data=True`, `NVMultimodal._prepare_prompt()` walks every turn in the conversation but only appends after the loop.

that means a multi-turn conversation gets collapsed to the final turn during prompt preparation.

this PR:
* appends each prepared turn inside the loop
* adds a regression test for a multi-turn conversation with embedded image data

## verification

* ran `PYTHONPATH=/Users/hoangvu/Code/OSS/garak /tmp/garak-pr-venv/bin/python -m pytest tests/generators/test_nim_multimodal.py`
* test passes with this change
* if the append is moved back outside the loop, the new test fails because only the final turn is preserved

I didn't run a live NIM endpoint check here, and I didn't run the full `tests/` suite in this local environment.
