### PR TITLE
fix: fail helpfully when generator/probe is not picklable under parallelism

### DIFF
--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -4,6 +4,7 @@ All `garak` generators must inherit from this.
 """
 
 import logging
+import pickle
 import random
 import re
 from typing import List, Union
@@ -193,6 +194,21 @@ class Generator(Configurable):
                     self.parallel_requests,
                     self.max_workers,
                 )
+
+                # multiprocessing.Pool pickles the work callable to ship it to
+                # worker processes; a generator carrying unpicklable state fails
+                # deep inside multiprocessing with an opaque traceback. Check up
+                # front and fail with an actionable message instead (see #361).
+                try:
+                    pickle.dumps(self._call_model)
+                except (pickle.PicklingError, TypeError, AttributeError) as e:
+                    msg = (
+                        f"Generator '{self.fullname}' cannot be run with "
+                        "parallel_requests (it is not picklable). Re-run without "
+                        "--parallel_requests (or set parallel_requests to 1)."
+                    )
+                    logging.error(msg)
+                    raise GarakException(msg) from e
 
                 pool = None
                 try:

--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -12,6 +12,7 @@ Abstract and common-level probe classes belong here. Contact the garak maintaine
 import copy
 import json
 import logging
+import pickle
 from collections.abc import Iterable
 import random
 from typing import Iterable, Union
@@ -329,6 +330,21 @@ class Probe(Configurable):
                 self.parallel_attempts,
                 self.max_workers,
             )
+
+            # multiprocessing.Pool pickles the work callable to ship it to
+            # worker processes; a probe carrying unpicklable state fails deep
+            # inside multiprocessing with an opaque traceback. Check up front
+            # and fail with an actionable message instead (see #361).
+            try:
+                pickle.dumps(self._execute_attempt)
+            except (pickle.PicklingError, TypeError, AttributeError) as e:
+                msg = (
+                    f"Probe '{self.probename}' cannot be run with "
+                    "parallel_attempts (it is not picklable). Re-run without "
+                    "--parallel_attempts (or set parallel_attempts to 1)."
+                )
+                logging.error(msg)
+                raise GarakException(msg) from e
 
             attempt_pool = None
             try:

--- a/tests/generators/test_generators.py
+++ b/tests/generators/test_generators.py
@@ -9,6 +9,7 @@ from typing import List, Union
 
 from garak import _plugins
 from garak import _config
+from garak.exception import GarakException
 
 from garak.attempt import Message, Turn, Conversation
 from garak.generators.base import Generator
@@ -38,6 +39,36 @@ def test_parallel_requests():
     assert all(
         len(item.text) > 0 for item in result
     ), "All generated Message texts should be non-empty"
+
+
+def test_parallel_requests_unpicklable_generator_fails_helpfully():
+    """An unpicklable generator under parallel_requests must fail politely.
+
+    multiprocessing.Pool pickles the work callable to ship it to worker
+    processes; a generator carrying unpicklable state (here, a lambda) makes
+    that pickling fail deep in multiprocessing with a raw PicklingError/TypeError
+    traceback that gives the user no idea what to do (see issue #361).  garak
+    should instead raise a clear GarakException naming the generator and the
+    flag to drop.
+    """
+    parallel_count = 2
+    _config.system.parallel_requests = parallel_count
+    _config.system.max_workers = parallel_count
+
+    g = _plugins.load_plugin("generators.test.Lipsum")
+    g._unpicklable = lambda x: x  # local closures cannot be pickled
+    prompt = Conversation(Turn("user", [Message("this is a test")]))
+
+    with pytest.raises(GarakException) as exc_info:
+        g.generate(prompt=prompt, generations_this_call=3)
+
+    error_text = str(exc_info.value)
+    assert (
+        "parallel_requests" in error_text
+    ), "error should point the user at the parallel_requests flag"
+    assert (
+        g.fullname in error_text or g.name in error_text
+    ), "error should name the offending generator"
 
 
 @pytest.mark.parametrize("classname", GENERATORS)

--- a/tests/probes/test_probes.py
+++ b/tests/probes/test_probes.py
@@ -8,6 +8,7 @@ import re
 
 from garak import _config, _plugins
 from garak.attempt import Turn, Conversation, Message, Attempt
+from garak.exception import GarakException
 import garak.probes
 
 PROBES = [classname for (classname, active) in _plugins.enumerate_plugins("probes")]
@@ -160,6 +161,41 @@ def test_probe_prune_alignment():
     assert len(p.triggers) == _config.run.soft_probe_prompt_cap
     assert p.triggers[0] in p.prompts[0]
     assert p.triggers[-1] in p.prompts[-1]
+
+
+def test_parallel_attempts_unpicklable_probe_fails_helpfully():
+    """An unpicklable probe under parallel_attempts must fail politely.
+
+    _execute_all() dispatches attempts to a multiprocessing.Pool, which pickles
+    the probe's bound method (and thus the probe) to ship it to workers.  A probe
+    carrying unpicklable state (here, a lambda) makes that pickling fail with a
+    raw PicklingError/TypeError traceback that gives the user no clue what to do
+    (issue #361).  garak should instead raise a clear GarakException naming the
+    probe and the flag to drop.
+    """
+    probe = _plugins.load_plugin("probes.test.Test")
+    probe.parallel_attempts = 2
+    probe.max_workers = 2
+    probe._unpicklable = lambda x: x  # local closures cannot be pickled
+
+    generator = _plugins.load_plugin("generators.test.Blank")
+    probe.generator = generator
+
+    attempts = [
+        probe._mint_attempt(Message(text="one"), seq=0),
+        probe._mint_attempt(Message(text="two"), seq=1),
+    ]
+
+    with pytest.raises(GarakException) as exc_info:
+        probe._execute_all(attempts)
+
+    error_text = str(exc_info.value)
+    assert (
+        "parallel_attempts" in error_text
+    ), "error should point the user at the parallel_attempts flag"
+    assert (
+        probe.probename in error_text
+    ), "error should name the offending probe"
 
 
 PROMPT_EXAMPLES = [


### PR DESCRIPTION
## What

Fixes #361 — fail helpfully when a generator or probe can't be run under parallelism.

When `--parallel_requests` or `--parallel_attempts` is used with a generator/probe that
carries unpicklable state, `multiprocessing.Pool` dies while pickling the work callable to
send it to a worker. The error surfaced deep inside multiprocessing
(`_ForkingPickler.dumps` → `put(task)`) as a raw `PicklingError` / `TypeError` /
`AttributeError` traceback — exactly the two stack traces in the issue — leaving the user
no idea what went wrong or how to recover.

## How

Add a pre-flight pickle check before the `Pool` is constructed at both parallel dispatch
sites:

- `Generator.generate()` (`garak/generators/base.py`) — the `parallel_requests` branch
- `Probe._execute_all()` (`garak/probes/base.py`) — the `parallel_attempts` branch

Each test-pickles the exact bound method the `Pool` would serialize
(`self._call_model` / `self._execute_attempt`) and, on failure, raises a clear
`GarakException` naming the offending plugin and the flag to drop. Because the check runs
*before* any worker executes, the broad `(PicklingError, TypeError, AttributeError)` catch
cannot mask a genuine runtime error — and picklable plugins (the common case) are
unaffected.

This follows the precedent set by #1859 (catch the unpicklable failure at the
multiprocessing boundary and raise a picklable `GarakException`); that fix handled an
unpicklable *result* coming back from a worker, whereas this handles the *task* failing to
pickle on the way in.

Example, before:

```
_pickle.PicklingError: Can't pickle <function ...>: import of module '...' failed
```

after:

```
Generator '<name>' cannot be run with parallel_requests (it is not picklable).
Re-run without --parallel_requests (or set parallel_requests to 1).
```

## Scope

Per the issue's "at least explode politely, for now", this PR implements the polite
failure only. Auto de-parallelisation (silently reduce to serial and log) is the separate
enhancement the issue defers — happy to open a follow-up issue and link it here.

## Tests

Added one RED→GREEN test per dispatch site:

- `tests/generators/test_generators.py::test_parallel_requests_unpicklable_generator_fails_helpfully`
- `tests/probes/test_probes.py::test_parallel_attempts_unpicklable_probe_fails_helpfully`

Both reproduce the raw traceback on `main` and pass with the fix. The existing
`test_parallel_requests` (picklable generator) still passes — the guard is a no-op for
picklable plugins.
