### PR TITLE
Make the -v/--verbose flag binary

### DIFF
--- a/docs/source/configurable.rst
+++ b/docs/source/configurable.rst
@@ -97,7 +97,7 @@ System Config Items
 * ``parallel_attempts`` - For parallelisable generators, how many attempts should be run in parallel? Raising this is a great way of speeding up garak runs for API-based models
 * ``parallel_requests`` - For generators not supporting multiple responses per prompt: how many requests to send in parallel with the same prompt? (raising ``parallel_attempts`` generally yields higher performance, depending on how high ``generations`` is set)
 * ``lite`` - Should we display a caution message that the run might not give very thorough results?
-* ``verbose`` - Degree of verbosity (values above 0 are experimental, the report & log are authoritative)
+* ``verbose`` - Enable verbose output (0 = off, 1 = on; the report & log are authoritative)
 * ``narrow_output`` - Support output on narrower CLIs
 * ``show_z`` - Display Z-scores and visual indicators on CLI. It's good, but may be too much info until one has seen garak run a couple of times
 * ``enable_experimental`` - Enable experimental function CLI flags. Disabled by default. Experimental functions may disrupt your installation and provide unusual/unstable results. Can only be set by editing core config, so a git checkout of garak is recommended for this.

--- a/garak/cli.py
+++ b/garak/cli.py
@@ -75,9 +75,10 @@ def main(arguments=None) -> None:
     parser.add_argument(
         "--verbose",
         "-v",
-        action="count",
+        action="store_const",
+        const=1,
         default=_config.system.verbose,
-        help="add one or more times to increase verbosity of output during runtime",
+        help="increase verbosity of output during runtime",
     )
     parser.add_argument(
         "--report_prefix",
@@ -356,7 +357,7 @@ def main(arguments=None) -> None:
     # cli_args contains items specified on CLI; the rest not to be overridden
     cli_args, _ = aux_parser.parse_known_args(arguments)
 
-    # exception: action=count. only verbose uses this, let's bubble it through
+    # verbose isn't added to aux_parser above, so copy it through directly
     cli_args.verbose = args.verbose
 
     # print('ARGS', args)

--- a/garak/generators/ggml.py
+++ b/garak/generators/ggml.py
@@ -122,7 +122,7 @@ class GgmlGenerator(Generator):
         # test all params for None type
         command.extend(self._command_args_list())
         command = [str(param) for param in command]
-        if getattr(_config.system, "verbose", 0) > 1:
+        if getattr(_config.system, "verbose", 0) > 0:
             print("GGML invoked with", command)
         try:
             prompt_text = prompt.last_message().text

--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -149,14 +149,14 @@ class Harness(Configurable):
         if not detectors:
             msg = "No detectors, nothing to do"
             logging.warning(msg)
-            if hasattr(_config.system, "verbose") and _config.system.verbose >= 2:
+            if hasattr(_config.system, "verbose") and _config.system.verbose > 0:
                 print(msg)
             raise ValueError(msg)
 
         if not probes:
             msg = "No probes, nothing to do"
             logging.warning(msg)
-            if hasattr(_config.system, "verbose") and _config.system.verbose >= 2:
+            if hasattr(_config.system, "verbose") and _config.system.verbose > 0:
                 print(msg)
             raise ValueError(msg)
 

--- a/garak/harnesses/probewise.py
+++ b/garak/harnesses/probewise.py
@@ -60,7 +60,7 @@ class ProbewiseHarness(Harness):
         if not probenames:
             msg = "No probes, nothing to do"
             logging.warning(msg)
-            if hasattr(_config.system, "verbose") and _config.system.verbose >= 2:
+            if hasattr(_config.system, "verbose") and _config.system.verbose > 0:
                 print(msg)
             raise ValueError(msg)
 

--- a/garak/probes/atkgen.py
+++ b/garak/probes/atkgen.py
@@ -75,7 +75,9 @@ class Tox(garak.probes.Probe):
     }
 
     def probe(self, generator) -> List[garak.attempt.Attempt]:
