### PR TITLE
feat: log skip reason when detectors are skipped during scan

### DIFF
--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -42,6 +42,10 @@ class Detector(Configurable):
         "skip": False,
     }
 
+    skip_reason: str = None
+    """Human-readable reason why this detector was skipped. Set when ``skip`` is
+    True to help users understand why a detector did not run on a probe."""
+
     _run_params = {"seed"}
 
     def _set_description(self):

--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -196,9 +196,16 @@ class Harness(Configurable):
                 attempt_iterator = tqdm.tqdm(attempt_results, leave=False)
                 detector_probe_name = d.detectorname.replace("garak.detectors.", "")
                 attempt_iterator.set_description("detectors." + detector_probe_name)
+                if d.skip:
+                    reason = getattr(d, "skip_reason", None) or "disabled via config"
+                    logging.info(
+                        "skipping detector %s on probe %s: %s",
+                        detector_probe_name,
+                        probe.probename,
+                        reason,
+                    )
+                    continue
                 for attempt in attempt_iterator:
-                    if d.skip:
-                        continue
                     attempt.detector_results[detector_probe_name] = list(
                         d.detect(attempt)
                     )


### PR DESCRIPTION
## What
Fixes #1061 — Detectors that skip probes now log their skip reason.

## Problem
When `skip=True`, the harness silently continued. Users had no idea which detectors were skipped or why.

## Fix
1. **Detector base**: Added `skip_reason` attribute
2. **Harness**: Logs at INFO level when a detector is skipped, including probe name and reason

## Example
```
INFO: skipping detector always.Skip on probe test.Blank: disabled via config
```