### PR TITLE
Feature/intent run spec selector

### DIFF
--- a/docs/source/_spec.rst
+++ b/docs/source/_spec.rst
@@ -17,11 +17,11 @@ empty selection ``none`` / ``probes.none`` (distinct from an unspecified spec,
 which defaults to ``probes.*``). A leading ``-`` excludes; ``tier:N`` is
 inclusive ("log level": tiers ``1..N``).
 
-``intent:`` is a separate selection axis consumed by the intent service, not a
-plugin selection: it does not add or remove probes. When no ``intent:`` selector
-is given, the configured default scope ``run.intent_spec`` (default ``S``, the
-top-level *Safety* branch of the intent typology) is injected at resolve time. Typology expansion (child codes) and detectorless
-filtering happen in the intent service, governed by the ``cas.*`` modifiers.
+``intent:`` is a separate selection axis consumed by the intent service. When no
+``intent:`` selector is given, the configured default scope ``run.intent_spec``
+(default ``S``, the top-level *Safety* branch of the intent typology) is injected
+at resolve time. Typology expansion (child codes) and detectorless filtering
+happen in the intent service, governed by the ``cas.*`` modifiers.
 
 ``garak/_spec.py`` covers the grammar: parsing and serialisation. Resolving a
 ``Spec`` to concrete plugin names (against active/tier/tag state) is done by

--- a/docs/source/_spec.rst
+++ b/docs/source/_spec.rst
@@ -18,8 +18,8 @@ which defaults to ``probes.*``). A leading ``-`` excludes; ``tier:N`` is
 inclusive ("log level": tiers ``1..N``).
 
 ``intent:`` is a separate selection axis consumed by the intent service. When no
-``intent:`` selector is given, the configured default scope ``run.intent_spec``
-(default ``S``, the top-level *Safety* branch of the intent typology) is injected
+``intent:`` selector is given, the default scope ``S`` (the top-level *Safety*
+branch of the intent typology, ``garak._spec.DEFAULT_INTENT_SCOPE``) is injected
 at resolve time. Typology expansion (child codes) and detectorless filtering
 happen in the intent service, governed by the ``cas.*`` modifiers.
 

--- a/docs/source/_spec.rst
+++ b/docs/source/_spec.rst
@@ -11,9 +11,17 @@ both transports parse to.
 
 Selectors carry a category-prefixed plugin path (``probes.<module>[.<Class>]``,
 ``buffs.<module>[.<Class>]``), a probe filter (``tag:<prefix>``,
-``tier:<N|name>``), or the explicit empty selection ``none`` / ``probes.none``
-(distinct from an unspecified spec, which defaults to ``probes.*``). A leading
-``-`` excludes; ``tier:N`` is inclusive ("log level": tiers ``1..N``).
+``tier:<N|name>``), an intent typology code (``intent:<code>``, or
+``intent:*`` / ``intent:all`` for every intent), or the explicit
+empty selection ``none`` / ``probes.none`` (distinct from an unspecified spec,
+which defaults to ``probes.*``). A leading ``-`` excludes; ``tier:N`` is
+inclusive ("log level": tiers ``1..N``).
+
+``intent:`` is a separate selection axis consumed by the intent service, not a
+plugin selection: it does not add or remove probes. When no ``intent:`` selector
+is given, the configured default scope ``run.intent_spec`` (default ``S``, the
+top-level *Safety* branch of the intent typology) is injected at resolve time. Typology expansion (child codes) and detectorless
+filtering happen in the intent service, governed by the ``cas.*`` modifiers.
 
 ``garak/_spec.py`` covers the grammar: parsing and serialisation. Resolving a
 ``Spec`` to concrete plugin names (against active/tier/tag state) is done by

--- a/docs/source/cliref.rst
+++ b/docs/source/cliref.rst
@@ -20,7 +20,7 @@ CLI reference for garak
                          [--generator_option_file GENERATOR_OPTION_FILE | --generator_options GENERATOR_OPTIONS]
                          [--harness_option_file HARNESS_OPTION_FILE | --harness_options HARNESS_OPTIONS]
                          [--probe_option_file PROBE_OPTION_FILE | --probe_options PROBE_OPTIONS]
-                         [--intents INTENTS] [--taxonomy TAXONOMY]
+                         [--taxonomy TAXONOMY]
                          [--confidence_interval_method {bootstrap,none}]
                          [--bootstrap_num_iterations BOOTSTRAP_NUM_ITERATIONS]
                          [--bootstrap_confidence_level BOOTSTRAP_CONFIDENCE_LEVEL]
@@ -104,9 +104,6 @@ CLI reference for garak
                           path to JSON file containing options to pass to probe
     --probe_options PROBE_OPTIONS
                           options to pass to probe, formatted as a JSON dict
-    --intents INTENTS, -i INTENTS
-                          comma-separated list of intents & intent prefixes to
-                          use. Default is empty, for all
     --taxonomy TAXONOMY   specify a MISP top-level taxonomy to be used for
                           grouping probes in reporting. e.g. 'avid-effect',
                           'owasp'

--- a/docs/source/configurable.rst
+++ b/docs/source/configurable.rst
@@ -127,6 +127,7 @@ Run Config Items
 
 * ``system_prompt`` -- If given and not overriden by the probe itself, probes will pass the specified system prompt when possible for generators that support chat modality.
 * ``spec`` - The unified selection spec for probes and buffs (``run.spec``); see "Selecting probes and buffs with run.spec" below. If absent, the default is all active probes (``probes.*``); use ``none`` to select no probes explicitly
+* ``intent_spec`` - Default intent scope (comma-separated typology codes / prefixes) injected as the ``run.spec`` ``intent:`` selector when none is given (default ``S``). Use ``run.spec`` ``intent:`` selectors to override per run; the ``cas.*`` modifiers govern expansion / detectorless filtering
 * ``generations`` - How many times to send each prompt for inference
 * ``deprefix`` - Remove the prompt from the start of the output (some models return the prompt as part of their output)
 * ``seed`` - An optional random seed
