### PR TITLE
Run an IntentProbe's own detectors alongside the intent ones (#1875)

### DIFF
--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -220,6 +220,14 @@ class Harness(Configurable):
                 probe_detector_names = {
                     d.detectorname.replace("garak.detectors.", "") for d in detectors
                 }
+                # technique-determined detectors are the probe's own, used only
+                # when it actually declares a primary_detector (else these are
+                # the always.Fail sentinel, which must not be unioned in) #1875
+                technique_detector_names = (
+                    set(probe_detector_names)
+                    if probe.primary_detector is not None
+                    else set()
+                )
 
                 for a in attempt_results_list:
                     intent = a.intent
@@ -234,14 +242,22 @@ class Harness(Configurable):
                     from garak.services import intentservice
 
                 for intent_observed in intents_observed:
-                    detectors = intentservice.get_detectors(intent_observed)
-                    if detectors is None:
+                    intent_detector_names = intentservice.get_detectors(intent_observed)
+                    if intent_detector_names is None:
                         logging.warning(
                             "No detectors specified for intent %s" % intent_observed
                         )
-                        detectors = probe_detector_names
-                    detectors_required.update(detectors)
-                    intent_to_detector[intent_observed] = detectors
+                        intent_detector_names = set()
+                    # select detectors by technique as well as intent: union the
+                    # probe's technique detectors with the intent-mapped ones
+                    # rather than using the probe's only as fallback (#1875)
+                    mapping = technique_detector_names | set(intent_detector_names)
+                    if not mapping:
+                        # no technique or intent detector; keep the probe's own
+                        # (always.Fail sentinel) so misconfiguration stays visible
+                        mapping = set(probe_detector_names)
+                    detectors_required.update(mapping)
+                    intent_to_detector[intent_observed] = mapping
 
                 logging.info(
                     "For probe %s, selected detectors %s based on intents"

--- a/tests/harnesses/test_harness_intent_plugin_cache.py
+++ b/tests/harnesses/test_harness_intent_plugin_cache.py
@@ -49,8 +49,9 @@ def _make_attempt(intent_code: str) -> garak.attempt.Attempt:
     return a
 
 
-@pytest.fixture
-def intent_report(tmp_path, monkeypatch):
+def _run_intent_harness(
+    tmp_path, monkeypatch, primary_detector=None, harness_detector="always.Pass"
+):
     """Run the harness over an IntentProbe with the real intentservice and
     return the path to the produced report.jsonl.
 
@@ -99,10 +100,11 @@ def intent_report(tmp_path, monkeypatch):
 
     model = garak._plugins.load_plugin("generators.test.Repeat")
     probe = garak._plugins.load_plugin(INTENT_PROBE)
+    probe.primary_detector = primary_detector
     monkeypatch.setattr(
         probe, "probe", lambda generator: [_make_attempt(MAPPED_INTENT)]
     )
-    detector = garak._plugins.load_plugin("detectors.always.Pass")
+    detector = garak._plugins.load_plugin(f"detectors.{harness_detector}")
 
     harness = garak.harnesses.base.Harness()
     harness.run(model, [probe], [detector], ThresholdEvaluator())
@@ -110,6 +112,26 @@ def intent_report(tmp_path, monkeypatch):
     garak._config.transient.reportfile.flush()
     # config_cleanup finalizer closes the reportfile and reloads _config
     return report_path
+
+
+@pytest.fixture
+def intent_report(tmp_path, monkeypatch):
+    """Default IntentProbe run: no probe-level primary_detector, so detectors
+    are resolved purely via the intent path."""
+    return _run_intent_harness(tmp_path, monkeypatch)
+
+
+def _attempt_detector_keys(report_path) -> set:
+    """detectors that actually scored attempts, read from the report's
+    ``entry_type == "attempt"`` records (``detector_results`` keys)."""
+    keys = set()
+    for line in report_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        record = json.loads(line)
+        if record.get("entry_type") == "attempt":
+            keys.update(record.get("detector_results", {}))
+    return keys
 
 
 def _plugin_cache_detectors(report_path) -> set:
@@ -143,3 +165,30 @@ def test_report_digest_completes_for_intent_run(intent_report):
             f"missing from plugin_cache): {e}"
         )
     assert digest is not None, "build_digest returned no digest for intent run"
+
+
+def test_technique_and_intent_detectors_union(tmp_path, monkeypatch):
+    """Issue #1875: when an IntentProbe declares a primary_detector, that
+    technique detector must run *as well as* the intent-mapped detector, not be
+    discarded once an intent mapping exists."""
+    report_path = _run_intent_harness(
+        tmp_path, monkeypatch, primary_detector="always.Pass", harness_detector="always.Pass"
+    )
+    keys = _attempt_detector_keys(report_path)
+    assert "always.Pass" in keys, f"technique detector discarded; ran: {sorted(keys)}"
+    assert INTENT_DETECTOR.replace("detectors.", "") in keys, (
+        f"intent-mapped detector missing; ran: {sorted(keys)}"
+    )
+
+
+def test_pure_intent_probe_excludes_fallback_sentinel(tmp_path, monkeypatch):
+    """Issue #1875: a purely intent-driven IntentProbe (no primary_detector)
+    must not have the always.Fail fallback sentinel unioned into its run."""
+    report_path = _run_intent_harness(
+        tmp_path, monkeypatch, primary_detector=None, harness_detector="always.Fail"
+    )
+    keys = _attempt_detector_keys(report_path)
+    assert INTENT_DETECTOR.replace("detectors.", "") in keys, (
+        f"intent-mapped detector missing; ran: {sorted(keys)}"
+    )
+    assert "always.Fail" not in keys, f"fallback sentinel ran; ran: {sorted(keys)}"


### PR DESCRIPTION
Fixes #1875.

When an IntentProbe runs, the harness currently picks its detectors from the intent and only falls back to the probe's own detectors when the intent has nothing mapped to it. The catch is that as soon as the intent does have detectors, the probe's own ones get dropped.

That's a problem for probes whose attack can only really be checked by their own detector. For example encoding needs `encoding.DecodeMatch` to know whether the payload actually got decoded, and goodside needs things like `goodside.Glitch`. These are the probes lined up to move over to IntentProbe:

- encoding.* (T018decode) -> encoding.DecodeMatch / DecodeApprox
- goodside.Tag (T009ignore) -> base.TriggerListDetector
- latentinjection.* (T009indirect) -> base.TriggerListDetector
- goodside.ThreatenJSON / Davidjl (M010degrade) -> goodside.PlainJSON / goodside.Glitch
- fileformats.HF_Files (M009arch) -> fileformats.FileIsPickled etc.

If any of them became an IntentProbe today they'd quietly lose the one detector that tells you whether the attack worked.

## What this changes

Instead of treating the probe's detectors as a fallback, it now uses both: the probe's own detectors plus whatever the intent maps to.

A couple of guards so nothing else breaks:
- The probe's detectors only count if it actually declares a `primary_detector`. If it doesn't, those detectors are just the `always.Fail` placeholder, so we leave them out (this keeps purely intent-driven probes like grandma.GrandmaIntent working exactly as before).
- If there's nothing from either side, we keep `always.Fail` so a misconfigured run still shows up.

Also tidied up the loop that was accidentally reusing the `detectors` variable name.

This is basically the groundwork so the probes above can safely move to IntentProbe later.

## Tests

Added two tests to the existing `tests/harnesses/test_harness_intent_plugin_cache.py` (no new file):

- one that checks a probe with a primary_detector runs both its own detector and the intent's
- one that checks a pure intent probe doesn't drag in the always.Fail placeholder

The fixture was pulled into a small helper so the two tests that were already there behave exactly the same.

Ran locally:
- `pytest tests/harnesses/test_harness_intent_plugin_cache.py` -> 4 passed
- `pytest tests/harnesses/ tests/cas/` -> 228 passed, 1 skipped
