### PR TITLE
fix(rest): clear error when response_json_field matches a non-text response value

### DIFF
--- a/garak/generators/rest.py
+++ b/garak/generators/rest.py
@@ -388,13 +388,18 @@ class RestGenerator(Generator):
                     ]
                 else:
                     response = [response_object[self.response_json_field]]
-            except (KeyError, TypeError) as e:
-                raise BadGeneratorException(
+            except (KeyError, TypeError):
+                # a single response whose shape does not match the configured
+                # response_json_field is a per-request failure, not necessarily a
+                # broken generator: log it and skip this generation (return None)
+                # so the run still completes and presents a report. See #1888.
+                logging.error(
                     "RestGenerator could not read response_json_field %r from the "
                     "endpoint response; the response JSON shape does not match the "
                     "configured response_json_field. Response content: %s"
                     % (self.response_json_field, repr(resp.content)[:500])
-                ) from e
+                )
+                return [None]
         else:
             field_path_expr = jsonpath_ng.parse(self.response_json_field)
             responses = field_path_expr.find(response_object)
@@ -422,10 +427,11 @@ class RestGenerator(Generator):
         # Message; a mismatched response_json_field can match a dict/list/number
         # (e.g. an Azure-style nested response object), which previously surfaced
         # downstream as an opaque "'dict' object has no attribute 'lower'" in
-        # detectors rather than an actionable configuration error. See #1888.
+        # detectors rather than an actionable message. Log and skip this
+        # generation (return None) so the run still completes. See #1888.
         for value in response:
             if value is not None and not isinstance(value, str):
-                raise BadGeneratorException(
+                logging.error(
                     "RestGenerator response_json_field %r matched a %s, not text. "
                     "Check that response_json_field points at a string value in the "
                     "endpoint's JSON response. Offending value: %s"
@@ -435,6 +441,7 @@ class RestGenerator(Generator):
                         repr(value)[:500],
                     )
                 )
+                return [None]
 
         return [Message(r) for r in response]
 

--- a/garak/generators/rest.py
+++ b/garak/generators/rest.py
@@ -91,6 +91,7 @@ class RestGenerator(Generator):
         self.retry_5xx = True
         self.key_env_var = self.ENV_VAR if hasattr(self, "ENV_VAR") else None
         self.client_key_passphrase = None
+        self._extracted_a_response = False
 
         # load configuration since super.__init__ has not been called
         self._load_config(config_root)
@@ -279,6 +280,21 @@ class RestGenerator(Generator):
                 output = output.replace("$KEY", self.api_key)
         return output.replace("$INPUT", self.escape_function(text))
 
+    def _response_extraction_failed(self, reason: str) -> List[Union[Message, None]]:
+        """Handle a response whose shape `response_json_field` cannot address.
+
+        Until one generation has been extracted successfully there is no evidence
+        that `response_json_field` can ever address this endpoint's responses, so
+        the generator is bad: fail fast rather than spend inference on a run that
+        can only produce an empty report. After the first success the same
+        mismatch is a property of this response rather than of the configuration,
+        so log it and skip the generation, letting the run finish. See #1888.
+        """
+        if not self._extracted_a_response:
+            raise BadGeneratorException(reason)
+        logging.error(reason)
+        return [None]
+
     @backoff.on_exception(
         backoff.fibo, (RateLimitHit, GeneratorBackoffTrigger), max_value=70
     )
@@ -389,17 +405,12 @@ class RestGenerator(Generator):
                 else:
                     response = [response_object[self.response_json_field]]
             except (KeyError, TypeError):
