### PR TITLE
fix: catch OpenAI AuthenticationError before multiprocessing pickle

### DIFF
--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -315,6 +315,22 @@ class OpenAICompatible(Generator):
 
         try:
             response = generator.create(**create_args)
+        except (
+            openai.AuthenticationError,
+            openai.PermissionDeniedError,
+        ) as e:
+            # 401 / 403 are terminal: retrying with the same key is pointless.
+            # Raise GarakException *before* the exception leaves this frame so
+            # that multiprocessing.Pool workers can pickle it cleanly.
+            # openai.APIStatusError carries an httpx.Response that is not
+            # picklable, which causes a TypeError in Pool's _handle_results
+            # thread and masks the real error (see github.com/NVIDIA/garak/issues/1357).
+            msg = (
+                f"OpenAI API authentication failed (HTTP {e.status_code}); "
+                f"verify {self.key_env_var} is valid. Original error: {e}"
+            )
+            logging.error(msg)
+            raise garak.exception.GarakException(msg) from None
         except openai.BadRequestError as e:
             msg = "Bad request: " + str(repr(prompt))
             logging.exception(e)

--- a/tests/generators/test_openai.py
+++ b/tests/generators/test_openai.py
@@ -99,3 +99,94 @@ def test_reasoning_switch():
         generator = OpenAIGenerator(
             name="o1-mini"
         )  # o1 models should use ReasoningGenerator
+
+
+# ── issue #1357: auth errors must not crash Pool._handle_results thread ─────────
+
+
+@pytest.mark.usefixtures("set_fake_env")
+@pytest.mark.respx(base_url="https://api.openai.com/v1")
+def test_call_model_auth_error_raises_garak_exception(respx_mock, openai_compat_mocks):
+    """HTTP 401 must surface as GarakException, not raw openai.AuthenticationError.
+
+    openai.AuthenticationError (and all openai.APIStatusError subclasses) carry
+    an httpx.Response attribute that is not picklable.  When parallel_attempts > 1,
+    multiprocessing.Pool workers try to pickle the exception to send it to the
+    parent process; the un-picklable type crashes the Pool._handle_results thread,
+    producing a silent "Exception in thread" message and hanging the run instead of
+    a clean abort.  Catching AuthenticationError here and re-raising as GarakException
+    (which is picklable) is the minimal fix.
+    See https://github.com/NVIDIA/garak/issues/1357.
+    """
+    mock_resp = openai_compat_mocks["auth_fail"]
+    respx_mock.post("chat/completions").mock(
+        return_value=httpx.Response(mock_resp["code"], json=mock_resp["json"])
+    )
+    generator = OpenAIGenerator(name="gpt-3.5-turbo")
+    prompt = Conversation([Turn(role="user", content=Message("hello"))])
+    with pytest.raises(garak.exception.GarakException) as exc_info:
+        generator.generate(prompt)
+    error_text = str(exc_info.value)
+    # message must mention status code and guide the user toward the key env var
+    assert "401" in error_text or OpenAIGenerator.ENV_VAR in error_text
+
+
+@pytest.mark.usefixtures("set_fake_env")
+@pytest.mark.respx(base_url="https://api.openai.com/v1")
+def test_call_model_auth_exception_is_picklable(respx_mock, openai_compat_mocks):
+    """The exception raised on HTTP 401 must survive a pickle round-trip.
+
+    This is the precise property that allows multiprocessing.Pool workers to
+    return authentication failures to the parent process without crashing
+    Pool._handle_results (the root cause of issue #1357).
+    """
+    import pickle
+
+    mock_resp = openai_compat_mocks["auth_fail"]
+    respx_mock.post("chat/completions").mock(
+        return_value=httpx.Response(mock_resp["code"], json=mock_resp["json"])
+    )
+    generator = OpenAIGenerator(name="gpt-3.5-turbo")
+    prompt = Conversation([Turn(role="user", content=Message("hello"))])
+    caught = None
+    try:
+        generator.generate(prompt)
+    except garak.exception.GarakException as exc:
+        caught = exc
+    assert caught is not None, "expected GarakException to be raised on HTTP 401"
+    # pickle round-trip must succeed
+    data = pickle.dumps(caught)
+    restored = pickle.loads(data)
+    assert str(restored) == str(caught)
+
+
+@pytest.mark.usefixtures("set_fake_env")
+def test_call_model_permission_denied_raises_garak_exception(mocker):
+    """HTTP 403 PermissionDeniedError must also surface as GarakException.
+
+    openai.PermissionDeniedError shares the same un-picklable httpx.Response
+    attribute as AuthenticationError; both are terminal auth failures.
+    """
+    generator = OpenAIGenerator(name="gpt-3.5-turbo")
+    req = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    resp = httpx.Response(
+        403,
+        request=req,
+        json={
+            "error": {
+                "message": "Permission denied",
+                "type": "invalid_request_error",
+            }
+        },
+    )
+    err = openai.PermissionDeniedError(
+        "Permission denied",
+        response=resp,
+        body={"error": {"message": "Permission denied"}},
+    )
+    mocker.patch.object(generator.generator, "create", side_effect=err)
+    prompt = Conversation([Turn(role="user", content=Message("hello"))])
+    with pytest.raises(garak.exception.GarakException) as exc_info:
+        generator.generate(prompt)
+    error_text = str(exc_info.value)
+    assert "403" in error_text or OpenAIGenerator.ENV_VAR in error_text