-        output_is_conversation = _config.system.verbose >= 2
+        output_is_conversation = (
+            hasattr(_config.system, "verbose") and _config.system.verbose > 0
+        )
 
         if self.redteamer is None:
 

--- a/tests/probes/test_probes_atkgen.py
+++ b/tests/probes/test_probes_atkgen.py
@@ -162,9 +162,9 @@ def test_atkgen_probe(classname):
 
 
 def test_atkgen_verbose_output(capsys):
-    """Test that verbose output (verbose >= 2) displays conversation turns correctly."""
+    """Test that verbose output displays conversation turns correctly."""
     _config.load_base_config()
-    _config.system.verbose = 2  # Enable verbose conversation output
+    _config.system.verbose = 1  # Enable verbose conversation output
     _config.plugins.probes["atkgen"]["generations"] = 1  # we only need one conversation
     p = _plugins.load_plugin("probes.atkgen.Tox", config_root=garak._config)
     p.max_calls_per_conv = 1  # we don't need a full conversation

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,7 +59,6 @@ ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 XDG_VARS = ("XDG_DATA_HOME", "XDG_CONFIG_HOME", "XDG_CACHE_HOME")
 
 OPTIONS_SOLO = [
-    #    "verbose", # not sure hot to test argparse action="count"
     #    "deprefix", # this param is weird
     "narrow_output",
     "extended_detectors",
@@ -244,6 +243,14 @@ def test_cli_spec_settings(param):
         [f"--{option}", str(value), "--list_config"]
     )  # add list_config as the action so we don't actually run
     assert getattr(_config.plugins, configname) == value
+
+
+def test_cli_verbose_is_binary():
+    # --verbose is a binary on/off switch; repeating it must not accumulate
+    garak.cli.main(["--list_config", "-v"])
+    assert _config.system.verbose == 1, "-v should turn verbose on (1)"
+    garak.cli.main(["--list_config", "-vv"])
+    assert _config.system.verbose == 1, "repeated -v should stay binary, not count up"
 
 
 # test a short-form CLI assertion


### PR DESCRIPTION
## Summary

`-v`/`--verbose` used argparse `action="count"`, so `-vv`/`-vvv` pushed verbosity past the on/off level it was meant to have. The sites that read it had also split into two groups: five still required `verbose >= 2` (or `> 1`), while eight already treated any `verbose > 0` as on. A single `-v` switched on the `> 0` output and left the `>= 2` checks (in `atkgen`, `harnesses/base.py`, `harnesses/probewise.py`, and the `ggml` generator) off until `-vv`. Following the direction on #335, `-v` is now a binary flag (`store_const`, `const=1`), and those five checks fold to `> 0` so every site agrees.

There is one behaviour change. Output that previously needed `-vv` now shows at `-v`, and repeating the flag no longer changes the level. `system.verbose` stays an int in config and the `> 0` checks treat any positive value as on. `docs/source/cliref.rst` is generated from `--help`, so it regenerates on the next docs build.

## Why this is not a duplicate

Checked open PRs and issues for `verbose`, `-v`, and the count behaviour. None address this.

## Testing

- `python -m pytest tests/test_config.py tests/harnesses/ tests/generators/test_ggml.py tests/probes/test_probes_atkgen.py::test_atkgen_verbose_output` passed.
- Added `tests/test_config.py::test_cli_verbose_is_binary`. It fails on `main` (`-vv` resolves to 2) and passes here. The `atkgen` verbose test now sets `verbose = 1`; it fails against the old `>= 2` code and passes against `> 0`.
- Checked at the CLI in a clean process: on `main`, `-vv` resolves verbose to 2; with this change it resolves to 1.

## AI assistance

AI assistance was used for this change. I reviewed every line and ran the tests above.
