### PR TITLE
escape regex metachars in StringDetector word matching

### DIFF
--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -223,7 +223,7 @@ class StringDetector(Detector):
                     if s in output_text:
                         match = True
                 elif self.matchtype == "word":
-                    if re.search(r"\b" + s + r"\b", output_text):
+                    if re.search(r"\b" + re.escape(s) + r"\b", output_text):
                         match = True
                 elif self.matchtype == "startswith":
                     if output_text.startswith(s):

--- a/tests/detectors/test_detectors_base.py
+++ b/tests/detectors/test_detectors_base.py
@@ -201,6 +201,32 @@ def test_stringdetector_word_boundary_matching():
         ], f"Word boundary match failed for '{text}', expected {match}"
 
 
+def test_stringdetector_word_regex_metacharacters():
+    """Substrings with regex metacharacters must be matched literally in 'word' mode.Several built-in wordlists (e.g. the Surge profanity list) contain entries
+    such as `c*nt`, `s.o.b.` and `pu$sy`. Without escaping, these were interpreted as regex patterns, 
+    causing false positives (`s.o.b.` matching benign words like `snobby`) and false negatives (the literal obfuscated
+    term never matching itself, e.g. `pu$sy`).
+    """
+    detector = garak.detectors.base.StringDetector(["s.o.b.", "pu$sy", "c*nt"])
+    detector.matchtype = "word"
+    detector.case_sensitive = True
+
+    test_cases = [
+        ("you are a snobby person", False),  # '.' must not match arbitrary chars
+        ("the word pu$sy appears", True),  # '$' must not act as an anchor
+        ("the word cnt appears", False),  # '*' must not make 'c' optional
+        ("the word c*nt appears", True),  # literal term must match itself
+    ]
+
+    for text, match in test_cases:
+        attempt = Attempt(prompt=Message(text=""))
+        attempt.outputs = [Message(text)]
+        results = detector.detect(attempt)
+        assert results == [
+            1.0 if match else 0.0
+        ], f"Word regex-metacharacter match failed for '{text}', expected {match}"
+
+
 def test_stringdetector_startswith():
     detector = garak.detectors.base.StringDetector(TEST_STRINGS)
     detector.matchtype = "startswith"


### PR DESCRIPTION
## What this change does

`StringDetector`'s `"word"` match mode interpolated each search string directly into a regex (`r"\b" + s + r"\b"`). When a target string contained regex metacharacters, it was interpreted as a pattern rather than a literal — a real problem because several built-in wordlists (e.g. the Surge profanity list) contain entries like `c*nt`, `s.o.b.`, and `pu$sy`.

This caused two classes of bugs:
- **False positives** — e.g. `s.o.b.` matching benign words like `snobby` (`.` matches any char).
- **False negatives** — the literal obfuscated term never matching itself, e.g. `pu$sy` (`$` acts as an anchor) or `c*nt` (`*` makes the preceding `c` optional).

The fix wraps the search string in `re.escape()` so metacharacters are matched literally:

```python
if re.search(r"\b" + re.escape(s) + r"\b", output_text):
```

## Verification

- [x] Added `test_stringdetector_word_regex_metacharacters` covering literal matching of `s.o.b.`, `pu$sy`, and `c*nt`, including the false-positive/false-negative cases above.
- [x] Run the tests and ensure they pass `python -m pytest tests/detectors/test_detectors_base.py`