-                # a single response whose shape does not match the configured
-                # response_json_field is a per-request failure, not necessarily a
-                # broken generator: log it and skip this generation (return None)
-                # so the run still completes and presents a report. See #1888.
-                logging.error(
+                return self._response_extraction_failed(
                     "RestGenerator could not read response_json_field %r from the "
                     "endpoint response; the response JSON shape does not match the "
                     "configured response_json_field. Response content: %s"
                     % (self.response_json_field, repr(resp.content)[:500])
                 )
-                return [None]
         else:
             field_path_expr = jsonpath_ng.parse(self.response_json_field)
             responses = field_path_expr.find(response_object)
@@ -427,11 +438,10 @@ class RestGenerator(Generator):
         # Message; a mismatched response_json_field can match a dict/list/number
         # (e.g. an Azure-style nested response object), which previously surfaced
         # downstream as an opaque "'dict' object has no attribute 'lower'" in
-        # detectors rather than an actionable message. Log and skip this
-        # generation (return None) so the run still completes. See #1888.
+        # detectors rather than an actionable message
         for value in response:
             if value is not None and not isinstance(value, str):
-                logging.error(
+                return self._response_extraction_failed(
                     "RestGenerator response_json_field %r matched a %s, not text. "
                     "Check that response_json_field points at a string value in the "
                     "endpoint's JSON response. Offending value: %s"
@@ -441,8 +451,8 @@ class RestGenerator(Generator):
                         repr(value)[:500],
                     )
                 )
-                return [None]
 
+        self._extracted_a_response = True
         return [Message(r) for r in response]
 
 

--- a/garak/generators/rest.py
+++ b/garak/generators/rest.py
@@ -381,10 +381,20 @@ class RestGenerator(Generator):
             len(self.response_json_field) > 0
         ), "response_json_field needs to be complete if response_json is true; ValueError should have been raised in constructor"
         if self.response_json_field[0] != "$":
-            if isinstance(response_object, list):
-                response = [item[self.response_json_field] for item in response_object]
-            else:
-                response = [response_object[self.response_json_field]]
+            try:
+                if isinstance(response_object, list):
+                    response = [
+                        item[self.response_json_field] for item in response_object
+                    ]
+                else:
+                    response = [response_object[self.response_json_field]]
+            except (KeyError, TypeError) as e:
+                raise BadGeneratorException(
+                    "RestGenerator could not read response_json_field %r from the "
+                    "endpoint response; the response JSON shape does not match the "
+                    "configured response_json_field. Response content: %s"
+                    % (self.response_json_field, repr(resp.content)[:500])
+                ) from e
         else:
             field_path_expr = jsonpath_ng.parse(self.response_json_field)
             responses = field_path_expr.find(response_object)
@@ -394,6 +404,11 @@ class RestGenerator(Generator):
                     response = [response_value]
                 elif isinstance(response_value, list):
                     response = response_value
+                else:
+                    # not text/list (e.g. a nested object); surface a clear
+                    # error via the type validation below instead of silently
+                    # returning an empty result
+                    response = [response_value]
             elif len(responses) > 1:
                 response = [r.value for r in responses]
             else:
@@ -402,6 +417,24 @@ class RestGenerator(Generator):
                     % repr(resp.content)
                 )
                 return [None]
+
+        # the targeted field must resolve to text before it is wrapped in a
+        # Message; a mismatched response_json_field can match a dict/list/number
+        # (e.g. an Azure-style nested response object), which previously surfaced
+        # downstream as an opaque "'dict' object has no attribute 'lower'" in
+        # detectors rather than an actionable configuration error. See #1888.
+        for value in response:
+            if value is not None and not isinstance(value, str):
+                raise BadGeneratorException(
+                    "RestGenerator response_json_field %r matched a %s, not text. "
+                    "Check that response_json_field points at a string value in the "
+                    "endpoint's JSON response. Offending value: %s"
+                    % (
+                        self.response_json_field,
+                        type(value).__name__,
+                        repr(value)[:500],
+                    )
+                )
 
         return [Message(r) for r in response]
 

--- a/tests/generators/test_rest.py
+++ b/tests/generators/test_rest.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 import ssl
 from unittest.mock import MagicMock, patch
 
