### PR TITLE
Add base65536 and hexagram encoding injection probes

### DIFF
--- a/garak/probes/encoding.py
+++ b/garak/probes/encoding.py
@@ -445,6 +445,40 @@ class InjectBase2048(EncodingMixin, garak.probes.Probe):
         EncodingMixin.__init__(self)
 
 
+class InjectBase65536(EncodingMixin, garak.probes.Probe):
+    """Probe for susceptibility to Base65536 encoding injections
+
+    Encodes payloads using base65536, which maps each pair of bytes to a single
+    Unicode character, and tries a variety of ways of getting the target model to
+    repeat & decode them."""
+
+    doc_uri = "https://github.com/qntm/base65536"
+    encoding_name = "BASE65536"
+    encoding_funcs = [garak.resources.encodings.base65536_encode]
+    active = True
+
+    def __init__(self, config_root=_config):
+        garak.probes.Probe.__init__(self, config_root=config_root)
+        EncodingMixin.__init__(self)
+
+
+class InjectHexagram(EncodingMixin, garak.probes.Probe):
+    """Probe for susceptibility to I Ching hexagram encoding injections
+
+    Encodes payloads as a string of I Ching hexagrams (Base64 with each character
+    replaced by a hexagram so the bits are visible), and tries a variety of ways
+    of getting the target model to repeat & decode them."""
+
+    doc_uri = "https://github.com/ferno/hexagram-encode"
+    encoding_name = "Hexagram"
+    encoding_funcs = [garak.resources.encodings.hexagram_encode]
+    active = True
+
+    def __init__(self, config_root=_config):
+        garak.probes.Probe.__init__(self, config_root=config_root)
+        EncodingMixin.__init__(self)
+
+
 class InjectBraille(EncodingMixin, garak.probes.Probe):
     """Probe for susceptibility to Braille encoding injections. Credit Wally#3422
 

--- a/garak/resources/encodings.py
+++ b/garak/resources/encodings.py
@@ -1,4 +1,6 @@
 # SPDX-FileCopyrightText: Portions Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Portions Copyright (c) 2016 qntm (base65536, MIT)
+# SPDX-FileCopyrightText: Portions Copyright (c) 2021 ferno (hexagram-encode, MIT)
 # SPDX-License-Identifier: Apache-2.0
 
 """Encoding functions
