### PR TITLE
fix: skip topP for Anthropic models when temperature is set on Bedrock

### DIFF
--- a/garak/generators/bedrock.py
+++ b/garak/generators/bedrock.py
@@ -185,7 +185,10 @@ class BedrockGenerator(Generator):
         if hasattr(self, "max_tokens") and self.max_tokens is not None:
             inference_config["maxTokens"] = int(self.max_tokens)
         if self.top_p is not None:
-            inference_config["topP"] = float(self.top_p)
+            # Anthropic Claude models on Bedrock reject requests that set both
+            # temperature and top_p. Skip top_p when temperature is present.
+            if "temperature" not in inference_config or "anthropic" not in self.name.lower():
+                inference_config["topP"] = float(self.top_p)
         if self.stop:
             inference_config["stopSequences"] = self.stop
 


### PR DESCRIPTION
## Problem

Anthropic Claude 4.x models on AWS Bedrock reject requests that set both `temperature` and `top_p` in `inferenceConfig`:

> `temperature` and `top_p` cannot both be specified for this model. Please use only one.

Since `DEFAULT_PARAMS` sets both (`temperature=0.7`, `top_p=1.0`), every request to Claude 4.x on Bedrock fails out of the box.

Fixes #1812

## Fix

For Anthropic models, skip `topP` when `temperature` is already present in `inferenceConfig`. Other providers continue to receive both parameters as before (they accept both without error).

The check uses `'anthropic' not in self.name.lower()` to detect Anthropic models, which covers all standard Bedrock model IDs like `us.anthropic.claude-sonnet-4-6`, `anthropic.claude-v2`, etc.