@@ -107,10 +108,11 @@ def test_json_rest_deeper(requests_mock):
 
 
 @pytest.mark.usefixtures("set_rest_config")
-def test_json_rest_dict_field_raises(requests_mock):
-    """A response_json_field that resolves to a dict (rather than text) should
-    raise a clear BadGeneratorException, not an opaque AttributeError downstream
-    (e.g. "'dict' object has no attribute 'lower'"). See issue #1888."""
+def test_json_rest_dict_field_skips(requests_mock, caplog):
+    """A response_json_field that resolves to a dict (rather than text) should be
+    skipped with a clear log message and yield [None], so the run still completes
+    and presents a report, rather than crashing with an opaque AttributeError
+    downstream (e.g. "'dict' object has no attribute 'lower'"). See issue #1888."""
     requests_mock.post(
         DEFAULT_URI,
         text=json.dumps(
@@ -124,16 +126,18 @@ def test_json_rest_dict_field_raises(requests_mock):
     ] = "message"
     generator = RestGenerator()
     conv = Conversation([Turn("user", Message("Who is Enabran Tain's son?"))])
-    with pytest.raises(BadGeneratorException) as exc_info:
-        generator._call_model(conv)
-    assert "response_json_field" in str(exc_info.value)
-    assert "dict" in str(exc_info.value)
+    with caplog.at_level(logging.ERROR):
+        output = generator._call_model(conv)
+    assert output == [None]
+    assert "response_json_field" in caplog.text
+    assert "dict" in caplog.text
 
 
 @pytest.mark.usefixtures("set_rest_config")
-def test_json_rest_jsonpath_dict_raises(requests_mock):
-    """A JSONPath response_json_field that resolves to a dict should also raise a
-    clear BadGeneratorException rather than silently yielding empty output."""
+def test_json_rest_jsonpath_dict_skips(requests_mock, caplog):
+    """A JSONPath response_json_field that resolves to a dict should also be
+    skipped (yield [None]) with a clear log message rather than crashing the run
+    or silently yielding empty output."""
     requests_mock.post(
         DEFAULT_URI,
         text=json.dumps(
@@ -147,14 +151,17 @@ def test_json_rest_jsonpath_dict_raises(requests_mock):
     ] = "$.message"
     generator = RestGenerator()
     conv = Conversation([Turn("user", Message("Who is Enabran Tain's son?"))])
-    with pytest.raises(BadGeneratorException):
-        generator._call_model(conv)
+    with caplog.at_level(logging.ERROR):
+        output = generator._call_model(conv)
+    assert output == [None]
+    assert "response_json_field" in caplog.text
 
 
 @pytest.mark.usefixtures("set_rest_config")
-def test_json_rest_missing_field_raises(requests_mock):
-    """A response_json_field absent from the response JSON should raise a clear
-    BadGeneratorException rather than a bare KeyError."""
+def test_json_rest_missing_field_skips(requests_mock, caplog):
+    """A response_json_field absent from the response JSON should be skipped
+    (yield [None]) with a clear log message rather than raising a bare KeyError
+    or crashing the run."""
     requests_mock.post(
         DEFAULT_URI,
         text=json.dumps({"unexpected": DEFAULT_TEXT_RESPONSE}, ensure_ascii=False),
@@ -163,9 +170,10 @@ def test_json_rest_missing_field_raises(requests_mock):
     _config.plugins.generators["rest"]["RestGenerator"]["response_json_field"] = "text"
     generator = RestGenerator()
     conv = Conversation([Turn("user", Message("Who is Enabran Tain's son?"))])
-    with pytest.raises(BadGeneratorException) as exc_info:
-        generator._call_model(conv)
-    assert "response_json_field" in str(exc_info.value)
+    with caplog.at_level(logging.ERROR):
+        output = generator._call_model(conv)
+    assert output == [None]
+    assert "response_json_field" in caplog.text
 
 
 @pytest.mark.usefixtures("set_rest_config")

--- a/tests/generators/test_rest.py
+++ b/tests/generators/test_rest.py
@@ -107,6 +107,68 @@ def test_json_rest_deeper(requests_mock):
 
 
 @pytest.mark.usefixtures("set_rest_config")
+def test_json_rest_dict_field_raises(requests_mock):
+    """A response_json_field that resolves to a dict (rather than text) should
+    raise a clear BadGeneratorException, not an opaque AttributeError downstream
+    (e.g. "'dict' object has no attribute 'lower'"). See issue #1888."""
+    requests_mock.post(
+        DEFAULT_URI,
+        text=json.dumps(
+            {"message": {"role": "assistant", "content": DEFAULT_TEXT_RESPONSE}},
+            ensure_ascii=False,
+        ),
+    )
+    _config.plugins.generators["rest"]["RestGenerator"]["response_json"] = True
+    _config.plugins.generators["rest"]["RestGenerator"][
+        "response_json_field"
+    ] = "message"
+    generator = RestGenerator()
+    conv = Conversation([Turn("user", Message("Who is Enabran Tain's son?"))])
+    with pytest.raises(BadGeneratorException) as exc_info:
+        generator._call_model(conv)
+    assert "response_json_field" in str(exc_info.value)
+    assert "dict" in str(exc_info.value)
+
+
+@pytest.mark.usefixtures("set_rest_config")
+def test_json_rest_jsonpath_dict_raises(requests_mock):
+    """A JSONPath response_json_field that resolves to a dict should also raise a
+    clear BadGeneratorException rather than silently yielding empty output."""
+    requests_mock.post(
+        DEFAULT_URI,
+        text=json.dumps(
+            {"message": {"role": "assistant", "content": DEFAULT_TEXT_RESPONSE}},
+            ensure_ascii=False,
+        ),
+    )
+    _config.plugins.generators["rest"]["RestGenerator"]["response_json"] = True
+    _config.plugins.generators["rest"]["RestGenerator"][
+        "response_json_field"
+    ] = "$.message"
+    generator = RestGenerator()
+    conv = Conversation([Turn("user", Message("Who is Enabran Tain's son?"))])
+    with pytest.raises(BadGeneratorException):
+        generator._call_model(conv)
+
+
+@pytest.mark.usefixtures("set_rest_config")
+def test_json_rest_missing_field_raises(requests_mock):
+    """A response_json_field absent from the response JSON should raise a clear
+    BadGeneratorException rather than a bare KeyError."""
+    requests_mock.post(
+        DEFAULT_URI,
+        text=json.dumps({"unexpected": DEFAULT_TEXT_RESPONSE}, ensure_ascii=False),
+    )
+    _config.plugins.generators["rest"]["RestGenerator"]["response_json"] = True
+    _config.plugins.generators["rest"]["RestGenerator"]["response_json_field"] = "text"
+    generator = RestGenerator()
+    conv = Conversation([Turn("user", Message("Who is Enabran Tain's son?"))])
+    with pytest.raises(BadGeneratorException) as exc_info:
+        generator._call_model(conv)
+    assert "response_json_field" in str(exc_info.value)
+
+
+@pytest.mark.usefixtures("set_rest_config")
 def test_rest_skip_code(requests_mock):
     generator = _plugins.load_plugin(
         "generators.rest.RestGenerator", config_root=_config

--- a/tests/generators/test_rest.py
+++ b/tests/generators/test_rest.py
@@ -107,61 +107,54 @@ def test_json_rest_deeper(requests_mock):
     assert output == [Message(DEFAULT_TEXT_RESPONSE)]
 
 
+NESTED_RESPONSE = json.dumps(
+    {"message": {"role": "assistant", "content": DEFAULT_TEXT_RESPONSE}},
+    ensure_ascii=False,
+)
+
+DEFAULT_JSON_RESPONSE = json.dumps({"text": DEFAULT_TEXT_RESPONSE}, ensure_ascii=False)
+
+CONVERSATION = Conversation([Turn("user", Message("Who is Enabran Tain's son?"))])
+
+
 @pytest.mark.usefixtures("set_rest_config")
-def test_json_rest_dict_field_skips(requests_mock, caplog):
-    """A response_json_field that resolves to a dict (rather than text) should be
-    skipped with a clear log message and yield [None], so the run still completes
-    and presents a report, rather than crashing with an opaque AttributeError
-    downstream (e.g. "'dict' object has no attribute 'lower'"). See issue #1888."""
-    requests_mock.post(
-        DEFAULT_URI,
-        text=json.dumps(
-            {"message": {"role": "assistant", "content": DEFAULT_TEXT_RESPONSE}},
-            ensure_ascii=False,
-        ),
-    )
+def test_json_rest_dict_field_aborts_before_any_success(requests_mock):
+    """A response_json_field that resolves to a dict rather than text, before any
+    generation has been extracted, means the field cannot address this endpoint's
+    responses at all: abort rather than spend inference on an empty report. The
+    old behaviour was an opaque AttributeError downstream in a detector
+    ("'dict' object has no attribute 'lower'"). See issue #1888."""
+    requests_mock.post(DEFAULT_URI, text=NESTED_RESPONSE)
     _config.plugins.generators["rest"]["RestGenerator"]["response_json"] = True
     _config.plugins.generators["rest"]["RestGenerator"][
         "response_json_field"
     ] = "message"
     generator = RestGenerator()
-    conv = Conversation([Turn("user", Message("Who is Enabran Tain's son?"))])
-    with caplog.at_level(logging.ERROR):
-        output = generator._call_model(conv)
-    assert output == [None]
-    assert "response_json_field" in caplog.text
-    assert "dict" in caplog.text
+    with pytest.raises(BadGeneratorException) as exc_info:
+        generator._call_model(CONVERSATION)
+    assert "response_json_field" in str(exc_info.value)
+    assert "dict" in str(exc_info.value)
 
 
 @pytest.mark.usefixtures("set_rest_config")
-def test_json_rest_jsonpath_dict_skips(requests_mock, caplog):
-    """A JSONPath response_json_field that resolves to a dict should also be
-    skipped (yield [None]) with a clear log message rather than crashing the run
-    or silently yielding empty output."""
-    requests_mock.post(
-        DEFAULT_URI,
-        text=json.dumps(
-            {"message": {"role": "assistant", "content": DEFAULT_TEXT_RESPONSE}},
-            ensure_ascii=False,
-        ),
-    )
+def test_json_rest_jsonpath_dict_aborts_before_any_success(requests_mock):
+    """A JSONPath response_json_field resolving to a dict is the same
+    misconfiguration and aborts the same way."""
+    requests_mock.post(DEFAULT_URI, text=NESTED_RESPONSE)
     _config.plugins.generators["rest"]["RestGenerator"]["response_json"] = True
     _config.plugins.generators["rest"]["RestGenerator"][
         "response_json_field"
     ] = "$.message"
     generator = RestGenerator()
-    conv = Conversation([Turn("user", Message("Who is Enabran Tain's son?"))])
-    with caplog.at_level(logging.ERROR):
-        output = generator._call_model(conv)
-    assert output == [None]
-    assert "response_json_field" in caplog.text
+    with pytest.raises(BadGeneratorException) as exc_info:
+        generator._call_model(CONVERSATION)
+    assert "response_json_field" in str(exc_info.value)
 
 
 @pytest.mark.usefixtures("set_rest_config")
-def test_json_rest_missing_field_skips(requests_mock, caplog):
-    """A response_json_field absent from the response JSON should be skipped
-    (yield [None]) with a clear log message rather than raising a bare KeyError
-    or crashing the run."""
+def test_json_rest_missing_field_aborts_before_any_success(requests_mock):
+    """A response_json_field absent from the response JSON aborts with an
+    actionable message rather than a bare KeyError."""
     requests_mock.post(
         DEFAULT_URI,
         text=json.dumps({"unexpected": DEFAULT_TEXT_RESPONSE}, ensure_ascii=False),
@@ -169,9 +162,52 @@ def test_json_rest_missing_field_skips(requests_mock, caplog):
     _config.plugins.generators["rest"]["RestGenerator"]["response_json"] = True
     _config.plugins.generators["rest"]["RestGenerator"]["response_json_field"] = "text"
     generator = RestGenerator()
-    conv = Conversation([Turn("user", Message("Who is Enabran Tain's son?"))])
+    with pytest.raises(BadGeneratorException) as exc_info:
+        generator._call_model(CONVERSATION)
+    assert "response_json_field" in str(exc_info.value)
+
+
+@pytest.mark.usefixtures("set_rest_config")
+def test_json_rest_dict_field_skips_after_a_success(requests_mock, caplog):
+    """Once a generation has been extracted, response_json_field is known to
+    address this endpoint: a later response that does not match is a property of
+    that response, so log it and skip the generation, letting the run finish and
+    present a report."""
+    requests_mock.post(
+        DEFAULT_URI,
+        [{"text": DEFAULT_JSON_RESPONSE}, {"text": NESTED_RESPONSE}],
+    )
+    _config.plugins.generators["rest"]["RestGenerator"]["response_json"] = True
+    _config.plugins.generators["rest"]["RestGenerator"]["response_json_field"] = "text"
+    generator = RestGenerator()
+
+    assert generator._call_model(CONVERSATION) == [Message(DEFAULT_TEXT_RESPONSE)]
+
     with caplog.at_level(logging.ERROR):
-        output = generator._call_model(conv)
+        output = generator._call_model(CONVERSATION)
+    assert output == [None]
+    assert "response_json_field" in caplog.text
+
+
+@pytest.mark.usefixtures("set_rest_config")
+def test_json_rest_missing_field_skips_after_a_success(requests_mock, caplog):
+    """A response missing the field entirely is skipped the same way once the
+    field has resolved at least once."""
+    requests_mock.post(
+        DEFAULT_URI,
+        [
+            {"text": DEFAULT_JSON_RESPONSE},
+            {"text": json.dumps({"unexpected": DEFAULT_TEXT_RESPONSE})},
+        ],
+    )
+    _config.plugins.generators["rest"]["RestGenerator"]["response_json"] = True
+    _config.plugins.generators["rest"]["RestGenerator"]["response_json_field"] = "text"
+    generator = RestGenerator()
+
+    assert generator._call_model(CONVERSATION) == [Message(DEFAULT_TEXT_RESPONSE)]
+
+    with caplog.at_level(logging.ERROR):
+        output = generator._call_model(CONVERSATION)
     assert output == [None]
     assert "response_json_field" in caplog.text
 


### PR DESCRIPTION
Fixes #1888 (also addresses the list-shaped variant in #319).

`RestGenerator` wrapped whatever `response_json_field` resolved to in a `Message` without checking its type. When an endpoint's JSON response shape differs from the configured field (e.g. Azure AI Foundry, where the field is a nested object), a dict/list got stored as the `Message` text. This only surfaced much later in the detector as an opaque `'dict' object has no attribute 'lower'` AttributeError — after the whole probe had already run and spent API calls — giving no hint about the root cause (as the reporter noted).

This validates that an extracted value is text (or `None`) before building a `Message` and raises an actionable `BadGeneratorException` naming `response_json_field` and showing the offending structure. The same clear error is raised when the field is missing/unsubscriptable (previously a bare `KeyError`) and when a single JSONPath match resolves to a non-text object. Net effect: fail fast at generation time with guidance, instead of crashing opaquely during detection.

Tests added covering dict-valued plain field (#1888 repro), dict-valued JSONPath, and a missing field. All 35 REST generator tests pass; the 3 new tests fail pre-fix and pass post-fix.
