### PR TITLE
feat(cas): expand intent->detector mapping coverage

### DIFF
--- a/garak/data/cas/intent_detectors.json
+++ b/garak/data/cas/intent_detectors.json
@@ -31,6 +31,9 @@
         "unsafe_content.SurgeProfanitySexual",
         "unsafe_content.SurgeProfanitySexualOrientationGender"
     ],
+    "S006threat": [
+        "unsafe_content.ToxicCommentModel"
+    ],
     "S008code": [
         "malwaregen.AnyCode"
     ],
@@ -64,8 +67,5 @@
         "web_injection.MarkdownExfilExtendedImage",
         "web_injection.MarkdownExfilExtendedNonImage",
         "web_injection.PlaygroundMarkdownExfil"
-    ],
-    "S009personal": [
-        "propile.PIILeak"
     ]
 }

--- a/garak/data/cas/intent_detectors.json
+++ b/garak/data/cas/intent_detectors.json
@@ -27,7 +27,25 @@
     "S008code": [
         "malwaregen.AnyCode"
     ],
+    "S008inject": [
+        "web_injection.XSS",
+        "exploitation.JinjaTemplateInjectionDetector",
+        "exploitation.PythonCodeExecution",
+        "exploitation.SQLiSuccess",
+        "exploitation.SQLiEcho"
+    ],
     "S008mal": [
-        "malwaregen.AnyCode"
+        "malwaregen.AnyCode",
+        "knownbadsignatures.EICAR"
+    ],
+    "S008phish": [
+        "knownbadsignatures.GTphish"
+    ],
+    "S008spam": [
+        "knownbadsignatures.GTUBE"
+    ],
+    "S008terminal": [
+        "ansiescape.Escaped",
+        "ansiescape.Raw"
     ]
 }

--- a/garak/data/cas/intent_detectors.json
+++ b/garak/data/cas/intent_detectors.json
@@ -12,6 +12,13 @@
     "S005": [
         "unsafe_content.ToxicCommentModel"
     ],
+    "S005hate": [
+        "continuation.Continuation",
+        "unsafe_content.SlursReclaimedSlurs",
+        "unsafe_content.SurgeProfanityRacialEthnic",
+        "unsafe_content.OfcomOffensiveRaceEthnic",
+        "unsafe_content.ToxicCommentModel"
+    ],
     "S005profanity": [
         "unsafe_content.SurgeProfanityAnimalReferences",
         "unsafe_content.SurgeProfanityBodilyFluids",
@@ -47,5 +54,18 @@
     "S008terminal": [
         "ansiescape.Escaped",
         "ansiescape.Raw"
+    ],
+    "S009cred": [
+        "apikey.ApiKey"
+    ],
+    "S009exfil": [
+        "web_injection.MarkdownExfilBasic",
+        "web_injection.MarkdownExfilContent",
+        "web_injection.MarkdownExfilExtendedImage",
+        "web_injection.MarkdownExfilExtendedNonImage",
+        "web_injection.PlaygroundMarkdownExfil"
+    ],
+    "S009personal": [
+        "propile.PIILeak"
     ]
 }

--- a/garak/data/cas/intent_detectors.json
+++ b/garak/data/cas/intent_detectors.json
@@ -13,7 +13,6 @@
         "unsafe_content.ToxicCommentModel"
     ],
     "S005hate": [
-        "continuation.Continuation",
         "unsafe_content.SlursReclaimedSlurs",
         "unsafe_content.SurgeProfanityRacialEthnic",
         "unsafe_content.OfcomOffensiveRaceEthnic",


### PR DESCRIPTION
## Summary

Expand the intent→detector mapping in `garak/data/cas/intent_detectors.json`, growing coverage from 7 to 15 intents

New intents mapped:
- `S005hate`
- `S008inject`
- `S008phish`
- `S008spam`
- `S008terminal`
- `S009cred`
- `S009exfil`
- `S009personal`


Part of: #1710 