### PR TITLE
fix: drop name fallback for stub-less intents

### DIFF
--- a/garak/services/intentservice.py
+++ b/garak/services/intentservice.py
@@ -161,14 +161,11 @@ def load():
 
 
 def _get_stubs_typology(intent_code: str) -> Set[Stub]:
-    """get stubs for an intent based on names & descriptions in the typology"""
+    """get stubs for an intent based on its configured default_stub"""
 
-    # return the descr of a given typology point, or if empty/absent, the name
-    intent_details = intent_typology.get(intent_code, {})
-
-    raw_stub = intent_details.get("default_stub")
+    raw_stub = intent_typology.get(intent_code, {}).get("default_stub")
     if not raw_stub:
-        raw_stub = intent_details.get("name")
+        return set()
 
     stubs = set([TextStub(intent_code, raw_stub)])
     return stubs
@@ -353,6 +350,10 @@ def get_intent_stubs(intent_code: str, text_only=True, conv_only=False) -> Set[S
 
     if conv_only:
         stubs = set(filter(lambda s: isinstance(s, ConversationStub), stubs))
+
+    # a leaf intent with no stubs cannot be exercised; surface the gap
+    if not stubs and len(intent_code) > 4:
+        logging.warning("intents: no stubs available for intent %s", intent_code)
 
     # return stubs
     return stubs

--- a/tests/cas/test_intentservice.py
+++ b/tests/cas/test_intentservice.py
@@ -58,6 +58,36 @@ def test_no_spurious_text_intents():
         )
 
 
+def test_typology_stub_no_default_returns_empty(monkeypatch):
+    import garak.services.intentservice as isvc
+
+    monkeypatch.setattr(
+        isvc, "intent_typology", {"C999x": {"name": "Some label", "default_stub": ""}}
+    )
+    assert (
+        isvc._get_stubs_typology("C999x") == set()
+    ), "absent default_stub must not fall back to the category name"
+
+
+def test_get_intent_stubs_empty_leaf_warns(monkeypatch, caplog):
+    import logging
+    import garak.services.intentservice as isvc
+
+    garak._config.load_config()
+    monkeypatch.setattr(isvc, "is_loaded", True)
+    monkeypatch.setattr(
+        isvc,
+        "intent_typology",
+        {"C999none": {"name": "Some label", "default_stub": "", "descr": ""}},
+    )
+    with caplog.at_level(logging.WARNING):
+        stubs = isvc.get_intent_stubs("C999none")
+    assert stubs == set(), "leaf intent without any stub source must yield no stubs"
+    assert any(
+        "no stubs available" in record.getMessage() for record in caplog.records
+    ), "missing stubs for an active leaf intent must be logged"
+
+
 @pytest.mark.skip(reason="nltk.pos_tag returns too many false negatives")
 def test_typology_intents_start_verb():
     import garak.services.intentservice

--- a/tools/cas/intent_quality.py
+++ b/tools/cas/intent_quality.py
@@ -53,7 +53,12 @@ def main(argv=None) -> None:
                 comments.append("No default stub")
             if garak.services.intentservice.get_detectors(intent_code) is None:
                 comments.append("No detectors set")
-            if len(garak.services.intentservice.get_intent_stubs(intent_code)) == 1:
+            stub_count = len(
+                garak.services.intentservice.get_intent_stubs(intent_code)
+            )
+            if stub_count == 0:
+                comments.append("No stubs at all")
+            elif stub_count == 1:
                 comments.append("No supplemental stubs")
 
         symbol = theme.EMOJI_SCALE_COLOUR_SQUARE[0]


### PR DESCRIPTION
Intents with no `default_stub` no longer fall back to the category name as a stub. They now yield no examples; a warning is logged for empty active leaf intents and intent_quality reports "No stubs at all".