### PR DESCRIPTION
## Summary

Catch `openai.AuthenticationError` and `openai.PermissionDeniedError` inside `_call_model` and re-raise as the picklable `garak.exception.GarakException`, so that runs with `--parallel_attempts > 1` abort cleanly on a bad API key instead of crashing the `Pool._handle_results` background thread.

## Problem / motivation

When a user runs garak with `--parallel_attempts 4` and an invalid `OPENAI_API_KEY`, the first generator call in each worker process raises `openai.AuthenticationError`. That exception is a subclass of `openai.APIStatusError`, which carries an `httpx.Response` attribute. `httpx.Response` is not picklable — its `__reduce__` is not defined and its `__init__` requires keyword-only arguments (`response=` and `body=`) that pickle does not supply on reconstruction.

Python's `multiprocessing.Pool` runs a background thread (`_handle_results`) that deserialises worker results from a queue. When `pickle.loads()` tries to reconstruct the `AuthenticationError`, it raises:

```
Exception in thread Thread-6 (_handle_results):
TypeError: APIStatusError.__init__() missing 2 required keyword-only arguments: 'response' and 'body'
```

This kills `_handle_results`, the pool becomes unable to deliver any further results, and the main process hangs indefinitely rather than surfacing the root cause to the user. The issue was root-caused in #1357 by a community member who filed no PR.

## Change

**`garak/generators/openai.py`** — `OpenAICompatible._call_model`

Added an `except (openai.AuthenticationError, openai.PermissionDeniedError)` clause in the existing `try / except` block around `generator.create()`. Both HTTP 401 and 403 are terminal authentication failures — retrying with the same key serves no purpose and the `@backoff` decorator must not loop on them. The handler:

1. Logs the full error message at `ERROR` level, including `self.key_env_var` so the user knows exactly which environment variable to fix.
2. Raises `garak.exception.GarakException` (a plain `Exception` subclass with no un-picklable attributes) from `None` to suppress the chained traceback.
3. Does **not** add `GarakException` to the backoff decorator's exception list — it propagates immediately as a fatal run error.

`PermissionDeniedError` (HTTP 403) is included because it shares the identical pickling defect and represents the same class of terminal credential failure.

**`tests/generators/test_openai.py`** — three new tests

| Test | What it asserts |
|---|---|
| `test_call_model_auth_error_raises_garak_exception` | HTTP 401 mock → `GarakException` raised, message contains `"401"` or the key env var name |
| `test_call_model_auth_exception_is_picklable` | The raised exception survives a `pickle.dumps` / `pickle.loads` round-trip (the precise property that makes multiprocessing safe) |
| `test_call_model_permission_denied_raises_garak_exception` | HTTP 403 mock (via `mocker.patch.object`) → `GarakException` raised |

The existing `auth_fail` entry already present in `tests/_assets/generators/openai.json` is reused for the HTTP-level mocks.

## Security rationale

Masking a credential failure behind an unhandled thread exception is an observability gap: the operator has no indication that the run aborted due to an invalid key, so they may misinterpret empty results as "no vulnerabilities found" — a false-negative outcome for a security evaluation tool. Surfacing authentication failures as first-class, logged, named exceptions aligns with **OWASP LLM09** (Overreliance) mitigation (auditable failure modes) and the general principle that security tooling must fail loudly and correctly.

## Testing / validation

```
pytest tests/generators/test_openai.py -v
```

Results on Python 3.14.4, openai 2.41.1, respx 0.23.1, pytest-mock 3.15.1:

```
tests/generators/test_openai.py::test_openai_version                                      PASSED
tests/generators/test_openai.py::test_openai_invalid_model_names                          PASSED
tests/generators/test_openai.py::test_openai_completion                                   SKIPPED (no live key)
tests/generators/test_openai.py::test_openai_chat                                         SKIPPED (no live key)
tests/generators/test_openai.py::test_reasoning_switch                                    PASSED
tests/generators/test_openai.py::test_call_model_auth_error_raises_garak_exception        PASSED
tests/generators/test_openai.py::test_call_model_auth_exception_is_picklable              PASSED
tests/generators/test_openai.py::test_call_model_permission_denied_raises_garak_exception PASSED

6 passed, 2 skipped
```

The root cause was also verified empirically: reproducing the broken path (worker raises raw `openai.AuthenticationError`) produces `Exception in thread Thread-6 (_handle_results): TypeError: APIStatusError.__init__() missing 2 required keyword-only arguments: 'response' and 'body'`; the fixed path catches cleanly as `GarakException` through the pool.
