### PR TITLE
feat: add suppressed_params support to BedrockGenerator

### DIFF
--- a/garak/generators/bedrock.py
+++ b/garak/generators/bedrock.py
@@ -37,7 +37,26 @@ MODEL_ALIASES = {
 
 
 class BedrockGenerator(Generator):
-    """Interface for AWS Bedrock foundation models using Converse API"""
+    """Interface for AWS Bedrock foundation models using Converse API.
+
+    suppressed_params (set[str], default empty): Bedrock Converse API inference
+    field names to omit from the request inferenceConfig, regardless of whether
+    the corresponding instance attribute is set. Useful for target models that
+    reject specific combinations of inference parameters (for example, Anthropic
+    Claude 4.x on Bedrock rejects sending both temperature and topP). Suppression
+    is applied at request-assembly time, so it overrides per-probe parameter
+    mutation (such as promptinject's _generator_precall_hook). Field names use
+    the Bedrock Converse API spelling (topP, not top_p; maxTokens, not max_tokens).
+
+    Example garak.site.yaml config to suppress topP::
+
+        plugins:
+          generators:
+            bedrock:
+              BedrockGenerator:
+                suppressed_params:
+                  - topP
+    """
 
     active = True
     generator_family_name = "Bedrock"
@@ -49,6 +68,7 @@ class BedrockGenerator(Generator):
         "top_p": 1.0,
         "stop": [],
         "region": "us-east-1",
+        "suppressed_params": set(),
     }
 
     _unsafe_attributes = ["client"]
@@ -104,6 +124,18 @@ class BedrockGenerator(Generator):
                 )
 
         super().__init__(self.name, config_root=config_root)
+        self.suppressed_params = set(self.suppressed_params)
+        _pythonic_names = {
+            "top_p": "topP",
+            "max_tokens": "maxTokens",
+            "stop": "stopSequences",
+        }
+        for param in self.suppressed_params:
+            if param in _pythonic_names:
+                logging.warning(
+                    f"suppressed_params entry '{param}' looks like a Python attribute name; "
+                    f"use the Bedrock API field name '{_pythonic_names[param]}' instead."
+                )
         self._validate_env_var()
         self._load_unsafe()
 
@@ -180,13 +212,19 @@ class BedrockGenerator(Generator):
             return [None]
 
         inference_config = {}