@@ -182,6 +183,16 @@ Selectors (a category prefix is mandatory):
 * ``tier:<N|name>`` - filters probes by tier; **inclusive** ("log level"): ``tier:N``
   admits tiers ``1..N`` (``tier:1`` is the most critical). Names work too
   (``tier:of_concern`` == ``tier:1``).
+* ``intent:<code>`` - selects intent typology codes for intent-based probes
+  (e.g. ``intent:S`` for the whole Safety branch, ``intent:S001`` for a category,
+  ``intent:S001mis`` for a leaf); ``intent:*`` or ``intent:all`` selects every
+  intent. This is a **separate axis** consumed by the
+  intent service: it does **not** add or remove probes. When no ``intent:`` is
+  given, the default scope ``run.intent_spec`` (default ``S``) is used. Typology
+  expansion and detectorless filtering are governed by the ``cas.*`` modifiers
+  (``expand_intent_tree``, ``serve_detectorless_intents``). Only ``IntentProbe``
+  subclasses consume intents; selecting ``intent:`` without an ``IntentProbe``
+  warns and proceeds.
 
 Polarity: a bare selector (or ``+``) includes; a leading ``-`` removes. Note
 the asymmetry of ``tier``: ``tier:N`` is the inclusive filter, while ``-tier:N``
@@ -208,6 +219,8 @@ wildcard, so quote those specs (or use the ``all`` alias instead).
     garak --spec probes.all,probes.fitd.FITD
     # tiers {1,3}: tier:3 admits 1..3, then -tier:2 removes exactly tier 2
     garak --spec "+probes.*,+tier:3,-tier:2"
+    # an intent probe over one intent category (intents are a separate axis)
+    garak --spec probes.grandma.GrandmaIntent,intent:S004
 
 .. code-block:: yaml
 
@@ -268,7 +281,6 @@ Reporting Config Items
 CAS Config Items
 """"""""""""""""
 
-* ``intent_spec`` - Comma-separated list of intent codes / code prefixes to use with intent-based probes
 * ``expand_intent_tree`` - Flag for whether child intents should be included when parsing the intent spec
 * ``serve_detectorless_intents`` - Should the intent service provide intents for which there are no configured detectors?
 * ``trust_code_stubs`` - Execute code for stub generation, as well as use static data sources

--- a/docs/source/configurable.rst
+++ b/docs/source/configurable.rst
@@ -126,8 +126,7 @@ Run Config Items
 """"""""""""""""
 
 * ``system_prompt`` -- If given and not overriden by the probe itself, probes will pass the specified system prompt when possible for generators that support chat modality.
-* ``spec`` - The unified selection spec for probes and buffs (``run.spec``); see "Selecting probes and buffs with run.spec" below. If absent, the default is all active probes (``probes.*``); use ``none`` to select no probes explicitly
-* ``intent_spec`` - Default intent scope (comma-separated typology codes / prefixes) injected as the ``run.spec`` ``intent:`` selector when none is given (default ``S``). Use ``run.spec`` ``intent:`` selectors to override per run; the ``cas.*`` modifiers govern expansion / detectorless filtering
+* ``spec`` - The unified selection spec for probes and buffs (``run.spec``); see "Selecting probes and buffs with run.spec" below. If absent, the default is all active probes (``probes.*``); use ``none`` to select no probes explicitly. The intent scope is part of this spec: when no ``intent:`` selector is given, the default scope ``S`` is injected; set ``run.spec`` ``intent:`` selectors to override
 * ``generations`` - How many times to send each prompt for inference
 * ``deprefix`` - Remove the prompt from the start of the output (some models return the prompt as part of their output)
 * ``seed`` - An optional random seed
@@ -188,7 +187,8 @@ Selectors (a category prefix is mandatory):
   ``intent:S001mis`` for a leaf); ``intent:*`` or ``intent:all`` selects every
   intent. This is a **separate axis** consumed by the
   intent service: it does **not** add or remove probes. When no ``intent:`` is
-  given, the default scope ``run.intent_spec`` (default ``S``) is used. Typology
+  given, the default scope ``S`` (the Safety branch) is injected at resolve
+  time. Typology
   expansion and detectorless filtering are governed by the ``cas.*`` modifiers
   (``expand_intent_tree``, ``serve_detectorless_intents``). Only ``IntentProbe``
   subclasses consume intents; selecting ``intent:`` without an ``IntentProbe``

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -41,7 +41,6 @@ system_params = (
 run_params = "seed deprefix eval_threshold generations interactive system_prompt spec".split()
 plugins_params = "target_type target_name extended_detectors".split()
 reporting_params = "taxonomy report_prefix confidence_interval_method bootstrap_num_iterations bootstrap_confidence_level bootstrap_min_sample_size".split()
-cas_params = "intent_spec".split()
 project_dir_name = "garak"
 
 
@@ -128,6 +127,7 @@ run.soft_probe_prompt_cap = 64
 run.target_lang = "en"
 run.langproviders = []
 run.spec = None  # unified selection spec; None -> implicit probes.* at resolve time
+run.intent_spec = "S"  # default intent scope, injected as intent:<value> when run.spec carries no intent: selector
 
 # placeholder
 # generator, probe, detector, buff = {}, {}, {}, {}

--- a/garak/_config.py
+++ b/garak/_config.py
@@ -127,7 +127,6 @@ run.soft_probe_prompt_cap = 64
 run.target_lang = "en"
 run.langproviders = []
 run.spec = None  # unified selection spec; None -> implicit probes.* at resolve time
-run.intent_spec = "S"  # default intent scope, injected as intent:<value> when run.spec carries no intent: selector
 
 # placeholder
 # generator, probe, detector, buff = {}, {}, {}, {}

--- a/garak/_selection.py
+++ b/garak/_selection.py
@@ -171,6 +171,30 @@ def resolve_spec(spec: _spec.Spec, skip_unknown: bool = False) -> _spec.Resoluti
         elif selector.kind == "tag":
             candidate = {p for p in candidate if not _has_any_tag(p, [selector.value])}
 
+    # Intent axis: a separate selection dimension consumed by IntentService, not
+    # a plugin category. Collect raw typology codes; format is validated here,
+    # typology membership + expansion + detectorless filtering happen later in
+    # IntentService. When no intent: selector is given, inject the configured
+    # default (run.intent_spec) so the intent scope survives a run.spec override.
+    from garak import _config
+    from garak.services.intentservice import validate_intent_specifier
+
+    intent_includes = [s.value for s in spec.include if s.kind == "intent"]
+    intent_excludes = [s.value for s in spec.exclude if s.kind == "intent"]
+    for code in intent_includes + intent_excludes:
+        # ``*`` / ``all`` select every intent (IntentService expands the vacuous
+        # sentinel); other codes must match the typology specifier format.
+        if code.lower() in ("*", "all"):
+            continue
+        if not validate_intent_specifier(code):
+            rejected.append(f"intent:{code}")
+    intents_explicit = bool(intent_includes or intent_excludes)
+    if intent_includes:
+        intents = list(dict.fromkeys(intent_includes))
+    else:
+        default = getattr(_config.run, "intent_spec", None)
+        intents = [c.strip() for c in str(default).split(",") if c.strip()] if default else []
+
     rejected = sorted(set(rejected))
     inactive_modules = sorted(set(inactive_modules))
     if rejected and not skip_unknown:
@@ -192,4 +216,7 @@ def resolve_spec(spec: _spec.Spec, skip_unknown: bool = False) -> _spec.Resoluti
         rejected=rejected,
         inactive=inactive_modules,
         empty_reason=empty_reason,
+        intents=intents,
+        blocked_intents=list(dict.fromkeys(intent_excludes)),
+        intents_explicit=intents_explicit,
     )

