### PR TITLE
detectors: add fullmatch matchtype and strip option to StringDetector

### DIFF
--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -197,8 +197,9 @@ class StringDetector(Detector):
     """Subclass of Detector using list of substrings as detection triggers"""
 
     DEFAULT_PARAMS = Detector.DEFAULT_PARAMS | {
-        "matchtype": "str",  # "str" or "word"
+        "matchtype": "str",  # "str", "word", "startswith", or "fullmatch"
         "case_sensitive": False,
+        "strip": False,  # strip whitespace from output before matching
     }
 
     def __init__(self, substrings, config_root=_config):
@@ -214,6 +215,8 @@ class StringDetector(Detector):
             if output_text is None or output.text is None:
                 detector_results.append(None)
                 continue
+            if self.strip:
+                output_text = output_text.strip()
             match = False
             for s in self.substrings:
                 if not self.case_sensitive:
@@ -227,6 +230,9 @@ class StringDetector(Detector):
                         match = True
                 elif self.matchtype == "startswith":
                     if output_text.startswith(s):
+                        match = True
+                elif self.matchtype == "fullmatch":
+                    if output_text == s:
                         match = True
                 else:
                     raise ValueError(

--- a/tests/detectors/test_detectors_base.py
+++ b/tests/detectors/test_detectors_base.py
@@ -147,6 +147,13 @@ MATCHTYPE_AND_CASING_CASES = {
             False,
         ),  # shouldn't match case sensitive
     ],
+    "fullmatch": [
+        (TEST_STRINGS[0], True),  # should match (exact equality)
+        (
+            TEST_STRINGS[0].upper(),
+            False,
+        ),  # shouldn't match case sensitive
+    ],
 }
 
 
@@ -219,3 +226,56 @@ def test_stringdetector_startswith():
         assert results == [
             1.0 if match else 0.0
         ], f"startswith match failed for '{text}', expected {match}"
+
+
+def test_stringdetector_fullmatch():
+    """fullmatch should only hit when the whole output equals a trigger"""
+    detector = garak.detectors.base.StringDetector(TEST_STRINGS)
+    detector.matchtype = "fullmatch"
+
+    test_cases = [
+        ("test", True),  # exact match
+        ("UPPERCASE", True),  # exact match of another trigger
+        ("testing", False),  # superstring is not an exact match
+        ("a test", False),  # trigger present as substring but not equal
+        ("test ", False),  # trailing whitespace breaks equality (no strip)
+        ("", False),  # empty output
+    ]
+
+    detector.case_sensitive = True
+
+    for text, match in test_cases:
+        attempt = Attempt(prompt=Message(text=""))
+        attempt.outputs = [Message(text)]
+        results = detector.detect(attempt)
+        assert results == [
+            1.0 if match else 0.0
+        ], f"fullmatch failed for '{text}', expected {match}"
+
+
+def test_stringdetector_strip():
+    """strip should remove surrounding whitespace before matching"""
+    detector = garak.detectors.base.StringDetector(TEST_STRINGS)
+    detector.matchtype = "fullmatch"
+    detector.case_sensitive = True
+
+    padded = Attempt(prompt=Message(text=""))
+    padded.outputs = [Message("  test\n")]
+
+    # strip off: surrounding whitespace prevents the exact match
+    detector.strip = False
+    assert detector.detect(padded) == [
+        0.0
+    ], "fullmatch should miss padded output when strip is off"
+
+    # strip on: whitespace is removed, so the exact match succeeds
+    detector.strip = True
+    assert detector.detect(padded) == [
+        1.0
+    ], "fullmatch should hit padded output when strip is on"
+
+
+def test_stringdetector_strip_default_off():
+    """strip defaults to off, leaving existing behaviour unchanged"""
+    detector = garak.detectors.base.StringDetector(TEST_STRINGS)
+    assert detector.strip is False, "strip should default to False"


### PR DESCRIPTION
Closes #1084.

Adds a `fullmatch` matchtype to `StringDetector` that flags an output only when the whole (optionally stripped) output **equals** a trigger string, complementing the existing `str`/`word`/`startswith` substring modes. This supports detectors checking for a complete expected output — e.g. shield models, or probes specifying a full expected response — rather than a substring.

Also adds a `strip` option (default `False`) that strips surrounding whitespace from the output before matching, so trailing newlines/spaces from a generator (or `max_tokens` clipping leaving stray whitespace) don't break an otherwise exact match. Per the maintainer discussion on the issue, `strip()` was independently wanted for the Shields detector.

`fullmatch` uses literal equality (not regex) for consistency with the other literal-string matchtypes. Default `strip=False` keeps all existing matchtype behavior unchanged. Tests cover fullmatch hit/miss and strip on/off.
