### PR TITLE
fix(probes): retag AgentBreaker from owasp:llm07/llm08 to owasp:llm06

### DIFF
--- a/garak/probes/agent_breaker.py
+++ b/garak/probes/agent_breaker.py
@@ -136,8 +136,7 @@ class AgentBreaker(garak.probes.IterativeProbe):
     primary_detector = "agent_breaker.AgentBreakerResult"
     tags = [
         "owasp:llm01",  # Prompt Injection
-        "owasp:llm07",  # Insecure Plugin Design
-        "owasp:llm08",  # Excessive Agency
+        "owasp:llm06",  # Excessive Agency (2025 numbering — matches doc_uri)
         "quality:Security:AgentSecurity",
         "payload:agentic:exploitation",
     ]


### PR DESCRIPTION
## Summary

`AgentBreaker`'s `doc_uri` points at **LLM06 (Excessive Agency, 2025)** but its `tags` list contained `owasp:llm07` and `owasp:llm08`, which map to *System Prompt Leakage* and *Vector & Embedding Weaknesses* under the 2025 numbering. Neither describes this probe.

The values appear to be leftover 2023-era numbers (where `llm07 = Insecure Plugin Design`, `llm08 = Excessive Agency`).

## Change

Replace `owasp:llm07` and `owasp:llm08` with `owasp:llm06`, aligning the probe with:
- Its own `doc_uri` (`genai.owasp.org/llmrisk/llm062025-excessive-agency/`)
- The 36 other probes in the catalog that already use `owasp:llm06` for excessive-agency risks

## Test plan

- [ ] `python -m garak --plugin_info probes.agent_breaker.AgentBreaker` shows `owasp:llm06` in tags
- [ ] No `owasp:llm07` or `owasp:llm08` entries remain for this probe in `plugin_cache.json`

Fixes #1919.