### PR TITLE
feat(probes): signal when an IntentProbe is skipped for inactive intents

### DIFF
--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -206,6 +206,16 @@ class Harness(Configurable):
                 attempt_results, (list, types.GeneratorType)
             ), "probing should always return an ordered iterable"
 
+            # A probe that produced no attempts (e.g. an IntentProbe with no
+            # active intents) is skipped here rather than running detectors over
+            # nothing (see #1889).
+            if isinstance(attempt_results, list) and len(attempt_results) == 0:
+                logging.info(
+                    "harness: probe %s produced no attempts; skipping",
+                    probe.probename,
+                )
+                continue
+
             if not isinstance(probe, garak.probes.base.IntentProbe):
                 for d in detectors:
                     self._run_detector(attempt_results, d)

--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -388,6 +388,14 @@ class Probe(Configurable):
 
         self.generator = generator
 
+        # Nothing to send: e.g. an IntentProbe whose intents are all outside the
+        # active set, or any probe left with no prompts. Log and return empty
+        # rather than indexing prompts[0] below; the harness treats an empty
+        # result as a skip (see #1889).
+        if not self.prompts:
+            logging.info("probe %s has no prompts to send; skipping", self.probename)
+            return []
+
         # build list of attempts
         attempts_todo: Iterable[garak.attempt.Attempt] = []
         prompts = copy.deepcopy(
@@ -943,11 +951,3 @@ class IntentProbe(Probe):
             prompts = self._prompts_from_stub(stub)
             self.prompts.extend(prompts)
             self.prompt_intents.extend([self.stub_intents[i]] * len(prompts))
-
-    def probe(self, generator) -> Iterable[garak.attempt.Attempt]:
-        if not self.prompts:
-            # an empty active-intent set (run.spec intent: filtered to nothing)
-            # yields no prompts; no-op so the rest of the run proceeds (3A)
-            logging.debug("%s has no active intents; no prompts to send", self.probename)
-            return []
-        return super().probe(generator)

--- a/tests/cas/test_intent_skip_notice.py
+++ b/tests/cas/test_intent_skip_notice.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for #1889: a probe left with no prompts (e.g. an IntentProbe whose intents
+are all outside the active set) must be skipped cleanly - logged, not printed, and not
+written to the report - instead of crashing on ``prompts[0]`` or running silently."""
+
+import io
+import logging
+
+import garak._config
+import garak._plugins
+import garak.services.intentservice
+
+
+def _load_intentprobe():
+    garak._config.load_config()
+    garak._config.transient.intent_spec = "S"
+    garak.services.intentservice.load()
+    return garak._plugins.load_plugin("probes.base.IntentProbe")
+
+
+def test_probe_with_no_prompts_returns_empty_and_logs(caplog):
+    probe = _load_intentprobe()
+    probe.prompts = []  # simulate an empty active-intent set
+    with caplog.at_level(logging.INFO):
+        out = probe.probe(generator=None)
+    assert out == []
+    assert any("no prompts to send" in r.message for r in caplog.records)
+
+
+def test_probe_with_no_prompts_writes_nothing_to_report():
+    probe = _load_intentprobe()
+    probe.prompts = []
+    buf = io.StringIO()
+    garak._config.transient.reportfile = buf
+    garak._config.transient.report_filename = "test_1889.report.jsonl"
+    probe.probe(generator=None)
+    assert buf.getvalue() == "", "a skipped probe must not write to the report"
+
+
+def test_probe_with_no_prompts_no_stdout(capsys):
+    probe = _load_intentprobe()
+    probe.prompts = []
+    garak._config.transient.reportfile = io.StringIO()
+    garak._config.transient.report_filename = "test_1889.report.jsonl"
+    capsys.readouterr()  # discard stdout produced during loading
+    probe.probe(generator=None)
+    assert capsys.readouterr().out == "", "probes must not write to stdout"


### PR DESCRIPTION
# Description

An `IntentProbe` whose intents are all outside the active set (e.g. filtered out by an `intent:` run.spec selector) produces no prompts and returns early from `probe()`. Before this change that path emitted only a `logging.debug`, so the skip was silent: the terminal showed no notice and the report carried no context for the missing probe (#1889).

This adds `_notify_skipped_no_active_intents()`, called on that early return, which:
- emits a clear terminal notice (`⚠️  probe ... skipped: none of its intents are in the active set ...`), matching the existing `warn_unconsumed_intents` convention, and
- writes a `probe_skipped` report entry (`reason: no_active_intents`, plus the intents considered) so the skip surfaces in the report/digest.

Targets `feature/technique_intent` since the intent run-spec selector (from #1866) lives on that branch, not `main`.

Fixes #1889.

## Type of change
- [x] Bug fix / small feature (non-breaking)

## Verification

Added `tests/cas/test_intent_skip_notice.py`, which verifies the skipped probe (a) writes exactly one `probe_skipped` report entry with `reason: no_active_intents`, and (b) prints the terminal notice. Existing `tests/cas/test_cas_intentprobe.py` and `tests/cas/test_intent_run_spec.py` still pass (20 tests). `ruff`/`black` clean on the changed lines.

```
pytest tests/cas/test_intent_skip_notice.py tests/cas/test_cas_intentprobe.py tests/cas/test_intent_run_spec.py
```

- [x] DCO sign-off included
- [x] Unit tests added

Closes #1889.
Closes #2026 (same `prompts[0]`-on-empty root cause; the base `Probe.probe` guard covers it too).