### PR TITLE
probes.base: balance IntentProbe pruning across intents

### DIFF
--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -848,6 +848,10 @@ class IntentProbe(Probe):
 
     import garak.services.intentservice
 
+    DEFAULT_PARAMS = Probe.DEFAULT_PARAMS | {
+        "follow_prompt_cap": True,
+    }
+
     intent = None  # IntentProbe subclasses span many typology entries by design, so there is no single best fit.
     skip_root_intents = True
     blocked_intent_spec = ""
@@ -858,7 +862,8 @@ class IntentProbe(Probe):
         self._populate_intents()
         self._populate_stubs()
         self.build_prompts()
-        self._prune_data(self.soft_probe_prompt_cap)
+        if self.follow_prompt_cap:
+            self._prune_data(self.soft_probe_prompt_cap)
 
     def _attempt_prestore_hook(
         self, attempt: garak.attempt.Attempt, seq: int

--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -858,12 +858,45 @@ class IntentProbe(Probe):
         self._populate_intents()
         self._populate_stubs()
         self.build_prompts()
+        self._prune_data(self.soft_probe_prompt_cap)
 
     def _attempt_prestore_hook(
         self, attempt: garak.attempt.Attempt, seq: int
     ) -> garak.attempt.Attempt:
         attempt.intent = self.prompt_intents[seq]
         return attempt
+
+    def _prune_data(self, cap, prune_triggers=False):
+        """Prune prompts to ``cap`` while balancing across intents.
+
+        Unlike ``Probe._prune_data``, this keeps roughly equal representation
+        (within one) for each intent in ``self.prompt_intents`` and keeps that
+        list aligned with ``self.prompts``. No pruning occurs when
+        ``cap >= len(self.prompts)``.
+        """
+        if cap >= len(self.prompts):
+            return
+
+        prompts_by_intent = {}
+        for idx, intent in enumerate(self.prompt_intents):
+            intent_key = tuple(intent) if isinstance(intent, list) else intent
+            prompts_by_intent.setdefault(intent_key, []).append(idx)
+
+        num_intents = len(prompts_by_intent)
+        target_per_intent = cap // num_intents
+        remainder = cap % num_intents
+
+        ids_to_keep = set()
+        for intent_idx, indices in enumerate(prompts_by_intent.values()):
+            target = target_per_intent + (1 if intent_idx < remainder else 0)
+            ids_to_keep.update(random.sample(indices, min(target, len(indices))))
+
+        ids_to_delete = sorted(
+            set(range(len(self.prompts))) - ids_to_keep, reverse=True
+        )
+        for idx in ids_to_delete:
+            del self.prompts[idx]
+            del self.prompt_intents[idx]
 
     def _populate_intents(self) -> None:
         # work out which intents this probe will process

--- a/tests/cas/test_cas_intentprobe.py
+++ b/tests/cas/test_cas_intentprobe.py
@@ -1,9 +1,25 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import random
+from collections import Counter
+
 import garak._config
 import garak._plugins
 import garak.services.intentservice
+
+
+def _load_base_intentprobe():
+    garak._config.load_config()
+    garak._config.cas.intent_spec = "S"
+    garak.services.intentservice.load()
+    return garak._plugins.load_plugin("probes.base.IntentProbe")
+
+
+def _seed_distribution(probe, prompt_intents):
+    """Replace probe prompts/prompt_intents with a controlled distribution."""
+    probe.prompts = [f"p{idx}" for idx in range(len(prompt_intents))]
+    probe.prompt_intents = list(prompt_intents)
 
 
 def test_intentprobe_load():
@@ -44,3 +60,83 @@ def test_intentprobe_consistency():
     assert set(i.stub_intents) == set(
         i.prompt_intents
     ), "stub intents and probe intents should match"
+
+
+def test_intentprobe_prune_respects_cap():
+    i = _load_base_intentprobe()
+    _seed_distribution(i, ["A"] * 20 + ["B"] * 7 + ["C"] * 3)
+    random.seed(1)
+    i._prune_data(9)
+    assert len(i.prompts) <= 9, "pruned prompt count must not exceed the cap"
+
+
+def test_intentprobe_prune_balanced():
+    i = _load_base_intentprobe()
+    _seed_distribution(i, ["A"] * 20 + ["B"] * 7 + ["C"] * 3)
+    random.seed(1)
+    i._prune_data(9)
+    counts = Counter(i.prompt_intents)
+    assert (
+        max(counts.values()) - min(counts.values()) <= 1
+    ), "kept prompts must be balanced within one per intent"
+
+
+def test_intentprobe_prune_keeps_prompts_and_intents_aligned():
+    i = _load_base_intentprobe()
+    _seed_distribution(i, ["A"] * 20 + ["B"] * 7 + ["C"] * 3)
+    random.seed(1)
+    i._prune_data(9)
+    assert len(i.prompts) == len(
+        i.prompt_intents
+    ), "prompts and prompt_intents must stay aligned after pruning"
+
+
+def test_intentprobe_prune_noop_when_cap_ge_len():
+    i = _load_base_intentprobe()
+    _seed_distribution(i, ["A"] * 5 + ["B"] * 5)
+    before = list(i.prompts)
+    i._prune_data(10)
+    assert i.prompts == before, "cap >= len(prompts) must leave prompts untouched"
+
+
+def test_intentprobe_prune_cap_below_intent_count():
+    i = _load_base_intentprobe()
+    _seed_distribution(i, ["A"] * 10 + ["B"] * 10 + ["C"] * 10)
+    random.seed(1)
+    i._prune_data(2)
+    counts = Counter(i.prompt_intents)
+    assert len(i.prompts) == 2, "cap below intent count keeps exactly cap prompts"
+    assert (
+        max(counts.values()) <= 1
+    ), "no intent may exceed one prompt when cap < intent count"
+
+
+def test_intentprobe_prune_deficit_not_redistributed():
+    i = _load_base_intentprobe()
+    _seed_distribution(i, ["A"] * 1 + ["B"] * 1 + ["C"] * 10)
+    random.seed(1)
+    i._prune_data(9)
+    counts = Counter(i.prompt_intents)
+    assert sum(counts.values()) <= 9, "total kept must not exceed the cap"
+    assert (
+        counts["A"] == 1 and counts["B"] == 1 and counts["C"] == 3
+    ), "short intents keep all their prompts; the deficit is not redistributed"
+
+
+def test_grandmaintent_init_prunes_balanced():
+    garak._config.load_config()
+    garak._config.cas.intent_spec = "S"
+    garak._config.run.soft_probe_prompt_cap = 50
+    garak.services.intentservice.load()
+    random.seed(1)
+    i = garak._plugins.load_plugin("probes.grandma.GrandmaIntent")
+    counts = Counter(i.prompt_intents)
+    assert len(i.prompts) == len(
+        i.prompt_intents
+    ), "GrandmaIntent prompts and prompt_intents must stay aligned after init pruning"
+    assert (
+        len(i.prompts) <= 50
+    ), "GrandmaIntent must honour soft_probe_prompt_cap during init"
+    assert (
+        max(counts.values()) - min(counts.values()) <= 1
+    ), "GrandmaIntent prompts must be balanced within one per intent"


### PR DESCRIPTION
## Summary
`IntentProbe` ignored `soft_probe_prompt_cap`. This adds a balanced `IntentProbe._prune_data` override that honors the cap and spreads prompts evenly (within 1) across intents: `cap // n` per intent plus the remainder to the first intents, sampled per intent, deleting in reverse to keep `prompts`/`prompt_intents` aligned.

Resolves #1835 