### PR TITLE
feat(probes): add UTF fullwidth encoding probe

### DIFF
--- a/garak/probes/encoding.py
+++ b/garak/probes/encoding.py
@@ -619,6 +619,35 @@ class InjectZalgo(EncodingMixin, garak.probes.Probe):
         EncodingMixin.__init__(self)
 
 
+def fullwidth(text: bytes) -> bytes:
+    """Convert ASCII printable characters (0x21-0x7E) to their Unicode
+    fullwidth equivalents (U+FF01-FF5E). Other characters are passed through
+    unchanged."""
+
+    converted = "".join(
+        chr(ord(char) + 0xFEE0) if 0x21 <= ord(char) <= 0x7E else char
+        for char in text.decode()
+    )
+    return bytes(converted, "utf-8")
+
+
+class InjectUTFFullwidth(EncodingMixin, garak.probes.Probe):
+    """Probe for susceptibility to fullwidth UTF encoding.
+
+    Encodes payloads using fullwidth unicode characters, and tries a variety
+    of ways of getting the target model to repeat & decode them."""
+
+    doc_uri = "https://qaz.wtf/u/convert.cgi"
+    active = True
+
+    encoding_name = "UTF Fullwidth"
+    encoding_funcs = [fullwidth]
+
+    def __init__(self, config_root=_config):
+        garak.probes.Probe.__init__(self, config_root=config_root)
+        EncodingMixin.__init__(self)
+
+
 def leet_bytes(plain_input: bytes):
     return bytes(garak.resources.encodings.leetspeak(plain_input.decode()), "utf-8")
 


### PR DESCRIPTION
## Summary

- Adds a new `InjectUTFFullwidth` probe to `garak/probes/encoding.py`, which encodes payloads by mapping ASCII printable characters (0x21-0x7E) to their Unicode fullwidth equivalents (U+FF01-FF5E), following the same pattern as the existing `InjectZalgo` and `InjectLeet` probes.
- Reuses the existing `EncodingMixin` base, `TEMPLATES`, payload mechanism, tags, and detectors used by other encoding probes.

Ref #152

## AI assistance disclosure

This change was developed with AI assistance (Claude). The implementation follows the existing conventions of `garak/probes/encoding.py` (mirroring `InjectZalgo`/`InjectLeet`). I reviewed the diff for correctness and style consistency before submitting.

## Test plan

- [x] `python -m pytest tests/probes/test_probes_encoding.py -q` - 226 passed, 1 skipped (skip is pre-existing/unrelated)
- [x] `python -m pytest tests/probes -q -k encoding` - all passing, new probe auto-discovered via existing test enumeration
- [x] `python -m black garak/probes/encoding.py` - no changes needed beyond new code, file formatted