### PR TITLE
test(config): assert aiohttp User-Agent test actually verifies the request

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -809,12 +809,14 @@ def test_agent_is_used_aiohttp(httpserver: HTTPServer):
     async def main():
         async with aiohttp.ClientSession() as session:
             async with session.get(httpserver.url_for("/")) as response:
-                html = await response.text()
+                return response.status
 
     httpserver.expect_request(
         "/", headers={"User-Agent": AGENT_TEST}
     ).respond_with_data("")
-    asyncio.run(main())
+    assert (
+        asyncio.run(main()) == 200
+    ), "aiohttp User-Agent should match the expected header so the request is served"
 
 
 def test_api_key_in_config():


### PR DESCRIPTION

`test_agent_is_used_aiohttp` in `tests/test_config.py` exercised the aiohttp
User-Agent override (`_config.set_http_lib_agents({"aiohttp": ...})`) but threw
the response away (`html = await response.text()`) and had no assertion, so it
verified nothing. A regression in the aiohttp branch of `set_http_lib_agents`
would still pass this test, i.e. it is a false-coverage / mutation-survivor test.

Its two siblings both assert the request was actually served with the expected
header:

- `test_agent_is_used_requests`: `assert requests.get(...).status_code == 200`
- `test_agent_is_used_httpx`: `assert httpx.get(...).status_code == 200`

This makes the aiohttp coroutine return `response.status` and asserts it equals
`200`, mirroring the siblings. `pytest_httpserver` only serves the request when
the incoming `User-Agent` matches the expected header, so if the aiohttp
User-Agent override breaks, the request goes unserved (500) and the test now
fails instead of passing silently. A terse assert message documents the expected
behaviour, as the repo's contribution guide asks.

Test-only, one file, `+4/-2`. No production code changes.

### Verification

- [x] Run the tests and ensure they pass `python -m pytest tests/`
  - `python -m pytest tests/test_config.py::test_agent_is_used_aiohttp` -> **1 passed**
  - `python -m pytest tests/test_config.py` -> **71 passed** (no regressions)
- [x] **Verify** the test now fails when the behaviour it guards is broken:
  temporarily disabling the aiohttp branch of `set_http_lib_agents` makes
  `pytest_httpserver` return 500 for the unexpected `User-Agent`, and the new
  assertion fails (`assert 500 == 200`) with the descriptive message. It passes
  again once the override is restored. This confirms the test is now a real
  red/green regression guard rather than a vacuous pass.
- [x] Formatting unchanged: `black --check tests/test_config.py`.

### Not a duplicate

No open PR touches `test_agent_is_used_aiohttp` or `set_http_lib_agents` in a
related way. The open PRs that edit `tests/test_config.py` do so at unrelated
functions: #1857 (deprecated `-m`/`--model_*` CLI-flag removal), #1816 (a
parallel-attempts test), #1790 (structured exit codes; its `set_http_lib_agents`
calls save/restore prior agents inside the worker-count test, not this one), and
#1651 (exit-code tests). A keyword scan of open PRs for `aiohttp` / `user-agent`
/ `set_http_lib_agents` / `agent is used` returns nothing relevant, and no open
issue tracks this test. (The related leakreplay test-coverage fix is a separate
PR, #1914, which touches only `tests/probes/test_probes_leakreplay.py`.)

### AI assistance

AI assistance was used to prepare this change. I have reviewed every changed
line, reproduced the missing-coverage behaviour and the fix locally (confirming
red -> green), and ran the test suite for the affected file.

---

## Notes for maintainers scope

- Follows the `test(config):` conventional-commit style already used in the repo
  (e.g. #1791).
- DCO sign-off and a `Co-authored-by: Claude` trailer are in the commit.
- No new dependencies, no base-class edits, no SPDX header (nothing imported
  under another license).