-        if self.temperature is not None:
-            inference_config["temperature"] = float(self.temperature)
-        if hasattr(self, "max_tokens") and self.max_tokens is not None:
-            inference_config["maxTokens"] = int(self.max_tokens)
-        if self.top_p is not None:
-            inference_config["topP"] = float(self.top_p)
-        if self.stop:
+        _field_map = {
+            "temperature": ("temperature", float),
+            "maxTokens": ("max_tokens", int),
+            "topP": ("top_p", float),
+        }
+        for api_field, (attr, coerce) in _field_map.items():
+            if api_field in self.suppressed_params:
+                continue
+            value = getattr(self, attr, None)
+            if value is None:
+                continue
+            inference_config[api_field] = coerce(value)
+        if self.stop and "stopSequences" not in self.suppressed_params:
             inference_config["stopSequences"] = self.stop
 
         call_args = {
@@ -217,10 +255,14 @@ class BedrockGenerator(Generator):
                 return [None]
 
             content_blocks_with_text = [
-                content_block for content_block in message["content"] if "text" in content_block
+                content_block
+                for content_block in message["content"]
+                if "text" in content_block
             ]
             if len(content_blocks_with_text) == 0:
-                logging.error("Malformed response from Bedrock: missing 'text' in content blocks")
+                logging.error(
+                    "Malformed response from Bedrock: missing 'text' in content blocks"
+                )
                 return [None]
 
             text = content_blocks_with_text[0]["text"]

--- a/garak/generators/bedrock.py
+++ b/garak/generators/bedrock.py
@@ -39,23 +39,23 @@ MODEL_ALIASES = {
 class BedrockGenerator(Generator):
     """Interface for AWS Bedrock foundation models using Converse API.
 
-    suppressed_params (set[str], default empty): Bedrock Converse API inference
-    field names to omit from the request inferenceConfig, regardless of whether
-    the corresponding instance attribute is set. Useful for target models that
-    reject specific combinations of inference parameters (for example, Anthropic
-    Claude 4.x on Bedrock rejects sending both temperature and topP). Suppression
+    suppressed_params (set[str], default empty): garak attribute names to omit
+    from the Bedrock Converse API inferenceConfig, regardless of whether the
+    corresponding attribute is set. Useful for target models that reject specific
+    combinations of inference parameters (for example, Anthropic Claude 4.x on
+    Bedrock rejects requests that set both temperature and top_p). Suppression
     is applied at request-assembly time, so it overrides per-probe parameter
-    mutation (such as promptinject's _generator_precall_hook). Field names use
-    the Bedrock Converse API spelling (topP, not top_p; maxTokens, not max_tokens).
+    mutation (such as promptinject's _generator_precall_hook). Use garak attribute
+    names (top_p, max_tokens, temperature, stop).
 
-    Example garak.site.yaml config to suppress topP::
+    Example garak.site.yaml config to suppress top_p::
 
         plugins:
           generators:
             bedrock:
               BedrockGenerator:
                 suppressed_params:
-                  - topP
+                  - top_p
     """
 
     active = True
@@ -72,6 +72,15 @@ class BedrockGenerator(Generator):
     }
 
     _unsafe_attributes = ["client"]
+
+    # Maps garak attribute names to (Bedrock inferenceConfig field name, coerce fn).
+    # coerce fn is None for list params, which use a truthy check instead of a None check.
+    _PARAM_MAP = {
+        "temperature": ("temperature", float),
+        "max_tokens": ("maxTokens", int),
+        "top_p": ("topP", float),
+        "stop": ("stopSequences", None),
+    }
 
     def __init__(self, name="", config_root=_config):
         """Initialize the Bedrock generator.
@@ -125,19 +134,14 @@ class BedrockGenerator(Generator):
 
         super().__init__(self.name, config_root=config_root)
         self.suppressed_params = set(self.suppressed_params)
-        _pythonic_names = {
-            "top_p": "topP",
-            "max_tokens": "maxTokens",
-            "stop": "stopSequences",
-        }
-        for param in self.suppressed_params:
-            if param in _pythonic_names:
-                logging.warning(
-                    f"suppressed_params entry '{param}' looks like a Python attribute name; "
-                    f"use the Bedrock API field name '{_pythonic_names[param]}' instead."
-                )
         self._validate_env_var()
         self._load_unsafe()
+        for param in self.suppressed_params:
+            if param not in self._PARAM_MAP:
+                logging.warning(
+                    f"suppressed_params entry '{param}' is not a known BedrockGenerator "
+                    f"parameter. Valid keys are: {sorted(self._PARAM_MAP)}."
+                )
 
     def _validate_env_var(self):
         """Validate and set region from environment variables if not configured.
@@ -212,20 +216,17 @@ class BedrockGenerator(Generator):
             return [None]
 
         inference_config = {}
-        _field_map = {
-            "temperature": ("temperature", float),
-            "maxTokens": ("max_tokens", int),
-            "topP": ("top_p", float),
-        }
-        for api_field, (attr, coerce) in _field_map.items():
-            if api_field in self.suppressed_params:
+        for attr, (api_field, coerce) in self._PARAM_MAP.items():
+            if attr in self.suppressed_params:
                 continue
             value = getattr(self, attr, None)
-            if value is None:
-                continue
-            inference_config[api_field] = coerce(value)
-        if self.stop and "stopSequences" not in self.suppressed_params:
-            inference_config["stopSequences"] = self.stop
+            if coerce is not None:
+                if value is None:
+                    continue
+                inference_config[api_field] = coerce(value)
+            else:
+                if value:
+                    inference_config[api_field] = value
 
         call_args = {
             "modelId": self.name,

--- a/tests/generators/test_bedrock.py
+++ b/tests/generators/test_bedrock.py
@@ -391,17 +391,20 @@ def test_warn_on_unknown_suppressed_key(mock_boto3, caplog):
     import logging
     from garak.generators.bedrock import BedrockGenerator
 
-    original_defaults = BedrockGenerator.DEFAULT_PARAMS.copy()
-    try:
-        BedrockGenerator.DEFAULT_PARAMS = BedrockGenerator.DEFAULT_PARAMS | {
-            "suppressed_params": {"foo"}
+    test_canary = "foo"
+    test_suppressed_params = BedrockGenerator.DEFAULT_PARAMS["suppressed_params"].copy()
+    test_suppressed_params.add(test_canary)
+    config_root = {
+        "generators": {
+            "bedrock": {
+                "BedrockGenerator": {"suppressed_params": test_suppressed_params}
+            }
         }
-        with caplog.at_level(logging.WARNING):
-            BedrockGenerator(name="claude-4-5-sonnet")
-        matching = [r for r in caplog.records if "foo" in r.message]
-        assert matching, "expected a WARNING mentioning 'foo'"
-        assert any(
-            any(k in r.message for k in BedrockGenerator._PARAM_MAP) for r in matching
-        ), "expected WARNING to list valid keys"
-    finally:
-        BedrockGenerator.DEFAULT_PARAMS = original_defaults
+    }
+    with caplog.at_level(logging.WARNING):
+        BedrockGenerator(name="claude-4-5-sonnet", config_root=config_root)
+    matching = [r for r in caplog.records if test_canary in r.message]
+    assert matching, f"expected a WARNING mentioning '{test_canary}'"
+    assert any(
+        any(k in r.message for k in BedrockGenerator._PARAM_MAP) for r in matching
+    ), "expected WARNING to list valid keys"

--- a/tests/generators/test_bedrock.py
+++ b/tests/generators/test_bedrock.py
@@ -252,7 +252,16 @@ def test_bedrock_reasoning_response_handling(mock_boto3):
                     }
                 }
             },