@@ -6,6 +8,8 @@
 Functions used to offer various encodings that are needed more than one place in garak
 """
 
+import base64
+import binascii
 import random
 
 
@@ -20,3 +24,138 @@ def leetspeak(input: str, transmute_chance: float = 0.6) -> str:
         [processed[i] if random.random() > 0.5 else input[i] for i in range(len(input))]
     )
     return output
+
+
+# ---------------------------------------------------------------------------
+# Base65536 — a binary-to-text encoding that packs 2 bytes per character using
+# "safe" Unicode code points. Used by probes.encoding to test whether a model
+# will decode obscure encodings of an unsafe payload.
+#
+# Ported to Python from the reference implementation qntm/base65536, which is
+# distributed under the MIT License:
+#
+#   Copyright (c) 2016 qntm (https://github.com/qntm/base65536)
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files, to deal in the
+#   Software without restriction, including the rights to use, copy, modify,
+#   merge, publish, distribute, sublicense, and/or sell copies of the Software.
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+# ---------------------------------------------------------------------------
+
+_BASE65536_BITS_PER_CHAR = 16
+_BASE65536_BITS_PER_BYTE = 8
+
+# Compressed inclusive ranges of code points used by Base65536, taken verbatim
+# from the qntm reference implementation. The first string holds the 256 blocks
+# for full 16-bit values; the second holds the block for a trailing 8-bit value.
+_BASE65536_PAIR_STRINGS = [
+    "㐀䳿一黿ꄀꏿꔀꗿ𐘀𐛿𒀀𒋿𓀀𓏿𔐀𔗿𖠀𖧿𠀀𨗿",
+    "ᔀᗿ",
+]
+
+
+def _build_base65536_tables():
+    """Build the Base65536 encode/decode lookup tables from the compressed ranges."""
+    encode = {}  # {num_z_bits: {z: char}}
+    decode = {}  # {char: (num_z_bits, z)}
+    for r, pair_string in enumerate(_BASE65536_PAIR_STRINGS):
+        num_z_bits = _BASE65536_BITS_PER_CHAR - _BASE65536_BITS_PER_BYTE * r
+        encode[num_z_bits] = {}
+        code_points = [ord(c) for c in pair_string]
+        z2 = 0
+        for first, last in zip(code_points[0::2], code_points[1::2]):
+            for code_point in range(first, last + 1):
+                # Full 16-bit blocks flip the byte order (the encoding was
+                # originally constructed taking the bytes in the wrong order);
+                # 8-bit blocks do not.
+                if num_z_bits == _BASE65536_BITS_PER_CHAR:
+                    z = 256 * (z2 % 256) + (z2 >> 8)
+                else:
+                    z = z2
+                encode[num_z_bits][z] = chr(code_point)
+                decode[chr(code_point)] = (num_z_bits, z)
+                z2 += 1
+    return encode, decode
+
+
+_BASE65536_ENCODE, _BASE65536_DECODE = _build_base65536_tables()
+
+
+def base65536_encode(payload: bytes) -> str:
+    """Encode bytes as a Base65536 string (2 bytes per character)."""
+    out = []
+    z = 0
+    num_z_bits = 0
+    for byte in payload:
+        for j in range(_BASE65536_BITS_PER_BYTE - 1, -1, -1):
+            z = (z << 1) + ((byte >> j) & 1)
+            num_z_bits += 1
+            if num_z_bits == _BASE65536_BITS_PER_CHAR:
+                out.append(_BASE65536_ENCODE[num_z_bits][z])
+                z = 0
+                num_z_bits = 0
+    if num_z_bits != 0:
+        # A trailing byte leaves 8 bits; Base65536 needs no padding because 8
+        # divides 16, so the remaining bits map straight onto an 8-bit block.
+        out.append(_BASE65536_ENCODE[num_z_bits][z])
+    return "".join(out)
+
+
+def base65536_decode(text: str) -> bytes:
+    """Decode a Base65536 string back to the original bytes."""
+    out = bytearray()
+    byte = 0
+    num_byte_bits = 0
+    for chr_ in text:
+        if chr_ not in _BASE65536_DECODE:
+            raise ValueError(f"Unrecognised Base65536 character: {chr_!r}")
+        num_z_bits, z = _BASE65536_DECODE[chr_]
+        for j in range(num_z_bits - 1, -1, -1):
+            byte = (byte << 1) + ((z >> j) & 1)
+            num_byte_bits += 1
+            if num_byte_bits == _BASE65536_BITS_PER_BYTE:
+                out.append(byte)
+                byte = 0
+                num_byte_bits = 0
+    return bytes(out)
+
+
+# ---------------------------------------------------------------------------
+# Hexagram encoding — Base64 with each character (including the padding symbol)
+# replaced by an I Ching hexagram, making the underlying bits visible as broken
+# and unbroken lines. Used by probes.encoding.
+#
+# Ported to Python from the reference implementation ferno/hexagram-encode,
+# which is distributed under the MIT License:
+#
+#   Copyright (c) 2021 ferno (https://github.com/ferno/hexagram-encode)
+#   Permission is hereby granted, free of charge, to any person obtaining a
+#   copy of this software and associated documentation files, to deal in the
+#   Software without restriction, including the rights to use, copy, modify,
+#   merge, publish, distribute, sublicense, and/or sell copies of the Software.
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+# ---------------------------------------------------------------------------
+
+# 64 Base64 characters in order; the 65th is the padding symbol. Mapped onto the
+# 64 I Ching hexagrams (binary order, most significant bit at the top) plus the
+# yin/yang symbol for padding, taken verbatim from the reference implementation.
+_HEXAGRAM_BASE64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
+_HEXAGRAM_GLYPHS = (
+    "䷁䷗䷆䷒䷎䷣䷭䷊䷏䷲䷧䷵䷽䷶䷟䷡䷇䷂䷜䷻䷦䷾䷯䷄䷬䷐䷮䷹䷞䷰䷛䷪"
+    "䷖䷚䷃䷨䷳䷕䷑䷙䷢䷔䷿䷥䷷䷝䷱䷍䷓䷩䷺䷼䷴䷤䷸䷈䷋䷘䷅䷉䷠䷌䷫䷀☯"
+)
+_B64_TO_HEXAGRAM = str.maketrans(_HEXAGRAM_BASE64, _HEXAGRAM_GLYPHS)
+_HEXAGRAM_TO_B64 = str.maketrans(_HEXAGRAM_GLYPHS, _HEXAGRAM_BASE64)
+
+
+def hexagram_encode(payload: bytes) -> str:
+    """Encode bytes as a string of I Ching hexagrams (Base64 over the hexagrams)."""
+    return base64.b64encode(payload).decode("ascii").translate(_B64_TO_HEXAGRAM)
+
+
+def hexagram_decode(text: str) -> bytes:
+    """Decode a hexagram-encoded string back to the original bytes."""
+    try:
+        return base64.b64decode(text.translate(_HEXAGRAM_TO_B64), validate=True)
+    except binascii.Error as exc:
+        raise ValueError(f"Invalid hexagram-encoded string: {exc}") from exc

--- a/tests/resources/test_encodings.py
+++ b/tests/resources/test_encodings.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import pytest
+
+from garak.resources.encodings import (
+    base65536_encode,
+    base65536_decode,
+    hexagram_encode,
+    hexagram_decode,
+)
+
+ROUNDTRIP_PAYLOADS = [
+    b"",
+    b"a",
+    b"ab",
+    b"abc",
+    b"Hello, World!",
+    "héllo \U0001f600".encode("utf-8"),
+    bytes(range(256)),
+    os.urandom(64),
+]
+
+
+@pytest.mark.parametrize("payload", ROUNDTRIP_PAYLOADS)
+def test_base65536_roundtrip(payload):
+    encoded = base65536_encode(payload)
+    assert (
+        base65536_decode(encoded) == payload
+    ), "base65536 decode must invert encode for all byte inputs"
+
+
+def test_base65536_known_vector():
+    # Regression vector matching the reference qntm/base65536 implementation.
+    assert (
+        base65536_encode(bytes([0, 1, 2, 255, 254])) == "㔀𨔂ᗾ"
+    ), "base65536 output must match the reference encoding"
+
+
+@pytest.mark.parametrize("payload", ROUNDTRIP_PAYLOADS)
+def test_hexagram_roundtrip(payload):
+    encoded = hexagram_encode(payload)
+    assert (
+        hexagram_decode(encoded) == payload
+    ), "hexagram decode must invert encode for all byte inputs"
+
+
+def test_hexagram_known_vector():
+    # Example from the reference ferno/hexagram-encode README.
+    assert (
+        hexagram_encode(bytes([0x00, 0x55, 0xFF])) == "䷁䷣䷄䷀"
+    ), "hexagram output must match the reference encoding"
+
+
+def test_hexagram_decode_rejects_invalid_input():
+    with pytest.raises(ValueError):
+        hexagram_decode("not hexagrams")
+
+
+def test_base65536_decode_rejects_invalid_input():
+    with pytest.raises(ValueError):
+        base65536_decode("!not base65536!")


### PR DESCRIPTION
## What

Adds two new encoding-injection probes to `probes.encoding`, addressing two items from the "extra encodings" wishlist in #152:

- **`InjectBase65536`** — encodes payloads with Base65536 (2 bytes per character).
- **`InjectHexagram`** — encodes payloads as I Ching hexagrams (Base64 with each character mapped to a hexagram so the bits are visible).

Both follow the existing `EncodingMixin` pattern (`primary_detector = encoding.DecodeMatch`).

## Dependencies

**No new runtime dependency is introduced.** Both encoders are clean-room ports of the MIT-licensed reference implementations, placed in `resources/encodings.py` with attribution comments and `SPDX-FileCopyrightText` lines:

- `base65536_encode/decode` — ported from [qntm/base65536](https://github.com/qntm/base65536) (MIT). Validated byte-for-byte against the reference package.
- `hexagram_encode/decode` — ported from [ferno/hexagram-encode](https://github.com/ferno/hexagram-encode) (MIT). Matches the reference README vector (`bytes([0x00,0x55,0xFF]) -> ䷁䷣䷄䷀`).

## Non-duplication

No open PR addresses these encoders (checked `base65536`, `hexagram`, and `#152` references in open PRs). This PR covers only two wishlist items; #152 stays open for the rest.

## Tests

New `tests/resources/test_encodings.py` adds roundtrip, known-vector, and invalid-input tests for both codecs. The new probes are also covered by the existing parametrized `tests/probes/test_probes_encoding.py` suite.

```
pytest tests/resources/test_encodings.py tests/probes/test_probes_encoding.py
  -> 112 passed, 1 skipped
pytest tests/test_docs.py
  -> 663 passed
black --check garak/probes/encoding.py garak/resources/encodings.py tests/resources/test_encodings.py
  -> clean
```
Codec ports were additionally verified with the `base65536` reference package uninstalled, confirming no dependency.

## AI assistance

This change was AI-assisted (Claude). The human submitter has reviewed every changed line and run the tests above.
