### PR TITLE
fix(detectors): guard against non-string output.text in AttackRogueString

### DIFF
--- a/garak/detectors/promptinject.py
+++ b/garak/detectors/promptinject.py
@@ -31,6 +31,8 @@ class AttackRogueString(Detector):
                 results.append(None)
                 continue
             output_text = output.text
+            if not isinstance(output_text, str):
+                output_text = str(output_text)
 
             score = 0.0
 

--- a/garak/detectors/promptinject.py
+++ b/garak/detectors/promptinject.py
@@ -31,9 +31,6 @@ class AttackRogueString(Detector):
                 results.append(None)
                 continue
             output_text = output.text
-            if not isinstance(output_text, str):
-                output_text = str(output_text)
-
             score = 0.0
 
             for trigger in triggers:

--- a/garak/generators/rest.py
+++ b/garak/generators/rest.py
@@ -403,7 +403,7 @@ class RestGenerator(Generator):
                 )
                 return [None]
 
-        return [Message(r) for r in response]
+        return [Message(str(r) if r is not None and not isinstance(r, str) else r) for r in response]
 
 
 class _MtlsAdapter(requests.adapters.HTTPAdapter):

--- a/tests/generators/test_rest.py
+++ b/tests/generators/test_rest.py
@@ -509,11 +509,13 @@ def test_rest_mtls_pickle_roundtrip(real_mtls_cert_files):
         (42, "42"),
         (3.14, "3.14"),
         (True, "True"),
+        ({"nested": "dict"}, "{'nested': 'dict'}"),
     ],
 )
 def test_json_rest_non_string_response_coerced_to_str(requests_mock, value, expected_text):
-    # regression: non-string values from response_json_field must be str()-coerced
-    # before being wrapped in Message (Message.text is typed str | None)
+    # regression for #1888: non-string values from response_json_field must be
+    # str()-coerced before being wrapped in Message (Message.text is typed str | None).
+    # The dict case is the original crash: AttackRogueString called .lower() on a dict.
     requests_mock.post(
         DEFAULT_URI,
         text=json.dumps({"result": value}, ensure_ascii=False),

--- a/tests/generators/test_rest.py
+++ b/tests/generators/test_rest.py
@@ -500,3 +500,42 @@ def test_rest_mtls_pickle_roundtrip(real_mtls_cert_files):
     assert isinstance(
         adapter, _MtlsAdapter
     ), "Reconstructed session must have an _MtlsAdapter mounted on 'https://'"
+
+
+@pytest.mark.usefixtures("set_rest_config")
+@pytest.mark.parametrize(
+    "value,expected_text",
+    [
+        (42, "42"),
+        (3.14, "3.14"),
+        (True, "True"),
+    ],
+)
+def test_json_rest_non_string_response_coerced_to_str(requests_mock, value, expected_text):
+    # regression: non-string values from response_json_field must be str()-coerced
+    # before being wrapped in Message (Message.text is typed str | None)
+    requests_mock.post(
+        DEFAULT_URI,
+        text=json.dumps({"result": value}, ensure_ascii=False),
+    )
+    _config.plugins.generators["rest"]["RestGenerator"]["response_json"] = True
+    _config.plugins.generators["rest"]["RestGenerator"]["response_json_field"] = "result"
+    generator = RestGenerator()
+    conv = Conversation([Turn("user", Message("test prompt"))])
+    output = generator._call_model(conv)
+    assert output == [Message(expected_text)]
+
+
+@pytest.mark.usefixtures("set_rest_config")
+def test_json_rest_non_string_list_coerced_to_str(requests_mock):
+    # regression: each element in a multi-value response list must be str()-coerced
+    requests_mock.post(
+        DEFAULT_URI,
+        text=json.dumps({"scores": [1, 2, 3]}, ensure_ascii=False),
+    )
+    _config.plugins.generators["rest"]["RestGenerator"]["response_json"] = True
+    _config.plugins.generators["rest"]["RestGenerator"]["response_json_field"] = "$.scores[*]"
+    generator = RestGenerator()
+    conv = Conversation([Turn("user", Message("test prompt"))])
+    output = generator._call_model(conv)
+    assert output == [Message("1"), Message("2"), Message("3")]


### PR DESCRIPTION
## Summary

When a REST generator returns a structured JSON response, `output.text` can be a `dict` rather than a `str`, causing a crash in `promptinject.AttackRogueString.detect()`:

```
AttributeError: 'dict' object has no attribute 'lower'
  File "garak/detectors/promptinject.py", line 39, in detect
      trigger, output_text = trigger.lower(), output_text.lower()
```

## Root cause

REST generators that return structured JSON populate `output.text` with the parsed dict. The subsequent `.lower()` call in the detector then crashes.

## Fix

Coerce non-string responses to `str` in `generators/rest.py` before wrapping them in `Message` objects. This is the correct layer since the type contract should be enforced at the generator boundary:

```python
return [Message(str(r) if r is not None and not isinstance(r, str) else r) for r in response]
```

This ensures `Message.text` is always `str | None` as the type annotation promises, without changing detector logic.

## Test plan

- [ ] Run `promptinject.HijackKillHumans` against a REST endpoint that returns a JSON dict; verify no `AttributeError` is raised
- [ ] Existing string outputs still scored correctly

Fixes #1888.