--- a/garak/_selection.py
+++ b/garak/_selection.py
@@ -170,10 +170,8 @@ def resolve_spec(spec: _spec.Spec, skip_unknown: bool = False) -> _spec.Resoluti
     # Intent axis: a separate selection dimension consumed by IntentService, not
     # a plugin category. Collect raw typology codes; format is validated here,
     # typology membership + expansion + detectorless filtering happen later in
-    # IntentService. When no intent: selector is given, inject the configured
-    # default (run.intent_spec) so the intent scope survives a run.spec override.
-    from garak import _config
-
+    # IntentService. When no intent: selector is given, inject the default scope
+    # (_spec.DEFAULT_INTENT_SCOPE) so the intent scope survives a run.spec override.
     intent_includes = [s.value for s in spec.include if s.kind == "intent"]
     intent_excludes = [s.value for s in spec.exclude if s.kind == "intent"]
     for code in intent_includes + intent_excludes:
@@ -187,10 +185,9 @@ def resolve_spec(spec: _spec.Spec, skip_unknown: bool = False) -> _spec.Resoluti
     if intent_includes:
         intents = list(dict.fromkeys(intent_includes))
     else:
-        default = getattr(_config.run, "intent_spec", None)
-        intents = (
-            [c.strip() for c in str(default).split(",") if c.strip()] if default else []
-        )
+        intents = [
+            c.strip() for c in _spec.DEFAULT_INTENT_SCOPE.split(",") if c.strip()
+        ]
 
     rejected = sorted(set(rejected))
     inactive_modules = sorted(set(inactive_modules))