-            [Message(text="Hello, world!", lang=None, data_path=None, data_type=None, data_checksum=None, notes={})],
+            [
+                Message(
+                    text="Hello, world!",
+                    lang=None,
+                    data_path=None,
+                    data_type=None,
+                    data_checksum=None,
+                    notes={},
+                )
+            ],
         ),
     ]
 
@@ -311,3 +320,85 @@ def test_bedrock_access_denied_error_does_not_retry(mock_boto3):
     assert len(output) == 1
     assert output[0] is None
     assert mock_boto3.converse.call_count == 1
+
+
+# suppressed_params tests
+
+
+@pytest.mark.usefixtures("set_aws_env", "mock_boto3")
+def test_inference_config_unchanged_with_empty_suppressed_params(mock_boto3):
+    """T1: empty suppressed_params produces identical inferenceConfig to prior behavior."""
+    from garak.generators.bedrock import BedrockGenerator
+
+    generator = BedrockGenerator(name="claude-4-5-sonnet")
+    generator.temperature = 0.8
+    generator.max_tokens = 100
+    generator.top_p = 0.9
+    generator.stop = ["END"]
+
+    conv = Conversation([Turn(role="user", content=Message("Test prompt"))])
+    generator.generate(conv, generations_this_call=1)
+
+    mock_boto3.converse.assert_called_once()
+    inference_config = mock_boto3.converse.call_args[1]["inferenceConfig"]
+    assert inference_config["temperature"] == 0.8
+    assert inference_config["maxTokens"] == 100
+    assert inference_config["topP"] == 0.9
+    assert inference_config["stopSequences"] == ["END"]
+
+
+@pytest.mark.usefixtures("set_aws_env", "mock_boto3")
+def test_suppressed_params_blocks_top_p(mock_boto3):
+    """T2: suppressed_params={"topP"} removes topP from inferenceConfig even when top_p is set."""
+    from garak.generators.bedrock import BedrockGenerator
+
+    generator = BedrockGenerator(name="claude-4-5-sonnet")
+    generator.suppressed_params = {"topP"}
+    generator.top_p = 0.9
+    generator.temperature = 0.7
+
+    conv = Conversation([Turn(role="user", content=Message("Test prompt"))])
+    generator.generate(conv, generations_this_call=1)
+
+    mock_boto3.converse.assert_called_once()
+    inference_config = mock_boto3.converse.call_args[1]["inferenceConfig"]
+    assert "topP" not in inference_config
+    assert "temperature" in inference_config
+
+
+@pytest.mark.usefixtures("set_aws_env", "mock_boto3")
+def test_suppression_survives_attribute_mutation(mock_boto3):
+    """T3: suppression holds even after self.top_p is mutated (simulating promptinject._generator_precall_hook)."""
+    from garak.generators.bedrock import BedrockGenerator
+
+    generator = BedrockGenerator(name="claude-4-5-sonnet")
+    generator.suppressed_params = {"topP"}
+
+    # Simulate promptinject._generator_precall_hook overwriting top_p mid-run
+    generator.top_p = 1.0
+
+    conv = Conversation([Turn(role="user", content=Message("Test prompt"))])
+    generator.generate(conv, generations_this_call=1)
+
+    mock_boto3.converse.assert_called_once()
+    inference_config = mock_boto3.converse.call_args[1]["inferenceConfig"]
+    assert "topP" not in inference_config
+
+
+@pytest.mark.usefixtures("set_aws_env", "mock_boto3")
+def test_warn_on_pythonic_suppressed_key(mock_boto3, caplog):
+    """T4: warn at init when suppressed_params uses a Pythonic attribute name instead of API field name."""
+    import logging
+    from garak.generators.bedrock import BedrockGenerator
+
+    original_defaults = BedrockGenerator.DEFAULT_PARAMS.copy()
+    try:
+        BedrockGenerator.DEFAULT_PARAMS = BedrockGenerator.DEFAULT_PARAMS | {
+            "suppressed_params": {"top_p"}
+        }
+        with caplog.at_level(logging.WARNING):
+            BedrockGenerator(name="claude-4-5-sonnet")
+        assert any("top_p" in record.message for record in caplog.records)
+        assert any("topP" in record.message for record in caplog.records)
+    finally:
+        BedrockGenerator.DEFAULT_PARAMS = original_defaults

