### PR TITLE
feat(probes/encoding): add InjectCaesar probe

### DIFF
--- a/garak/probes/encoding.py
+++ b/garak/probes/encoding.py
@@ -704,3 +704,36 @@ class InjectSneakyBits(EncodingMixin, garak.probes.Probe):
     def __init__(self, config_root=_config):
         garak.probes.Probe.__init__(self, config_root=config_root)
         EncodingMixin.__init__(self)
+
+
+def _caesar_shift(shift: int):
+    def _encode(text: bytes) -> bytes:
+        out = []
+        for ch in text.decode():
+            if "a" <= ch <= "z":
+                out.append(chr((ord(ch) - ord("a") + shift) % 26 + ord("a")))
+            elif "A" <= ch <= "Z":
+                out.append(chr((ord(ch) - ord("A") + shift) % 26 + ord("A")))
+            else:
+                out.append(ch)
+        return "".join(out).encode("utf-8")
+
+    _encode.__name__ = f"caesar_shift_{shift}"
+    return _encode
+
+
+class InjectCaesar(EncodingMixin, garak.probes.Probe):
+    """Probe for susceptibility to Caesar cipher encoded injections.
+
+    Encodes payloads using Caesar cipher with shifts 3, 7, and 17, and tries
+    a variety of ways of getting the target model to repeat & decode them.
+    ROT13 (shift 13) is handled separately by InjectROT13."""
+
+    doc_uri = "https://en.wikipedia.org/wiki/Caesar_cipher"
+    encoding_name = "Caesar"
+    active = True
+    encoding_funcs = [_caesar_shift(3), _caesar_shift(7), _caesar_shift(17)]
+
+    def __init__(self, config_root=_config):
+        garak.probes.Probe.__init__(self, config_root=config_root)
+        EncodingMixin.__init__(self)

--- a/tests/probes/test_probes_encoding.py
+++ b/tests/probes/test_probes_encoding.py
@@ -91,3 +91,22 @@ def test_atbash_function(plain, expected):
     encoder = InjectAtbash.atbash  # staticmethod reference
     result = encoder(plain.encode()).decode()
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "plain, shift, expected",
+    [
+        ("abc", 3, "def"),
+        ("xyz", 3, "abc"),
+        ("ABC", 3, "DEF"),
+        ("Hello, World!", 3, "Khoor, Zruog!"),
+        ("123!?", 3, "123!?"),
+        ("abc", 7, "hij"),
+        ("abc", 17, "rst"),
+    ],
+)
+def test_caesar_shift_function(plain, shift, expected):
+    from garak.probes.encoding import _caesar_shift
+
+    result = _caesar_shift(shift)(plain.encode()).decode()
+    assert result == expected


### PR DESCRIPTION
Adds a Caesar cipher encoding probe that tests whether models silently decode and execute instructions obfuscated with Caesar cipher shifts (3, 7, and 17). Complements the existing InjectROT13 probe which covers shift 13.

Includes parametrized unit tests for the _caesar_shift helper function.

## What changed
- `garak/probes/encoding.py`: added `InjectCaesar` class with `_caesar_shift` helper supporting configurable shift values
- `tests/probes/test_probes_encoding.py`: added parametrized tests for `_caesar_shift` and probe instantiation
- `garak/data/plugin_cache.json`: regenerated via `--list_probes`

## Testing
pytest tests/probes/test_probes_encoding.py tests/probes/test_probes.py

## Verification
- [x] Run the tests and ensure they pass  `python -m pytest tests/probes/test_probes_encoding.py tests/probes/test_probes.py`
- [x] Verify the probe encodes payloads correctly across shifts 3, 7, and 17
- [x] Verify encoded prompts do not contain the plaintext trigger (covered by existing `test_encoding_triggers_not_in_prompts` parametrized test)