### PR TITLE
Resolve symlinked install paths in data_path escape protections

### DIFF
--- a/garak/data/__init__.py
+++ b/garak/data/__init__.py
@@ -35,9 +35,11 @@ class LocalDataPath(type(pathlib.Path())):
     ]
 
     def _determine_suffix(self):
+        resolved_self = pathlib.Path(self).resolve()
         for path in self.ORDERED_SEARCH_PATHS:
-            if path == self or path in self.parents:
-                return self.relative_to(path)
+            resolved_path = path.resolve()
+            if resolved_path == resolved_self or resolved_path in resolved_self.parents:
+                return resolved_self.relative_to(resolved_path)
 
     def _eval_paths(self, segment, next_call, relative):
         msg = "The requested resource does not refer to a valid path"
@@ -56,7 +58,7 @@ class LocalDataPath(type(pathlib.Path())):
             else:
                 current_path = path / prefix_removed
                 projected = getattr(current_path, next_call)(segment)
-            if projected.exists() and projected.resolve().is_relative_to(path):
+            if projected.exists() and projected.resolve().is_relative_to(path.resolve()):
                 return LocalDataPath(projected.resolve())
 
         if projected in self.ORDERED_SEARCH_PATHS:
@@ -64,7 +66,7 @@ class LocalDataPath(type(pathlib.Path())):
 
         if not any(
             [
-                projected.resolve().is_relative_to(path)
+                projected.resolve().is_relative_to(path.resolve())
                 for path in self.ORDERED_SEARCH_PATHS
             ]
         ):


### PR DESCRIPTION
The `_eval_paths` security check introduced in #1781 compares `projected.resolve()` (symlinks followed) against path (unresolved) from `ORDERED_SEARCH_PATHS`. In environments where the Python installation directory contains symlinks (aka: Docker containers) where `lib64 → lib`, the two sides of `is_relative_to` refer to different paths and the check always fails, raising `GarakException` on any data_path access.

The same issue affects `_determine_suffix`, which also compares self and its parents against `ORDERED_SEARCH_PATHS` without resolving either side.

Example `scan.log` output:
```
2026-06-12 14:10:17,011  DEBUG  rebuilding plugin cache
2026-06-12 14:10:17,062  ERROR  The requested resource does not refer to a valid path
Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.12/site-packages/garak/cli.py", line 638, in main
    names, rejected = _config.parse_plugin_spec(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/garak/_config.py", line 444, in parse_plugin_spec
    for p, a in enumerate_plugins(category=category)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/garak/_plugins.py", line 387, in enumerate_plugins
    for k, v in PluginCache.instance()[category].items():
                ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/garak/_plugins.py", line 223, in instance
    return PluginCache()._plugin_cache_dict
           ^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/garak/_plugins.py", line 59, in __init__
    PluginCache._plugin_cache_dict = self._load_plugin_cache()
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/garak/_plugins.py", line 115, in _load_plugin_cache
    self._build_plugin_cache()
  File "/opt/app-root/lib64/python3.12/site-packages/garak/_plugins.py", line 177, in _build_plugin_cache
    for plugin in self._enumerate_plugin_klasses(plugin_type):
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/garak/_plugins.py", line 210, in _enumerate_plugin_klasses
    mod = importlib.import_module(f"garak.{category}.{module_name}")
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/opt/app-root/lib64/python3.12/site-packages/garak/probes/badchars.py", line 15, in <module>
    import garak.payloads
  File "/opt/app-root/lib64/python3.12/site-packages/garak/payloads.py", line 37, in <module>
    PAYLOAD_DIR = data_path / "payloads"
                  ~~~~~~~~~~^~~~~~~~~~~~
  File "/usr/lib64/python3.12/pathlib.py", line 721, in __truediv__
    return self.joinpath(key)
           ^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/garak/data/__init__.py", line 106, in joinpath
    projected = self._eval_paths(segment, "joinpath", "..")
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/garak/data/__init__.py", line 71, in _eval_paths
    raise GarakException(msg)
garak.exception.GarakException: The requested resource does not refer to a valid path

```

Fix by resolving both sides before comparing in `_eval_paths` and `_determine_suffix`:
```
  projected.resolve().is_relative_to(path.resolve())
```

The security intent of #1781 should be preserved: paths that escape the allowed directories are still rejected, but the check now works correctly when the install tree contains symlinks.