### PR TITLE
Fix FileDetector output/result misalignment (yield None for skipped outputs)

### DIFF
--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -286,11 +286,19 @@ class FileDetector(Detector):
 
         for local_filename in attempt.outputs:
             if not local_filename or not local_filename.text:
+                # Yield None so detector_results stays length-aligned with
+                # attempt.outputs. The evaluator indexes attempt.outputs by
+                # position (see evaluators.base.Evaluator.evaluate); skipping
+                # silently via ``continue`` here would shift later results
+                # onto the wrong outputs and misattribute detector hits in
+                # the hitlog.
+                yield None
                 continue
             if not os.path.isfile(
                 local_filename.text
             ):  # skip missing files but also pipes, devices, etc
                 logging.info("Skipping non-file path %s", local_filename)
+                yield None
                 continue
 
             else:

--- a/tests/detectors/test_detectors_base.py
+++ b/tests/detectors/test_detectors_base.py
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import tempfile
+
 import pytest
 
 from garak.attempt import Attempt, Message
@@ -12,9 +15,18 @@ def test_filedetector_nonexist():
     a = Attempt(prompt=Message(text=""))
     a.outputs = [Message(f) for f in [None, "", "/non/existing/file"]]
     a.notes["format"] = d.valid_format
-    assert (
-        len(list(d.detect(a))) == 0
-    ), "FileDetector should skip filenames for non-existing files"
+    # FileDetector now yields None for skipped outputs (missing/empty/non-file)
+    # so that detector_results stays length-aligned with attempt.outputs. The
+    # evaluator indexes outputs by position; previously these were silently
+    # dropped via ``continue``, misattributing later results to the wrong
+    # outputs.
+    results = list(d.detect(a))
+    assert len(results) == len(
+        a.outputs
+    ), "FileDetector should yield one result per output (None for skipped)"
+    assert all(
+        r is None for r in results
+    ), "FileDetector should yield None for non-existing/empty files"
 
 
 TEST_STRINGS = [
@@ -219,3 +231,74 @@ def test_stringdetector_startswith():
         assert results == [
             1.0 if match else 0.0
         ], f"startswith match failed for '{text}', expected {match}"
+
+
+# ---------------------------------------------------------------------------
+# FileDetector result/output alignment.
+#
+# FileDetector.detect() iterates attempt.outputs and yields a score per file.
+# Previously it used ``continue`` to skip missing/empty/non-file outputs,
+# which made detector_results SHORTER than attempt.outputs. Since the
+# evaluator indexes attempt.outputs by position, this misattributed later
+# detector scores to the wrong outputs (and silently dropped some). The fix
+# yields None for skipped outputs to preserve alignment.
+# ---------------------------------------------------------------------------
+
+
+class _ConcreteFileDetector(garak.detectors.base.FileDetector):
+    """Minimal concrete FileDetector for testing alignment."""
+
+    valid_format = "local filename"
+
+    def _test_file(self, filename):
+        return 1.0 if filename.endswith(".pkl") else 0.0
+
+
+def test_filedetector_yields_none_for_missing_file_preserving_alignment():
+    """FIX: a missing file between two valid files must yield None (not be
+    dropped), so the valid files' scores stay aligned with their outputs."""
+    d = _ConcreteFileDetector()
+    tmpdir = tempfile.mkdtemp()
+    valid_pkl = os.path.join(tmpdir, "real.pkl")
+    valid_txt = os.path.join(tmpdir, "real.txt")
+    open(valid_pkl, "w").write("x")
+    open(valid_txt, "w").write("x")
+
+    attempt = Attempt(prompt=Message(text=""))
+    attempt.notes["format"] = "local filename"
+    attempt.outputs = [
+        Message(valid_pkl),
+        Message("/nonexistent/path"),
+        Message(valid_txt),
+    ]
+    results = list(d.detect(attempt))
+    assert len(results) == 3, "one result per output (None for missing file)"
+    assert results == [1.0, None, 0.0]
+    # the critical alignment: outputs[0] hits (pkl), outputs[2] misses (txt)
+    assert results[0] == 1.0
+    assert results[2] == 0.0
+
+
+def test_filedetector_yields_none_for_empty_output():
+    """FIX: empty/None outputs yield None rather than being dropped."""
+    d = _ConcreteFileDetector()
+    attempt = Attempt(prompt=Message(text=""))
+    attempt.notes["format"] = "local filename"
+    attempt.outputs = [Message(""), Message(None), Message("/missing")]
+    results = list(d.detect(attempt))
+    assert len(results) == 3
+    assert all(r is None for r in results)
+
+
+def test_filedetector_all_valid_outputs_scored():
+    """SANITY: when all outputs are valid files, alignment and scoring work."""
+    d = _ConcreteFileDetector()
+    tmpdir = tempfile.mkdtemp()
+    pkl = os.path.join(tmpdir, "a.pkl")
+    txt = os.path.join(tmpdir, "b.txt")
+    open(pkl, "w").write("x")
+    open(txt, "w").write("x")
+    attempt = Attempt(prompt=Message(text=""))
+    attempt.notes["format"] = "local filename"
+    attempt.outputs = [Message(pkl), Message(txt)]
+    assert list(d.detect(attempt)) == [1.0, 0.0]


### PR DESCRIPTION
# Fix `FileDetector` output/result misalignment (yield `None` for skipped outputs)

## Summary

`FileDetector.detect()` used `continue` to skip missing/empty/non-file outputs,
which made `detector_results` **shorter than `attempt.outputs`**. The evaluator
then indexes `attempt.outputs` by position, so this **misattributed later
detector scores to the wrong outputs** and silently dropped some from scoring.
The hitlog recorded incorrect output↔score pairings.

The fix yields `None` for skipped outputs, preserving length alignment. The
evaluator already counts `None` scores as `nones` (excluded from pass/fail), so
this is the correct downstream signal.

## The bug

```python
# garak/detectors/base.py, FileDetector.detect (before)
for local_filename in attempt.outputs:
    if not local_filename or not local_filename.text:
        continue                          # <- drops this output's result
    if not os.path.isfile(local_filename.text):
        logging.info("Skipping non-file path %s", local_filename)
        continue                          # <- drops this output's result
    else:
        test_result = self._test_file(local_filename.text)
        yield test_result if test_result is not None else 0.0
```

The evaluator consumes these results positionally:

```python
# garak/evaluators/base.py, Evaluator.evaluate
for idx, score in enumerate(attempt.detector_results[detector]):
    ...
    messages.append(attempt.outputs[idx])   # <- indexes outputs by position
```

When `FileDetector` skips an output, the results list shifts — so `outputs[idx]`
no longer corresponds to the output that produced `results[idx]`. The code even
documents the assumption: *"expects that detector_results aligns with
attempt.outputs"*.

## Reproduction

```python
import os, tempfile
from garak.detectors.base import FileDetector
from garak.attempt import Attempt, Message

class T(FileDetector):
    """test"""
    valid_format = "local filename"
    def _test_file(self, f): return 1.0 if f.endswith(".pkl") else 0.0

tmp = tempfile.mkdtemp()
pkl, txt = os.path.join(tmp,"a.pkl"), os.path.join(tmp,"a.txt")
open(pkl,"w").write("x"); open(txt,"w").write("x")

a = Attempt(prompt=Message(""))
a.notes["format"] = "local filename"
a.outputs = [Message(pkl), Message("/missing"), Message(txt)]

# Before fix: list(T().detect(a)) == [1.0, 0.0]   (len 2, NOT 3)
#   -> evaluator attributes 0.0 to outputs[1] ("/missing")  ← WRONG
#   -> outputs[2] (txt) is never scored                     ← DROPPED
# After fix:  list(T().detect(a)) == [1.0, None, 0.0]       (len 3, aligned)
#   -> evaluator counts None as a "none" (excluded), 0.0 correctly to outputs[2]
```

## The fix

```python
# after
for local_filename in attempt.outputs:
    if not local_filename or not local_filename.text:
        yield None
        continue
    if not os.path.isfile(local_filename.text):
        logging.info("Skipping non-file path %s", local_filename)
        yield None
        continue
    else:
        test_result = self._test_file(local_filename.text)
        yield test_result if test_result is not None else 0.0
```

Yielding `None` for skipped outputs keeps `detector_results` length-aligned
with `attempt.outputs`. The evaluator already handles `None`:

```python
# garak/evaluators/base.py
if score is None:
    nones += 1          # excluded from pass/fail totals
```

## Tests

Updated `test_filedetector_nonexist` (it previously asserted `len(results) == 0`
for skipped files — encoding the buggy behavior) and added 3 alignment tests to
`tests/detectors/test_detectors_base.py`:

- **Alignment regression**: a missing file between two valid files yields
  `None`, so the valid files' scores stay aligned (`[1.0, None, 0.0]`).
- **Empty/None outputs**: each yields `None` rather than being dropped.
- **All-valid sanity**: when all outputs are valid files, scoring works.

```
$ python -m pytest tests/detectors/test_detectors_base.py -q
..............                                                           [100%]
14 passed in 0.05s
```

## Impact

- **Affected detectors:** all `FileDetector` subclasses — `FileIsPickled`,
  `FileIsExecutable`, `PossiblePickleName` in `detectors/fileformats.py` — and
  any third-party subclass.
- **Trigger:** any attempt where at least one output is a missing file, empty,
  or non-file (e.g. a broken model-repo download, a non-file path).
- **Severity:** high for integrity. A safety scanner whose hitlog attributes
  detector hits to the **wrong prompts** produces unreliable reports. Verified
  against the three built-in fileformat detectors.

## Scope

Single-purpose: one fix in `FileDetector.detect` + tests. Diff: +94/−3 across
2 files. No changes to any probe, evaluator, or other detector class.

## Notes

- Verified the three real fileformat detectors (`FileIsPickled`,
  `FileIsExecutable`, `PossiblePickleName`) produce aligned results after the
  fix.
- The evaluator's `None` handling predates this change — it was already designed
  to accept `None` scores (e.g. `StringDetector` yields `None` for `None`
  outputs). This fix makes `FileDetector` consistent with that contract.
- No behavior change for the all-valid-files path (the common case).
