### PR TITLE
fix calibration pathlib paths

### DIFF
--- a/garak/analyze/calibration.py
+++ b/garak/analyze/calibration.py
@@ -18,7 +18,7 @@ class Calibration:
     """Helper for managing probe/detector score calibration data processing"""
 
     def _load_calibration(
-        self, calibration_filename: Union[str, None] = None
+        self, calibration_filename: Union[str, pathlib.Path, None] = None
     ) -> Union[None, int]:
 
         if calibration_filename is None:
@@ -110,9 +110,7 @@ class Calibration:
             self.calibration_filename = self._build_path("calibration.json")
 
         else:
-            if not isinstance(calibration_path, str) or isinstance(
-                calibration_path, pathlib.Path
-            ):
+            if not isinstance(calibration_path, (str, pathlib.Path)):
                 raise ValueError("calibration_path must be a string or Path")
             self.calibration_filename = calibration_path
 

--- a/tests/analyze/test_calibration.py
+++ b/tests/analyze/test_calibration.py
@@ -10,6 +10,8 @@
 # check comment assignment
 # check dc assignment
 
+from pathlib import Path
+
 import pytest
 
 import garak.analyze
@@ -42,6 +44,22 @@ def test_constructor_with_missing_file():
     assert isinstance(c._data, dict)
     assert c._data == {}
     assert c.metadata is None
+
+    c = garak.analyze.calibration.Calibration(Path("akshjdfiojavpoij"))
+    assert c.calibration_successfully_loaded == False
+    assert isinstance(c._data, dict)
+    assert c._data == {}
+    assert c.metadata is None
+
+
+def test_constructor_with_path():
+    c = garak.analyze.calibration.Calibration(
+        Path("garak/data/calibration/calibration.json")
+    )
+    assert c.calibration_successfully_loaded == True
+    assert isinstance(c._data, dict)
+    assert len(c._data) > 0
+    assert isinstance(c.metadata, dict)
 
 
 def test_lookup():


### PR DESCRIPTION
## Summary

Thanks for maintaining garak. This small fix lets calibration accept `pathlib.Path` inputs as intended.

The constructor already advertises that `calibration_path` can be a string or `Path`, but the type guard accidentally rejected `Path` objects. This updates the check so both accepted types work, and adds regression coverage for existing and missing calibration paths passed as `Path`.

## Testing

- `git diff --check`