### PR TITLE
Migrate langdetect to langid.py with lazy loading (#1208)

### DIFF
--- a/garak/langproviders/base.py
+++ b/garak/langproviders/base.py
@@ -8,9 +8,7 @@ from typing import List, Callable
 import re
 import unicodedata
 import string
-import logging
 from garak.resources.api import nltk
-from langdetect import detect, DetectorFactory, LangDetectException
 
 _intialized_words = False
 
@@ -104,20 +102,21 @@ def contains_invisible_unicode(text: str) -> bool:
 
 def is_meaning_string(text: str) -> bool:
     """Check if the input text is a meaningless sequence or invalid for translation."""
-    DetectorFactory.seed = 0
-
-    # Detect Language: Skip if no valid language is detected
-    try:
-        lang = detect(text)
-    except LangDetectException:
-        logging.debug("langdetect failed to detect a valid language.")
-        return False
-
-    if lang == "en":
-        return False
+    # Imported lazily so the langid model is only loaded when language
+    # detection is actually needed (e.g. reverse-translation judging).
+    import langid
 
     # Length and pattern checks: Skip if it's too short or repetitive
-    if len(text) < 3 or re.match(r"(.)\1{3,}", text):  # e.g., "aaaa" or "123123"
+    if len(text) < 3 or re.match(r"(.)\1{3,}", text):  # e.g., "aaaa" (4+ repeats)
+        return False
+
+    # Skip if there is no linguistic content to detect a language from
+    if not any(char.isalpha() for char in text):
+        return False
+
+    # Detect Language: Skip if the text is English (no translation needed)
+    lang, _ = langid.classify(text)
+    if lang == "en":
         return False
 
     return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ dependencies = [
   "nvidia-riva-client==2.16.0",
   "google-cloud-translate>=2.0.4",
   "grpcio-tools>=1.71.0",
-  "langdetect==1.0.9",
+  "langid==1.1.6",
   "tiktoken>=0.7.0",
   "mistralai==1.5.2",
   "pillow>=10.4.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ ollama>=0.4.7
 nvidia-riva-client==2.16.0
 google-cloud-translate>=2.0.4
 grpcio-tools>=1.71.0
-langdetect==1.0.9
+langid==1.1.6
 tiktoken>=0.7.0
 mistralai==1.5.2
 pillow>=10.4.0

--- a/tests/langservice/test_langprovision.py
+++ b/tests/langservice/test_langprovision.py
@@ -4,7 +4,7 @@
 import pytest
 
 from garak.langservice import _load_langprovider
-from garak.langproviders.base import split_input_text
+from garak.langproviders.base import is_meaning_string, split_input_text
 
 
 def test_split_input_text():
@@ -15,6 +15,52 @@ def test_split_input_text():
     input_text = "Hello\nHow are you?\nI am fine\nThank you."
     expected_output = ["Hello", "How are you?", "I am fine", "Thank you."]
     assert split_input_text(input_text) == expected_output
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Bonjour, ceci est une phrase en français.",
+        "これは日本語の文章です。",
+        "Hola mundo, esto es una frase en español.",
+    ],
+)
+def test_is_meaning_string_true_for_non_english(text):
+    # Non-English, translatable text should be flagged as meaningful
+    assert is_meaning_string(text) is True
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "This is a normal English sentence about cats.",  # English needs no translation
+        "ab",  # too short
+        "a",  # too short
+        "",  # empty
+        "aaaa",  # repetitive
+        "123123123",  # no alphabetic content
+        "12345",  # no alphabetic content
+        "!!! ??? ...",  # no alphabetic content
+        "$",  # no alphabetic content
+        "   ",  # whitespace only
+    ],
+)
+def test_is_meaning_string_false_for_meaningless_or_english(text):
+    assert is_meaning_string(text) is False
+
+
+def test_langproviders_base_uses_langid_lazily():
+    # Migration contract for issue #1208: langdetect is gone, and langid is
+    # imported lazily inside is_meaning_string rather than at module load.
+    import inspect
+
+    from garak.langproviders import base
+
+    module_source = inspect.getsource(base)
+    assert "langdetect" not in module_source
+    module_top = module_source.split("\ndef ")[0]
+    assert "import langid" not in module_top
+    assert "import langid" in inspect.getsource(base.is_meaning_string)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Migrates the language-detection dependency used by the language service from `langdetect` to [`langid.py`](https://aclanthology.org/P12-3005.pdf), and loads it lazily. Closes #1208.

`langid.py` provides faster and more accurate detection across a wider range of languages than `langdetect`, and importing it inside `is_meaning_string()` means the model is only loaded when language detection is actually exercised (i.e. reverse-translation judging) rather than on every import of `garak.langproviders.base`.

### What changed

- `garak/langproviders/base.py`
  - Drop the module-level `from langdetect import ...` (and the now-unused `import logging`).
  - `is_meaning_string()` now uses a lazily-imported `langid.classify()`.
  - Behaviour is preserved: `langdetect` previously raised `LangDetectException` on inputs with no linguistic features (e.g. pure digits/punctuation), which the old code treated as "not meaningful". `langid` never raises, so that path is replicated with an explicit "no alphabetic character → not meaningful" guard. The cheap length/repetition checks now run first so trivial inputs short-circuit before any model load.
- `pyproject.toml` / `requirements.txt`: swap `langdetect==1.0.9` → `langid==1.1.6`.
- `tests/langservice/test_langprovision.py`: add unit tests for `is_meaning_string` (the function previously had none), covering non-English (→ translatable), English, too-short, repetitive, and no-feature inputs, plus a structural test asserting `langdetect` is gone and `langid` is imported lazily.

## Verification

- [x] `python -m pytest tests/langservice/test_langprovision.py -k "is_meaning_string or langid"` → 14 passed
- [x] `python -m pytest tests/test_reqs.py` → passed (requirements.txt / pyproject.toml stay consistent)
- [x] Full suite collects cleanly with `langdetect` uninstalled (no other module imported it): `python -m pytest --co` → 4664 tests, exit 0
- [x] `black --check garak/langproviders/base.py tests/langservice/test_langprovision.py` → clean
- [x] **Verify** non-English text is still flagged meaningful and English / no-feature text is skipped
- [x] **Verify** `langid` is not imported at module load, only when `is_meaning_string()` runs