--- a/garak/_selection.py
+++ b/garak/_selection.py
@@ -44,7 +44,7 @@ def _resolve_plugin_paths(
             # explicit empty selection contributes nothing (and is not unknown)
             continue
         token = selector.value
-        body = token[len(prefix):] if token.startswith(prefix) else token
+        body = token[len(prefix) :] if token.startswith(prefix) else token
         if body == "*":
             names |= {p for p, active in enumerated if active is True}
         elif body.count(".") < 1:
@@ -114,9 +114,7 @@ def resolve_spec(spec: _spec.Spec, skip_unknown: bool = False) -> _spec.Resoluti
     probe_includes = [
         s for s in spec.include if s.kind == "plugin_path" and s.category == "probes"
     ]
-    probe_none = any(
-        s.kind == "none" and s.category == "probes" for s in spec.include
-    )
+    probe_none = any(s.kind == "none" and s.category == "probes" for s in spec.include)
     if probe_includes:
         candidate, rej, inact = _resolve_plugin_paths(probe_includes, "probes")
         rejected += rej
@@ -164,9 +162,7 @@ def resolve_spec(spec: _spec.Spec, skip_unknown: bool = False) -> _spec.Resoluti
             number = int(selector.value)
             removed = {p for p in candidate if _tier_of(p) == number}
             if not removed:
-                logging.debug(
-                    "run.spec: no active probe of tier %s to remove", number
-                )
+                logging.debug("run.spec: no active probe of tier %s to remove", number)
             candidate -= removed
         elif selector.kind == "tag":
             candidate = {p for p in candidate if not _has_any_tag(p, [selector.value])}
@@ -177,7 +173,6 @@ def resolve_spec(spec: _spec.Spec, skip_unknown: bool = False) -> _spec.Resoluti
     # IntentService. When no intent: selector is given, inject the configured
     # default (run.intent_spec) so the intent scope survives a run.spec override.
     from garak import _config
-    from garak.services.intentservice import validate_intent_specifier
 
     intent_includes = [s.value for s in spec.include if s.kind == "intent"]
     intent_excludes = [s.value for s in spec.exclude if s.kind == "intent"]
@@ -186,14 +181,16 @@ def resolve_spec(spec: _spec.Spec, skip_unknown: bool = False) -> _spec.Resoluti
         # sentinel); other codes must match the typology specifier format.
         if code.lower() in ("*", "all"):
             continue
-        if not validate_intent_specifier(code):
+        if not _spec.validate_intent_specifier(code):
             rejected.append(f"intent:{code}")
     intents_explicit = bool(intent_includes or intent_excludes)
     if intent_includes:
         intents = list(dict.fromkeys(intent_includes))
     else:
         default = getattr(_config.run, "intent_spec", None)
-        intents = [c.strip() for c in str(default).split(",") if c.strip()] if default else []
+        intents = (
+            [c.strip() for c in str(default).split(",") if c.strip()] if default else []
+        )
 
     rejected = sorted(set(rejected))
     inactive_modules = sorted(set(inactive_modules))

--- a/garak/_spec.py
+++ b/garak/_spec.py
@@ -30,13 +30,15 @@ _CATEGORIES = ("probes", "buffs")
 class Selector:
     """A single selection clause.
 
-    ``kind`` is one of ``"plugin_path"``, ``"none"``, ``"tag"`` or ``"tier"``.
-    For ``plugin_path`` and ``none`` selectors ``value`` carries the
-    category-prefixed token (e.g. ``"probes.dan"`` / ``"probes.none"``) and
-    ``category`` is set; for ``tag``/``tier`` the filter applies to probes and
-    ``category`` is ``None``. A ``none`` selector is an explicit empty
-    selection for its category, distinct from an unspecified spec (which
-    defaults to all active probes at resolve time).
+    ``kind`` is one of ``"plugin_path"``, ``"none"``, ``"tag"``, ``"tier"`` or
+    ``"intent"``. For ``plugin_path`` and ``none`` selectors ``value`` carries
+    the category-prefixed token (e.g. ``"probes.dan"`` / ``"probes.none"``) and
+    ``category`` is set; for ``tag``/``tier``/``intent`` the selector applies to
+    a non-plugin axis and ``category`` is ``None`` (``tag``/``tier`` filter
+    probes; ``intent`` carries a raw typology code for IntentService). A
+    ``none`` selector is an explicit empty selection for its category, distinct
+    from an unspecified spec (which defaults to all active probes at resolve
+    time).
     """
 
     kind: str
@@ -76,12 +78,21 @@ class Resolution:
     lists unknown selectors; ``inactive`` lists bare-module selectors that exist
     but whose plugins are all inactive (known-but-empty, distinct from unknown -
     see issue #830); ``empty_reason`` is set when the spec resolves to no probes.
-    ``probes`` and ``buffs`` are convenience accessors over ``selected``."""
+    ``probes`` and ``buffs`` are convenience accessors over ``selected``.
+
+    The intent axis is separate: ``intents``/``blocked_intents`` are raw typology
+    codes (IntentService expands and detectorless-filters them); ``intents`` may
+    be the injected ``run.intent_spec`` default. ``intents_explicit`` flags a
+    user-supplied ``intent:`` (vs the default) to warn when no ``IntentProbe`` is
+    selected."""
 
     selected: Dict[str, List[str]]
     rejected: List[str]
     inactive: List[str] = field(default_factory=list)
     empty_reason: Optional[str] = None
+    intents: List[str] = field(default_factory=list)
+    blocked_intents: List[str] = field(default_factory=list)
+    intents_explicit: bool = False
 
     @property
     def probes(self) -> List[str]:
@@ -147,6 +158,20 @@ def _classify(token: str, include: bool) -> Selector:
         return Selector("tag", token[4:], include, None)
     if token.startswith("tier:"):
         return Selector("tier", _normalize_tier(token[5:]), include, None)
+    # intent typology code (e.g. ``intent:S``, ``intent:S001``, ``intent:S001mis``),
+    # or ``intent:*`` / ``intent:all`` for every intent. A run.spec axis consumed by
+    # IntentService, not a plugin selection; format is validated at resolve time,
+    # typology membership at IntentService load. One code per selector: a
+    # comma-separated value (e.g. an old ``cas.intent_spec: "S004,S005"`` string)
+    # is a syntax error -- use one ``intent:`` per code.
+    if token.startswith("intent:"):
+        value = token[7:].strip()
+        if "," in value:
+            raise ValueError(
+                f"run.spec intent selector {value!r}: use one intent: per code "
+                f"(e.g. 'intent:S004, intent:S005'), not a comma-separated value"
+            )
+        return Selector("intent", value, include, None)
     # explicit empty selection: bare ``none`` (probes) or ``<category>.none``
     # selects nothing for that category, distinct from an unspecified spec.
     if token.lower() == "none":

--- a/garak/_spec.py
+++ b/garak/_spec.py
@@ -18,12 +18,18 @@ adapter shares the same resolution core.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
 # Plugin categories selectable via run.spec. Detectors are not selectable here
 # yet; they keep their own legacy spec surface (parse_plugin_spec).
 _CATEGORIES = ("probes", "buffs")
+
+
+def validate_intent_specifier(intent_specifier: str) -> bool:
+    """Validate a single intent typology specifier (format only)."""
+    return re.fullmatch("[CTMS]([0-9]{3}([a-z]+)?)?", intent_specifier) is not None
 
 
 @dataclass(frozen=True)
@@ -146,7 +152,7 @@ def parse_spec_file(node: Optional[dict]) -> Spec:
                     raise ValueError(
                         f"run.spec item must be a string or single-key mapping: {item!r}"
                     )
-                (key, value), = item.items()
+                ((key, value),) = item.items()
                 item = f"{key}:{value}"
             bucket.append(_classify(item, polarity == "include"))
     return out

--- a/garak/_spec.py
+++ b/garak/_spec.py
@@ -26,6 +26,9 @@ from typing import Dict, List, Optional
 # yet; they keep their own legacy spec surface (parse_plugin_spec).
 _CATEGORIES = ("probes", "buffs")
 
+# Default intent scope (Safety branch), injected when run.spec has no intent:
+DEFAULT_INTENT_SCOPE = "S"
+
 
 def validate_intent_specifier(intent_specifier: str) -> bool:
     """Validate a single intent typology specifier (format only)."""
@@ -88,7 +91,7 @@ class Resolution:
 
     The intent axis is separate: ``intents``/``blocked_intents`` are raw typology
     codes (IntentService expands and detectorless-filters them); ``intents`` may
-    be the injected ``run.intent_spec`` default. ``intents_explicit`` flags a
+    be the injected :data:`DEFAULT_INTENT_SCOPE`. ``intents_explicit`` flags a
     user-supplied ``intent:`` (vs the default) to warn when no ``IntentProbe`` is
     selected."""
 

--- a/garak/_spec.py
+++ b/garak/_spec.py
@@ -168,8 +168,8 @@ def _classify(token: str, include: bool) -> Selector:
     # or ``intent:*`` / ``intent:all`` for every intent. A run.spec axis consumed by
     # IntentService, not a plugin selection; format is validated at resolve time,
     # typology membership at IntentService load. One code per selector: a
-    # comma-separated value (e.g. an old ``cas.intent_spec: "S004,S005"`` string)
-    # is a syntax error -- use one ``intent:`` per code.
+    # comma-separated value (e.g. ``intent:S004,S005``) is a syntax error --
+    # use one ``intent:`` per code.
     if token.startswith("intent:"):
         value = token[7:].strip()
         if "," in value:

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -219,15 +219,6 @@ def main(arguments=None) -> None:
             help=f"options to pass to {plugin_type}, formatted as a JSON dict",
         )
 
-    ## CAS
-    parser.add_argument(
-        "--intents",
-        "-i",
-        type=str,
-        default=_config.cas.intent_spec,
-        help="comma-separated list of intents & intent prefixes to use. Default is empty, for all",
-    )
-
     ## REPORTING
     parser.add_argument(
         "--taxonomy",
@@ -718,6 +709,10 @@ def main(arguments=None) -> None:
                 parse_spec_file(_config.run.spec), skip_unknown=True
             )
             _check_selection(resolved.rejected, "run.spec", resolved.inactive)
+            # stash the resolved intent axis for IntentService (consumed at harness load)
+            _config.transient.intent_spec = ",".join(resolved.intents)
+            _config.transient.blocked_intent_spec = ",".join(resolved.blocked_intents)
+            _config.transient.intents_explicit = resolved.intents_explicit
             # --skip_unknown tolerates an empty selection (e.g. every include was an
             # unknown selector that was skipped); only guard when not skipping.
             if (
@@ -761,6 +756,8 @@ def main(arguments=None) -> None:
 
             command.start_run()  # start the run now that all config validation is complete
             print(f"📜 reporting to {_config.transient.report_filename}")
+
+            command.warn_unconsumed_intents(parsed_specs["probe"])
 
             if parsed_specs["detector"] == []:
                 command.probewise_run(

--- a/garak/command.py
+++ b/garak/command.py
@@ -331,6 +331,45 @@ def plugin_info(plugin_name):
 # TODO set probe config string
 
 
+def _selection_has_intent_probe(probe_names) -> bool:
+    """True if any selected probe (``probes.<module>.<Class>``) is an IntentProbe
+    subclass. Resolves the class without instantiating; short-circuits on the
+    first match."""
+    import importlib
+    from garak.probes.base import IntentProbe
+
+    for name in probe_names:
+        module_path, _, klass_name = name.rpartition(".")
+        if not module_path.startswith("probes."):
+            continue
+        try:
+            module = importlib.import_module(f"garak.{module_path}")
+            klass = getattr(module, klass_name)
+        except (ImportError, AttributeError):
+            continue
+        if isinstance(klass, type) and issubclass(klass, IntentProbe):
+            return True
+    return False
+
+
+def warn_unconsumed_intents(probe_names) -> None:
+    """Warn once when ``intent:`` was given explicitly but no IntentProbe is in the
+    selection to consume it. The intent axis does not select probes, so without an
+    IntentProbe the intents are never exercised."""
+    from garak import _config
+
+    if not getattr(_config.transient, "intents_explicit", False):
+        return
+    if _selection_has_intent_probe(probe_names):
+        return
+    msg = (
+        "intent: selector(s) given but no IntentProbe is selected; intents will "
+        "not be exercised (select an IntentProbe, e.g. probes.grandma.GrandmaIntent)"
+    )
+    logging.warning(msg)
+    print(f"⚠️  {msg}")
+
+
 # do a run
 def probewise_run(generator, probe_names, evaluator, buffs):
     import garak.harnesses.probewise

--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -907,4 +907,9 @@ class IntentProbe(Probe):
             self.prompt_intents.extend([self.stub_intents[i]] * len(prompts))
 
     def probe(self, generator) -> Iterable[garak.attempt.Attempt]:
+        if not self.prompts:
+            # an empty active-intent set (run.spec intent: filtered to nothing)
+            # yields no prompts; no-op so the rest of the run proceeds (3A)
+            logging.debug("%s has no active intents; no prompts to send", self.probename)
+            return []
         return super().probe(generator)

--- a/garak/resources/garak.core.yaml
+++ b/garak/resources/garak.core.yaml
@@ -16,9 +16,9 @@ run:
   generations: 5
   user_agent: "garak/{version} (LLM vulnerability scanner https://garak.ai)"
   soft_probe_prompt_cap: 256
+  intent_spec: S
 
 cas:
-  intent_spec: S
   expand_intent_tree: True
   trust_code_stubs: False
   serve_detectorless_intents: False

--- a/garak/resources/garak.core.yaml
+++ b/garak/resources/garak.core.yaml
@@ -16,7 +16,6 @@ run:
   generations: 5
   user_agent: "garak/{version} (LLM vulnerability scanner https://garak.ai)"
   soft_probe_prompt_cap: 256
-  intent_spec: S
 
 cas:
   expand_intent_tree: True

--- a/garak/services/intentservice.py
+++ b/garak/services/intentservice.py
@@ -91,7 +91,7 @@ def _expand_intent_spec(
 
     expanded_intents = set()
 
-    if intent_spec is None or intent_spec in ("*", "all", ""):
+    if intent_spec in (None, "*", "all", ""):
         expanded_intents.update(intent_typology.keys())
     else:
         for intent_prefix in intent_spec.split(","):
@@ -122,18 +122,46 @@ def _expand_intent_specifier_children(intent_specifier: str) -> Set[str]:
     return intent_codes_to_lookup
 
 
-def _populate_intents(intent_spec: str | None) -> None:
-    """set the active intents according to an intent spec and the
-    loaded typology."""
+def _validate_intent_codes(intent_spec: str | None) -> None:
+    """Fail-closed when a requested include code is well-formed but absent from
+    the loaded typology (e.g. ``S999``). Vacuous specs (``None``/``*``/``all``/
+    ``""``) select everything and are not validated."""
+
+    if intent_spec in (None, "*", "all", ""):
+        return
+    for code in (c.strip() for c in intent_spec.split(",")):
+        if code and code not in intent_typology:
+            raise GarakException(
+                f"intent code '{code}' is not in the loaded intent typology"
+            )
+
+
+def _populate_intents(intent_spec: str | None, blocked_spec: str | None = "") -> None:
+    """Set the active intents from an include spec minus a blocked spec.
+
+    Both are comma-separated typology codes or prefixes. Requested include codes
+    must exist in the loaded typology (fail-closed). Non-leaf codes expand to
+    their children when ``cas.expand_intent_tree`` is set; intents without a
+    mapped detector are dropped unless ``cas.serve_detectorless_intents``."""
 
     global intents_active
 
-    if intent_spec is None or intent_spec in ("*", "all", ""):
+    _validate_intent_codes(intent_spec)
+
+    if intent_spec in (None, "*", "all", ""):
         intents_active = _expand_intent_spec(intent_spec)
     else:
         intents_active = _expand_intent_spec(
             intent_spec, expand_subnodes=garak._config.cas.expand_intent_tree
         )
+
+    if blocked_spec:
+        blocked = _expand_intent_spec(blocked_spec, expand_subnodes=True)
+        if not (intents_active & blocked):
+            logging.debug(
+                "run.spec: no active intent to remove for -intent spec %r", blocked_spec
+            )
+        intents_active.difference_update(blocked)
 
     if not garak._config.cas.serve_detectorless_intents:
         detectorless_intents = set()
@@ -152,11 +180,20 @@ def _populate_intents(intent_spec: str | None) -> None:
 
 
 def load():
-    """load the intentservice"""
+    """load the intentservice.
+
+    The active intents come from the resolved ``run.spec`` (``intent:`` axis),
+    stashed on ``_config.transient`` by the CLI. When that is absent (e.g. a
+    direct service load that did not resolve a spec), fall back to the default
+    scope in ``run.intent_spec``."""
     global is_loaded
     _load_intent_typology()
     _load_intent_detector_mapping()
-    _populate_intents(garak._config.cas.intent_spec)
+    intent_spec = getattr(garak._config.transient, "intent_spec", None)
+    blocked_spec = getattr(garak._config.transient, "blocked_intent_spec", None)
+    if intent_spec is None:
+        intent_spec = getattr(garak._config.run, "intent_spec", None)
+    _populate_intents(intent_spec, blocked_spec or "")
     is_loaded = True
 
 

--- a/garak/services/intentservice.py
+++ b/garak/services/intentservice.py
@@ -30,12 +30,12 @@ To check the quality of the intents present in the system, see ``tools.cas.inten
 import importlib
 import json
 import logging
-import re
 from typing import List, Set
 import yaml
 
 import garak._config
 import garak.data
+from garak._spec import validate_intent_specifier
 from garak.exception import GarakException
 from garak.intents import Stub, TextStub, ConversationStub
 
@@ -314,11 +314,6 @@ def _get_stubs_code(intent_code: str) -> Set[Stub]:
         stubs = set()
 
     return stubs
-
-
-def validate_intent_specifier(intent_specifier: str) -> bool:
-    """validate a single intent specifier"""
-    return re.fullmatch("[CTMS]([0-9]{3}([a-z]+)?)?", intent_specifier) is not None
 
 
 def get_intent_parts(intent_specifier: str) -> List[str]:

--- a/garak/services/intentservice.py
+++ b/garak/services/intentservice.py
@@ -35,7 +35,7 @@ import yaml
 
 import garak._config
 import garak.data
-from garak._spec import validate_intent_specifier
+from garak._spec import validate_intent_specifier, DEFAULT_INTENT_SCOPE
 from garak.exception import GarakException
 from garak.intents import Stub, TextStub, ConversationStub
 
@@ -184,15 +184,15 @@ def load():
 
     The active intents come from the resolved ``run.spec`` (``intent:`` axis),
     stashed on ``_config.transient`` by the CLI. When that is absent (e.g. a
-    direct service load that did not resolve a spec), fall back to the default
-    scope in ``run.intent_spec``."""
+    direct service load that did not resolve a spec), fall back to
+    :data:`garak._spec.DEFAULT_INTENT_SCOPE`."""
     global is_loaded
     _load_intent_typology()
     _load_intent_detector_mapping()
     intent_spec = getattr(garak._config.transient, "intent_spec", None)
     blocked_spec = getattr(garak._config.transient, "blocked_intent_spec", None)
     if intent_spec is None:
-        intent_spec = getattr(garak._config.run, "intent_spec", None)
+        intent_spec = DEFAULT_INTENT_SCOPE
     _populate_intents(intent_spec, blocked_spec or "")
     is_loaded = True
 

--- a/tests/cas/test_cas_intentprobe.py
+++ b/tests/cas/test_cas_intentprobe.py
@@ -14,7 +14,7 @@ def test_intentprobe_load():
 
 def test_intentprobe_root_intents():
     garak._config.load_config()
-    garak._config.cas.intent_spec = "S"
+    garak._config.transient.intent_spec = "S"
     garak._config.cas.serve_detectorless_intents = True
     garak.services.intentservice.load()
     i = garak._plugins.load_plugin("probes.base.IntentProbe")
@@ -28,7 +28,7 @@ def test_intentprobe_root_intents():
 
 def test_intentprobe_consistency():
     garak._config.load_config()
-    garak._config.cas.intent_spec = "S"
+    garak._config.transient.intent_spec = "S"
     garak.services.intentservice.load()
     i = garak._plugins.load_plugin("probes.base.IntentProbe")
     assert len(i.stubs) == len(i.stub_intents), "should be 1 stub intent per stub "

--- a/tests/cas/test_intent_run_spec.py
+++ b/tests/cas/test_intent_run_spec.py
@@ -45,10 +45,10 @@ def test_blocked_intent_removed():
 
 
 def test_default_fallback_when_transient_unset():
-    # transient unset -> fall back to the run.intent_spec default (S)
+    # transient unset -> fall back to DEFAULT_INTENT_SCOPE (S)
     fallback = _load(None)
     explicit_s = _load("S")
-    assert fallback == explicit_s, "unset transient must fall back to run.intent_spec default (S)"
+    assert fallback == explicit_s, "unset transient must fall back to DEFAULT_INTENT_SCOPE (S)"
     assert fallback, "default S scope must resolve to a non-empty active set"
 
 

--- a/tests/cas/test_intent_run_spec.py
+++ b/tests/cas/test_intent_run_spec.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Portions Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Wiring between the run.spec ``intent:`` axis and the IntentService.
+
+The CLI stashes the resolved intent codes on ``_config.transient``; IntentService
+reads them at ``load()`` and performs typology expansion + detectorless filtering.
+"""
+
+import pytest
+
+import garak._config
+import garak.services.intentservice as intentservice
+from garak.exception import GarakException
+
+
+@pytest.fixture(autouse=True)
+def _reset_intent_transient():
+    garak._config.load_config()
+    yield
+    garak._config.transient.intent_spec = None
+    garak._config.transient.blocked_intent_spec = None
+    garak._config.transient.intents_explicit = False
+
+
+def _load(intent_spec=None, blocked_spec=None):
+    garak._config.transient.intent_spec = intent_spec
+    garak._config.transient.blocked_intent_spec = blocked_spec
+    intentservice.load()
+    return intentservice.intents_active
+
+
+def test_resolved_intents_drive_active():
+    active = _load("S004")
+    assert active, "resolved intent:S004 must populate active intents"
+    assert all(
+        code.startswith("S004") for code in active
+    ), "only the S004 subtree should be active for intent:S004"
+
+
+def test_blocked_intent_removed():
+    active = _load("S005", "S005profanity")
+    assert "S005profanity" not in active, "-intent:S005profanity must drop that code"
+    assert "S005hate" in active, "sibling S005 codes remain after blocking profanity"
+
+
+def test_default_fallback_when_transient_unset():
+    # transient unset -> fall back to the run.intent_spec default (S)
+    fallback = _load(None)
+    explicit_s = _load("S")
+    assert fallback == explicit_s, "unset transient must fall back to run.intent_spec default (S)"
+    assert fallback, "default S scope must resolve to a non-empty active set"
+
+
+def test_nonexistent_code_fails_closed():
+    with pytest.raises(GarakException, match="not in the loaded intent typology"):
+        _load("S999")
+
+
+def test_serve_detectorless_flag_governs_expansion():
+    garak._config.cas.serve_detectorless_intents = False
+    assert _load("S001") == set(), "S001 is detectorless; dropped by default"
+    garak._config.cas.serve_detectorless_intents = True
+    assert "S001mis" in _load("S001"), "serve_detectorless_intents keeps detectorless S001 codes"
+
+
+def test_all_intents_selector_spans_branches():
+    # intent:* / intent:all -> IntentService expands the vacuous sentinel to every
+    # intent (then detectorless-filtered), spanning branches beyond S.
+    active = _load("*")
+    assert active, "intent:* selects every intent (after detectorless filter)"
+    assert "M010" in active, "all-intents spans branches beyond Safety (e.g. M010)"
+
+
+def test_empty_axis_yields_no_prompts():
+    # intent:S004 then -intent:S004 -> exclude wins -> empty active-intent set.
+    # The IntentProbe must build no prompts and not crash (graceful no-op, 3A).
+    import garak._plugins
+
+    assert _load("S004", "S004") == set(), "exclude of the included code empties the axis"
+    probe = garak._plugins.load_plugin("probes.base.IntentProbe")
+    assert probe.prompts == [], "empty intent axis yields an IntentProbe with no prompts"
+
+
+# The "intent: without consumer" warning lives once at orchestration (command),
+# over the whole probe selection -- not in the per-probe Harness.run() loop, which
+# would false-positive on the non-IntentProbe calls of a mixed selection.
+def test_warn_unconsumed_intents_fires_without_intent_probe(capsys):
+    import garak.command as command
+
+    garak._config.transient.intents_explicit = True
+    command.warn_unconsumed_intents(["probes.dan.DanInTheWild"])
+    assert (
+        "no IntentProbe is selected" in capsys.readouterr().out
+    ), "explicit intent: with no IntentProbe in the selection must warn"
+
+
+def test_warn_unconsumed_intents_silent_with_mixed_selection(capsys):
+    import garak.command as command
+
+    # an IntentProbe alongside a regular probe must NOT warn (the per-probe harness
+    # location used to false-positive on the regular probe here)
+    garak._config.transient.intents_explicit = True
+    command.warn_unconsumed_intents(
+        ["probes.grandma.GrandmaIntent", "probes.dan.DanInTheWild"]
+    )
+    assert capsys.readouterr().out == "", "an IntentProbe in the selection consumes intents"
+
+
+def test_warn_unconsumed_intents_silent_when_default(capsys):
+    import garak.command as command
+
+    garak._config.transient.intents_explicit = False
+    command.warn_unconsumed_intents(["probes.dan.DanInTheWild"])
+    assert capsys.readouterr().out == "", "the injected default (not explicit) must not warn"

--- a/tests/harnesses/test_harness_intent_plugin_cache.py
+++ b/tests/harnesses/test_harness_intent_plugin_cache.py
@@ -60,7 +60,7 @@ def intent_report(tmp_path, monkeypatch):
     """
     garak._config.load_config()
     garak._config.run.generations = 1
-    garak._config.cas.intent_spec = MAPPED_INTENT
+    garak._config.transient.intent_spec = MAPPED_INTENT
     garak._config.cas.serve_detectorless_intents = False
 
     report_path = tmp_path / "intent_plugin_cache.report.jsonl"

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -304,7 +304,7 @@ def test_intent_round_trip():
 
 def test_intent_default_injected_when_absent():
     res = resolve("probes.dan")
-    assert res.intents == ["S"], "default run.intent_spec must be injected when no intent: given"
+    assert res.intents == ["S"], "DEFAULT_INTENT_SCOPE must be injected when no intent: given"
     assert res.intents_explicit is False, "injected default is not an explicit intent selection"
 
 
@@ -345,7 +345,7 @@ def test_intent_comma_value_rejected():
 
 def test_intent_exclude_only_applies_to_default():
     res = resolve("probes.dan,-intent:S004")
-    assert res.intents == ["S"], "exclude-only keeps the injected default include (run.intent_spec)"
+    assert res.intents == ["S"], "exclude-only keeps the injected default include (DEFAULT_INTENT_SCOPE)"
     assert res.blocked_intents == ["S004"], "the -intent: code is recorded as blocked"
     assert res.intents_explicit is True, "a lone -intent: still counts as an explicit intent selection"
 

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -277,10 +277,77 @@ def test_prefix_required():
         parse_spec_string("dan")
 
 
-@pytest.mark.parametrize("token", ["detectors.always.Pass", "intent:S"])
+@pytest.mark.parametrize("token", ["detectors.always.Pass"])
 def test_out_of_scope_kinds_raise(token):
     with pytest.raises(ValueError):
         parse_spec_string(token)
+
+
+@pytest.mark.parametrize("code", ["S", "S001", "S001mis"])
+def test_intent_classify(code):
+    (selector,) = parse_spec_string(f"intent:{code}").include
+    assert selector.kind == "intent", "intent: token must classify as the intent kind"
+    assert selector.value == code, "intent value must be the raw typology code"
+    assert selector.category is None, "intent is a non-plugin axis (no category)"
+
+
+def test_intent_round_trip():
+    spec = parse_spec_string("intent:S004,-intent:S005profanity")
+    assert spec.to_file_dict() == {
+        "include": [{"intent": "S004"}],
+        "exclude": [{"intent": "S005profanity"}],
+    }, "intent selectors must serialise to single-key {intent: code} mappings"
+    again = parse_spec_file(spec.to_file_dict())
+    assert (again.include[0].kind, again.include[0].value) == ("intent", "S004")
+    assert (again.exclude[0].kind, again.exclude[0].value) == ("intent", "S005profanity")
+
+
+def test_intent_default_injected_when_absent():
+    res = resolve("probes.dan")
+    assert res.intents == ["S"], "default run.intent_spec must be injected when no intent: given"
+    assert res.intents_explicit is False, "injected default is not an explicit intent selection"
+
+
+def test_intent_explicit_overrides_default():
+    res = resolve("probes.dan,intent:S004,-intent:S005profanity")
+    assert res.intents == ["S004"], "explicit intent: replaces the injected default"
+    assert res.blocked_intents == ["S005profanity"], "-intent: codes recorded as blocked"
+    assert res.intents_explicit is True, "user-supplied intent: marks the selection explicit"
+
+
+def test_intent_does_not_filter_probe_set():
+    with_intent = set(resolve("probes.dan,intent:S004").probes)
+    without = set(resolve("probes.dan").probes)
+    assert with_intent == without, "intent: must not add or remove probes (separate axis)"
+
+
+def test_intent_invalid_format_rejected():
+    res = resolve("intent:zzz", skip_unknown=True)
+    assert "intent:zzz" in res.rejected, "malformed intent code recorded in rejected"
+    with pytest.raises(ValueError, match="unknown run.spec"):
+        resolve("intent:zzz")
+
+
+@pytest.mark.parametrize("token", ["intent:*", "intent:all"])
+def test_intent_all_selector_not_rejected(token):
+    res = resolve(f"probes.dan,{token}")
+    assert res.rejected == [], "intent:* / intent:all are valid (all intents), not rejected"
+    assert res.intents and res.intents[0].lower() in (
+        "*",
+        "all",
+    ), "all-intents sentinel passes through to IntentService"
+
+
+def test_intent_comma_value_rejected():
+    with pytest.raises(ValueError, match="one intent: per code"):
+        parse_spec_file({"include": [{"intent": "S004,S005"}]})
+
+
+def test_intent_exclude_only_applies_to_default():
+    res = resolve("probes.dan,-intent:S004")
+    assert res.intents == ["S"], "exclude-only keeps the injected default include (run.intent_spec)"
+    assert res.blocked_intents == ["S004"], "the -intent: code is recorded as blocked"
+    assert res.intents_explicit is True, "a lone -intent: still counts as an explicit intent selection"
 
 
 # --- T9: unknown / skip_unknown -------------------------------------------

--- a/tools/cas/intent_quality.py
+++ b/tools/cas/intent_quality.py
@@ -33,7 +33,6 @@ def main(argv=None) -> None:
 
     import garak.services.intentservice
 
-    garak._config.cas.intent_spec = ""
     garak._config.cas.serve_detectorless_intents = True
     garak._config.cas.trust_code_stubs = True
     garak.services.intentservice.load()


### PR DESCRIPTION
Brings the intent typology into the unified `run.spec` grammar (#1831) as a new `intent:` selector, replacing `--intents` CLI flag and the `cas.intent_spec` config key.

`intent:` is an **orthogonal selection axis**, not a probe filter: it does not add or remove probes. It resolves to a set of typology codes consumed by `IntentService`. Any selected `IntentProbe` then runs over those intents; non-intent probes are unaffected.

```bash
# probe selection unchanged; intents drive the IntentProbe's prompts
garak -t test.Blank --spec "probes.grandma.GrandmaIntent,intent:S004"
garak -t test.Blank --spec "probes.grandma.GrandmaIntent,intent:S005,-intent:S005profanity"
garak -t test.Blank --spec "probes.grandma.GrandmaIntent,intent:*"   # every intent
```

## What changed

- **Grammar**: new `intent:<code>` selector kind; `Resolution` gains `intents` / `blocked_intents` / `intents_explicit` (the intent axis is separate from the `selected` plugin map, since its values are typology codes, not loadable plugin paths).
- **Resolver**: collects `intent:` codes, validates format, injects the default `run.intent_spec` when no `intent:` is given. `*` / `all` pass through as the "every intent" sentinel.
- **Default scope**: `cas.intent_spec` relocated to **`run.intent_spec: S`** in `garak.core.yaml` (the top-level Safety branch). Injected only when no `intent:` selector is present, so it survives a wholesale `run.spec` override.
- **Docs**: `_spec.rst`, `configurable.rst`, `cliref.rst` updated.

## Edge cases covered

- `intent:*` / `intent:all` → every intent (parity with the legacy `cas.intent_spec`).
- Comma in a single token (e.g. config `{intent: "S004,S005"}`) → clear parse error ("use one intent: per code").
- `-intent:X` → applies to the injected default (`S` minus `X`).
- Empty intent axis (`intent:S004, -intent:S004`, or all-detectorless) → `IntentProbe` is a graceful no-op (0 prompts), run proceeds.

Resolves #1707 