### PR TITLE
fix: repair dead blank-prompt guard in NVCF 400 handling

### DIFF
--- a/garak/generators/nvcf.py
+++ b/garak/generators/nvcf.py
@@ -126,7 +126,7 @@ class NvcfChat(Generator):
         if 400 <= response.status_code < 600:
             logging.warning("nvcf : returned error code %s", response.status_code)
             logging.warning("nvcf : returned error body %s", response.content)
-            if response.status_code == 400 and prompt == "":
+            if response.status_code == 400 and prompt.last_message().text in ("", None):
                 # error messages for refusing a blank prompt are fragile and include multi-level wrapped JSON, so this catch is a little broad
                 return [None]
             if response.status_code == 404 and self.stop_on_404:

--- a/tests/generators/test_nvcf.py
+++ b/tests/generators/test_nvcf.py
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+
 import pytest
+import requests
 
 from garak import _config
 from garak import _plugins
@@ -9,6 +12,13 @@ import garak.generators.base
 import garak.generators.nvcf
 
 PLUGINS = ("NvcfChat", "NvcfCompletion")
+
+
+class _FakeResponse:
+    def __init__(self, status_code, content):
+        self.status_code = status_code
+        self.content = content
+        self.headers = {}
 
 
 @pytest.mark.parametrize("klassname", PLUGINS)
@@ -50,3 +60,58 @@ def test_custom_keys(klassname):
     test_payload = g._build_payload(conv)
     for k, v in params.items():
         assert test_payload[k] == v
+
+
+@pytest.mark.parametrize("klassname", PLUGINS)
+def test_blank_prompt_400_skipped(klassname, monkeypatch, caplog):
+    from garak.attempt import Message, Turn, Conversation
+
+    _config.plugins.generators["nvcf"] = {}
+    _config.plugins.generators["nvcf"][klassname] = {}
+    _config.plugins.generators["nvcf"][klassname]["name"] = "placeholder name"
+    _config.plugins.generators["nvcf"][klassname]["api_key"] = "placeholder key"
+    g = _plugins.load_plugin(f"generators.nvcf.{klassname}")
+
+    # blank-prompt refusals come back as a fragile multi-level wrapped JSON 400
+    monkeypatch.setattr(
+        requests.Session,
+        "post",
+        lambda self, *args, **kwargs: _FakeResponse(
+            400, b'{"detail": {"error": {"message": "empty prompt"}}}'
+        ),
+    )
+
+    blank_prompt = Conversation([Turn("user", Message(""))])
+    with caplog.at_level(logging.WARNING):
+        result = g._call_model(blank_prompt)
+
+    assert result == [None], "a blank prompt rejected with HTTP 400 should yield [None]"
+    assert (
+        "skipping this prompt" not in caplog.text
+    ), "blank prompt should hit the dedicated 400 guard, not the generic skip path"
+
+
+@pytest.mark.parametrize("klassname", PLUGINS)
+def test_nonblank_prompt_400_not_caught_by_blank_guard(klassname, monkeypatch, caplog):
+    from garak.attempt import Message, Turn, Conversation
+
+    _config.plugins.generators["nvcf"] = {}
+    _config.plugins.generators["nvcf"][klassname] = {}
+    _config.plugins.generators["nvcf"][klassname]["name"] = "placeholder name"
+    _config.plugins.generators["nvcf"][klassname]["api_key"] = "placeholder key"
+    g = _plugins.load_plugin(f"generators.nvcf.{klassname}")
+
+    monkeypatch.setattr(
+        requests.Session,
+        "post",
+        lambda self, *args, **kwargs: _FakeResponse(400, b"{}"),
+    )
+
+    real_prompt = Conversation([Turn("user", Message("a non-blank prompt"))])
+    with caplog.at_level(logging.WARNING):
+        result = g._call_model(real_prompt)
+
+    assert result == [None], "a generic HTTP 400 should still be skipped"
+    assert (
+        "skipping this prompt" in caplog.text
+    ), "a non-blank 400 must fall through to the generic skip path, not the blank guard"


