### PR TITLE
fix(probes): correct inverted target_lang_name_en guard message

### DIFF
--- a/garak/probes/latentinjection.py
+++ b/garak/probes/latentinjection.py
@@ -130,7 +130,7 @@ class TranslationMixin:
 
     def __init__(self):
         if self.target_lang_name_en is None:
-            msg = f"{self.__class__.__name__}: Probe cannot operate with target_lang_name_en being set"
+            msg = f"{self.__class__.__name__}: Probe cannot operate without target_lang_name_en being set"
             logging.error(msg)
             raise ValueError(msg)
         self.top_instructions = [

--- a/tests/probes/test_probes_latentinjection.py
+++ b/tests/probes/test_probes_latentinjection.py
@@ -68,6 +68,21 @@ def test_whois_payload_injection_marker():
         ), f"Each whois payload must contain {marker} but this was not found in {payload_name} payload {id}"
 
 
+def test_translation_mixin_requires_target_lang():
+    class _MissingTargetLang(garak.probes.latentinjection.TranslationMixin):
+        pass
+
+    with pytest.raises(ValueError) as exc_info:
+        _MissingTargetLang()
+    msg = str(exc_info.value)
+    assert (
+        "without target_lang_name_en" in msg
+    ), "error must state target_lang_name_en is required, not that it must be unset"
+    assert (
+        "operate with target_lang_name_en" not in msg
+    ), "error must not describe the inverse of the guarded condition"
+
+
 class TestFactSnippet(
     garak.probes.latentinjection.FactSnippetMixin, garak.probes.Probe
 ):


### PR DESCRIPTION

Tell us what this change does:

`garak.probes.latentinjection.TranslationMixin.__init__` raises a `ValueError`
when `target_lang_name_en` is `None`, i.e. the mixin **requires**
`target_lang_name_en` to be set and the guard fires precisely when it is not.
The message, however, read:

> `Probe cannot operate with target_lang_name_en being set`

That states the opposite of the guarded condition. Anyone extending the mixin
(for example a new translation-based probe subclass that forgets to set
`target_lang_name_en`) who hits this error is told to *unset* the value, which
guarantees the failure persists.

This changes one word so the diagnostic matches the code's actual requirement:

> `Probe cannot operate without target_lang_name_en being set`

It is a message-only change with no behavioural effect. There is exactly one
occurrence of this string in the codebase, so the fix is complete.

A regression test is added in the existing
`tests/probes/test_probes_latentinjection.py`: it instantiates a
`TranslationMixin` subclass without `target_lang_name_en`, asserts the raised
message states the value is required (`without target_lang_name_en`), and
asserts it no longer describes the inverse condition
(`operate with target_lang_name_en`). No target/model backend is needed.

### Not a duplicate

`gh pr list --state open` searches on `latentinjection`, `target_lang_name_en`,
and `TranslationMixin` return no PR that touches
`garak/probes/latentinjection.py`, `target_lang_name_en`, or `TranslationMixin`.
The only two open PRs that mention the `latentinjection` module (1776 AgentHarm,
1627 0DIN JEF) do not modify this file or symbol (confirmed via
`gh pr diff --name-only`); they reference it incidentally. No existing issue
covers this message.

### AI assistance

AI assistance (Claude) was used to help identify and fix this bug; this is
disclosed here and attributed in the commit via a `Co-authored-by:` trailer, as
garak's contribution guide requests. Every changed line has been reviewed and is
understood and defended by the human submitter.

## Verification

- [x] Run the tests and ensure they pass: `python -m pytest tests/probes/test_probes_latentinjection.py -q` -> **20 passed**
- [x] Broader probe suite unaffected: `python -m pytest tests/probes/test_probes.py -q` -> **1148 passed, 1 failed**; the single failure is `probes.audio.AudioAchillesHeel` needing optional deps `soundfile`/`librosa` (not installed here), unrelated to this change and pre-existing
- [x] Formatting: `python -m black --check garak/probes/latentinjection.py tests/probes/test_probes_latentinjection.py` -> **clean**
- [x] Red -> green proof: reverting the source to the old "with" message makes the new test fail with a clear assertion; restoring the fix makes it pass
- [x] **Verify** the thing does what it should: a `TranslationMixin` subclass with no `target_lang_name_en` now raises a `ValueError` whose message correctly says the value must be set
- [x] **Verify** the thing does not do what it should not: no behavioural change; only the error string wording differs, and only the one guard message is touched

(No generator config, target run, or special hardware/software is relevant: this
is a message-only correctness fix with a unit-level regression test.)