--- a/tests/generators/test_bedrock.py
+++ b/tests/generators/test_bedrock.py
@@ -353,7 +353,7 @@ def test_suppressed_params_blocks_top_p(mock_boto3):
     from garak.generators.bedrock import BedrockGenerator
 
     generator = BedrockGenerator(name="claude-4-5-sonnet")
-    generator.suppressed_params = {"topP"}
+    generator.suppressed_params = {"top_p"}
     generator.top_p = 0.9
     generator.temperature = 0.7
 
@@ -372,7 +372,7 @@ def test_suppression_survives_attribute_mutation(mock_boto3):
     from garak.generators.bedrock import BedrockGenerator
 
     generator = BedrockGenerator(name="claude-4-5-sonnet")
-    generator.suppressed_params = {"topP"}
+    generator.suppressed_params = {"top_p"}
 
     # Simulate promptinject._generator_precall_hook overwriting top_p mid-run
     generator.top_p = 1.0
@@ -386,19 +386,22 @@ def test_suppression_survives_attribute_mutation(mock_boto3):
 
 
 @pytest.mark.usefixtures("set_aws_env", "mock_boto3")
-def test_warn_on_pythonic_suppressed_key(mock_boto3, caplog):
-    """T4: warn at init when suppressed_params uses a Pythonic attribute name instead of API field name."""
+def test_warn_on_unknown_suppressed_key(mock_boto3, caplog):
+    """Warn at init when suppressed_params contains a key not in _PARAM_MAP."""
     import logging
     from garak.generators.bedrock import BedrockGenerator
 
     original_defaults = BedrockGenerator.DEFAULT_PARAMS.copy()
     try:
         BedrockGenerator.DEFAULT_PARAMS = BedrockGenerator.DEFAULT_PARAMS | {
-            "suppressed_params": {"top_p"}
+            "suppressed_params": {"foo"}
         }
         with caplog.at_level(logging.WARNING):
             BedrockGenerator(name="claude-4-5-sonnet")