### PR DESCRIPTION
`NvcfChat._call_model` has a dedicated branch meant to skip blank prompts that
the endpoint rejects with HTTP 400:

```python
if response.status_code == 400 and prompt == "":
    # error messages for refusing a blank prompt are fragile ...
    return [None]
```

`prompt` is now a `Conversation` (`garak.attempt.Conversation`, a `@dataclass`),
not a `str`. Its auto-generated `__eq__` only compares equal to another
`Conversation`, so `prompt == ""` is **always `False`** and this guard is dead
code. Blank prompts rejected with a 400 never hit their intended branch; they
only get skipped by coincidence via the generic fall-through at the bottom of the
`4xx/5xx` block (`logging.warning("nvcf : skipping this prompt")`).

This is a regression from the `str` -> `Conversation` generator refactor: the
comparison was correct when `prompt` was a plain string. The last functional
change to this line is commit `d417303` ("Set generator `_call_model()` ... type
hints", #694), which is exactly that refactor.

### The fix

Compare the prompt's last message text instead, reproducing the original intent:

```python
if response.status_code == 400 and prompt.last_message().text in ("", None):
```

`Conversation.last_message()` returns the last turn's `Message`; `Message.text`
is `""` for an empty prompt and `None` when unset, so both are caught. The fix is
inherited by `NvcfCompletion` (a subclass of `NvcfChat`). Scope is one line; no
base classes or `attempt` touched, no new dependencies.

### Tests

Added two parametrized regression tests over both NVCF generators
(`NvcfChat`, `NvcfCompletion`) in the existing `tests/generators/test_nvcf.py`,
stubbing `requests.Session.post` with a fake 400 response:

- `test_blank_prompt_400_skipped` - a blank prompt + 400 now returns `[None]` via
  the dedicated guard and does **not** log `"skipping this prompt"`.
- `test_nonblank_prompt_400_not_caught_by_blank_guard` - a non-blank prompt + 400
  still falls through to the generic skip path (asserts it **does** log
  `"skipping this prompt"`), so the guard is not over-broad.

On `main` (before the fix) `test_blank_prompt_400_skipped` fails for both classes
and the non-blank test passes, i.e. the tests pin precisely the guard behaviour.

## Verification

- [x] No supporting configuration needed (uses placeholder generator config in
      the tests; no live endpoint).
- [x] `python -m pytest tests/generators/test_nvcf.py -q` -> **10 passed**
- [x] `python -m pytest tests/generators/test_nvcf.py tests/test_attempt.py tests/generators/test_generators.py -q` -> **150 passed** (no existing tests broken)
- [x] `python -m black --check garak/generators/nvcf.py tests/generators/test_nvcf.py` -> clean
- [x] **Verify** blank-prompt 400 hits the dedicated guard (new test, was failing on `main`).
- [x] **Verify** non-blank 400 is unaffected and still uses the generic skip path.
- [x] **Document** intent is preserved; the existing inline comment on the guard
      still describes the behaviour, so no doc change is needed.

### Not a duplicate

- No open PR modifies `garak/generators/nvcf.py`. PRs surfaced by an `nvcf`
  search (#1673 Cohere generator, #1757 PDF-injection probe) do not touch
  `nvcf.py`.
- No matching issue. Two adjacent-but-distinct issues exist:
  - **#642** is about NVCF **9xx** return codes; this fix is specifically the
    **400** blank-prompt guard.
  - **#804** is the broader evaluator question of whether failed-output prompts
    should be SKIP vs PASS; this fix is a narrow generator-side correctness
    repair and does not change SKIP/PASS semantics.

### AI assistance disclosure

This change was developed with AI assistance. I (the submitter) reviewed every
changed line, understand the bug and the fix end-to-end, and ran the tests above
locally. Attribution is in the commit trailer (`Co-authored-by: Claude`), and the
commit is DCO signed-off.
