### PR TITLE
rest: coerce non-string JSON response values to text

### DIFF
--- a/garak/generators/rest.py
+++ b/garak/generators/rest.py
@@ -28,6 +28,22 @@ from garak.exception import (
 from garak.generators.base import Generator
 
 
+def _coerce_response_text(value):
+    """Coerce a value extracted from a JSON response into text for a Message.
+
+    ``response_json_field`` / a JSONPath can resolve to a dict, list, number, or
+    bool rather than a string (observed with some Azure OpenAI response shapes).
+    Downstream detectors call string methods such as ``.lower()`` on the response,
+    so a non-string value must be normalised here rather than raising an
+    ``AttributeError`` after every subtest has run.
+    """
+    if value is None or isinstance(value, str):
+        return value
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, ensure_ascii=False)
+    return str(value)
+
+
 class RestGenerator(Generator):
     """Generic API interface for REST models
 
@@ -394,6 +410,11 @@ class RestGenerator(Generator):
                     response = [response_value]
                 elif isinstance(response_value, list):
                     response = response_value
+                else:
+                    # dict / number / bool — a valid JSONPath match that isn't a
+                    # string (e.g. some Azure OpenAI response shapes). Keep it and
+                    # coerce to text below rather than silently dropping to [None].
+                    response = [response_value]
             elif len(responses) > 1:
                 response = [r.value for r in responses]
             else:
@@ -403,7 +424,11 @@ class RestGenerator(Generator):
                 )
                 return [None]
 
-        return [Message(r) for r in response]
+        # A response_json_field / JSONPath can resolve to a dict, list, or scalar
+        # rather than a string (seen with some Azure OpenAI response shapes).
+        # Downstream detectors expect text, so normalise here instead of letting a
+        # non-string value reach them and raise e.g. AttributeError on .lower().
+        return [Message(_coerce_response_text(r)) for r in response]
 
 
 class _MtlsAdapter(requests.adapters.HTTPAdapter):

--- a/tests/generators/test_rest.py
+++ b/tests/generators/test_rest.py
@@ -500,3 +500,36 @@ def test_rest_mtls_pickle_roundtrip(real_mtls_cert_files):
     assert isinstance(
         adapter, _MtlsAdapter
     ), "Reconstructed session must have an _MtlsAdapter mounted on 'https://'"
+
+
+# Regression: a response_json_field / JSONPath that resolves to a non-string
+# (dict / number) must not crash; it is coerced to text. See issue #1888
+# (AttributeError: 'dict' object has no attribute 'lower' after all subtests run).
+@pytest.mark.usefixtures("set_rest_config")
+def test_json_rest_dict_value_is_coerced(requests_mock):
+    requests_mock.post(
+        "https://www.wikidata.org/wiki/Q22971",
+        text=json.dumps({"text": {"content": "nested reply"}}, ensure_ascii=False),
+    )
+    _config.plugins.generators["rest"]["RestGenerator"]["response_json"] = True
+    _config.plugins.generators["rest"]["RestGenerator"]["response_json_field"] = "text"
+    generator = RestGenerator()
+    conv = Conversation([Turn("user", Message("prompt"))])
+    output = generator._call_model(conv)
+    assert output == [Message(json.dumps({"content": "nested reply"}, ensure_ascii=False))]
+    assert isinstance(output[0].text, str)  # the thing detectors will call .lower() on
+
+
+@pytest.mark.usefixtures("set_rest_config")
+def test_json_rest_jsonpath_dict_value_is_coerced(requests_mock):
+    requests_mock.post(
+        "https://www.wikidata.org/wiki/Q22971",
+        text=json.dumps({"choices": [{"message": {"role": "assistant"}}]}, ensure_ascii=False),
+    )
+    _config.plugins.generators["rest"]["RestGenerator"]["response_json"] = True
+    _config.plugins.generators["rest"]["RestGenerator"]["response_json_field"] = "$.choices[0].message"
+    generator = RestGenerator()
+    conv = Conversation([Turn("user", Message("prompt"))])
+    output = generator._call_model(conv)
+    assert isinstance(output[0].text, str)
+    assert "assistant" in output[0].text


### PR DESCRIPTION
## Summary
Fixes #1888. A `response_json_field` / JSONPath can resolve to a **dict, list, number, or bool** rather than a string — observed with some Azure OpenAI REST response shapes. The extracted value flowed unmodified into `Message()`, and a downstream detector then raised `AttributeError: 'dict' object has no attribute 'lower'` — only *after* every subtest in the probe had run, so the whole run was wasted.

## Fix
- Add `_coerce_response_text()`: passes strings/None through, serializes dict/list to JSON, and `str()`s other scalars — so the value handed to `Message()` is always text.
- In the single-match JSONPath branch, keep a non-str/non-list value (e.g. a dict) instead of silently leaving `response = [None]` (which discarded a real response).

## Tests
Adds `test_json_rest_dict_value_is_coerced` and `test_json_rest_jsonpath_dict_value_is_coerced` mirroring the existing `requests_mock` REST tests: a response field that resolves to a dict now yields a string `Message` (what detectors call `.lower()` on) instead of crashing.

Minimal and backwards-compatible: string and list responses are unchanged.