-        assert any("top_p" in record.message for record in caplog.records)
-        assert any("topP" in record.message for record in caplog.records)
+        matching = [r for r in caplog.records if "foo" in r.message]
+        assert matching, "expected a WARNING mentioning 'foo'"
+        assert any(
+            any(k in r.message for k in BedrockGenerator._PARAM_MAP) for r in matching
+        ), "expected WARNING to list valid keys"
     finally:
         BedrockGenerator.DEFAULT_PARAMS = original_defaults


### PR DESCRIPTION
Refs #1812

## Why added

Issue #1812 surfaced that BedrockGenerator cannot send a Bedrock-compatible inferenceConfig for target models with parameter restrictions: Anthropic Claude 4.x on Bedrock rejects requests that set both temperature and topP. In comments on #1812, @jmartin-tech proposed a model-agnostic mechanism: support suppressed_params on BedrockGenerator the same way OpenAICompatible generators do, so operators can globally suppress any parameter known to be unsupported by their target.

This PR implements that suggestion.

### Relationship to PR #1729 (merged)

PR #1729 added configurability at the probe layer (`garak/probes/promptinject.py`) for which generation_params promptinject's `_generator_precall_hook` overrides. This PR operates at the generator layer (`garak/generators/bedrock.py`), providing suppression for any Bedrock target regardless of which probe is running. The two mechanisms compose: #1729 addresses the promptinject-specific override behavior, this PR addresses the broader case where a Bedrock model rejects a parameter combination from any source.

### Relationship to PR #1840 (open)

PR #1840 patches the immediate Anthropic case with a model-name-gated conditional in `_call_model`. This PR is the generic mechanism @jmartin-tech suggested in the #1812 thread. Once it lands, the same outcome is achievable via site config (`suppressed_params: [top_p]`) or a per-model default suppression set, without model-name checks in `_call_model`. The two approaches aren't mutually exclusive, but the generic mechanism subsumes the special case.

## How utilized

In `garak.site.yaml`:

```yaml
plugins:
  generators:
    bedrock:
      BedrockGenerator:
        suppressed_params:
          - top_p
```

Then run garak normally:

```
garak --target_type bedrock \
      --target_name us.anthropic.claude-sonnet-4-6 \
      --probes promptinject.HijackHateHumans \
      --generations 1
```

The `topP` field is absent from every `inferenceConfig` sent to `bedrock-runtime.converse`, even when downstream hooks (e.g., `promptinject._generator_precall_hook`) mutate `generator.top_p` mid-run.

## Tests

- `test_inference_config_unchanged_with_empty_suppressed_params`: refactored code is output-identical to the original for all four fields.
- `test_suppressed_params_blocks_top_p`: `topP` absent from inferenceConfig when `suppressed_params={"top_p"}` and `top_p` is non-None.
- `test_suppression_survives_attribute_mutation`: suppression holds after `generator.top_p` is mutated mid-run, simulating `promptinject._generator_precall_hook`.
- `test_warn_on_unknown_suppressed_key`: WARNING logged at init when suppressed_params contains a key not in `_PARAM_MAP`.

All 15 tests in `tests/generators/test_bedrock.py` pass.
