### PR TITLE
Add opt-in Unicode normalization to StringDetector to resist homoglyph evasion

### DIFF
--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -6,6 +6,7 @@ in `garak`. `garak` detectors must inherit from a class in here."""
 import logging
 import os
 import re
+import unicodedata
 from typing import List, Iterable, Union
 
 from colorama import Fore, Style
@@ -194,16 +195,71 @@ class HFDetector(Detector, HFCompatible):
 
 
 class StringDetector(Detector):
-    """Subclass of Detector using list of substrings as detection triggers"""
+    """Subclass of Detector using list of substrings as detection triggers
+
+    By default, matching is byte-comparison after optional lower-casing, with
+    no Unicode normalization. This leaves substring-based detectors open to
+    evasion via trivially-normalizable Unicode forms — fullwidth characters,
+    zero-width joiners/spaces, and similar — where a toxic term that is
+    semantically present but written with non-ASCII code points scores clean.
+
+    Set ``normalize`` to opt into homoglyph-resistant matching:
+
+    * ``None`` (default) — no normalization; preserves today's behavior so
+      existing scores and tests are unchanged.
+    * ``"NFKC"`` — apply ``unicodedata.normalize("NFKC", ...)`` to both the
+      candidate substring and the output text before matching. Catches
+      fullwidth homoglyphs and compatibility decomposition cases.
+    * ``"NFKC+strip_format"`` — NFKC then strip Unicode category ``Cf``
+      (format characters, including zero-width joiner U+200D, zero-width
+      space U+200B, and zero-width non-joiner U+200C) before matching.
+      Catches zero-width insertion attacks that NFKC leaves intact.
+
+    Known limitations: neither tier collapses Cyrillic/Latin homoglyphs
+    (e.g. Cyrillic ``е`` vs ASCII ``e``) nor combining marks
+    (e.g. ``e`` + U+0301 combining acute). Those require a confusables table
+    and are out of scope for this parameter.
+    """
 
     DEFAULT_PARAMS = Detector.DEFAULT_PARAMS | {
         "matchtype": "str",  # "str" or "word"
         "case_sensitive": False,
+        "normalize": None,  # None, "NFKC", or "NFKC+strip_format"
     }
+
+    _NORMALIZE_CHOICES = (None, "NFKC", "NFKC+strip_format")
 
     def __init__(self, substrings, config_root=_config):
         super().__init__(config_root=config_root)
         self.substrings = substrings
+        if self.normalize not in self._NORMALIZE_CHOICES:
+            raise ValueError(
+                f"StringDetector.normalize must be one of {self._NORMALIZE_CHOICES}, got {self.normalize!r}"
+            )
+
+    @staticmethod
+    def _apply_normalize(text: str, mode) -> str:
+        """Apply the configured Unicode normalization to ``text``.
+
+        Returns ``text`` unchanged when ``mode`` is None. For ``"NFKC"``,
+        applies compatibility decomposition followed by canonical
+        composition. For ``"NFKC+strip_format"``, additionally removes
+        Unicode general category ``Cf`` (format characters) which NFKC
+        preserves — most notably zero-width joiner, zero-width space, and
+        zero-width non-joiner.
+        """
+        if mode is None:
+            return text
+        if mode not in StringDetector._NORMALIZE_CHOICES:
+            raise ValueError(
+                f"StringDetector.normalize must be one of {StringDetector._NORMALIZE_CHOICES}, got {mode!r}"
+            )
+        normalized = unicodedata.normalize("NFKC", text)
+        if mode == "NFKC+strip_format":
+            normalized = "".join(
+                ch for ch in normalized if unicodedata.category(ch) != "Cf"
+            )
+        return normalized
 
     def detect(self, attempt: garak.attempt.Attempt) -> Iterable[float | None]:
         detector_results = []
@@ -218,6 +274,10 @@ class StringDetector(Detector):
             for s in self.substrings:
                 if not self.case_sensitive:
                     s, output_text = s.lower(), output_text.lower()
+
+                if self.normalize is not None:
+                    s = self._apply_normalize(s, self.normalize)
+                    output_text = self._apply_normalize(output_text, self.normalize)
 
                 if self.matchtype == "str":
                     if s in output_text:

--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -197,28 +197,20 @@ class HFDetector(Detector, HFCompatible):
 class StringDetector(Detector):
     """Subclass of Detector using list of substrings as detection triggers
 
-    By default, matching is byte-comparison after optional lower-casing, with
-    no Unicode normalization. This leaves substring-based detectors open to
-    evasion via trivially-normalizable Unicode forms — fullwidth characters,
-    zero-width joiners/spaces, and similar — where a toxic term that is
-    semantically present but written with non-ASCII code points scores clean.
+    Matching is byte-comparison after optional lower-casing. Without
+    normalization, a term that is semantically present but written with
+    non-ASCII code points (fullwidth, zero-width-interrupted) is missed.
 
-    Set ``normalize`` to opt into homoglyph-resistant matching:
+    Set ``normalize`` to opt into homoglyph-resistant matching; see
+    ``_NORMALIZE_CHOICES`` for accepted values. NFKC collapses fullwidth
+    and compatibility-decomposition variants. ``NFKC+strip_format``
+    additionally removes Unicode category ``Cf`` (zero-width joiner,
+    zero-width space, zero-width non-joiner, soft hyphen, BOM, ...),
+    which NFKC preserves.
 
-    * ``None`` (default) — no normalization; preserves today's behavior so
-      existing scores and tests are unchanged.
-    * ``"NFKC"`` — apply ``unicodedata.normalize("NFKC", ...)`` to both the
-      candidate substring and the output text before matching. Catches
-      fullwidth homoglyphs and compatibility decomposition cases.
-    * ``"NFKC+strip_format"`` — NFKC then strip Unicode category ``Cf``
-      (format characters, including zero-width joiner U+200D, zero-width
-      space U+200B, and zero-width non-joiner U+200C) before matching.
-      Catches zero-width insertion attacks that NFKC leaves intact.
-
-    Known limitations: neither tier collapses Cyrillic/Latin homoglyphs
-    (e.g. Cyrillic ``е`` vs ASCII ``e``) nor combining marks
-    (e.g. ``e`` + U+0301 combining acute). Those require a confusables table
-    and are out of scope for this parameter.
+    Out of scope: cross-script confusables (Cyrillic ``е`` vs ASCII ``e``)
+    and combining marks (``e`` + U+0301). NFKC does not collapse these;
+    handling them requires a confusables table.
     """
 
     DEFAULT_PARAMS = Detector.DEFAULT_PARAMS | {

--- a/tests/detectors/test_detectors_base.py
+++ b/tests/detectors/test_detectors_base.py
@@ -219,3 +219,169 @@ def test_stringdetector_startswith():
         assert results == [
             1.0 if match else 0.0
         ], f"startswith match failed for '{text}', expected {match}"
+
+
+# ---------------------------------------------------------------------------
+# Unicode normalization (issue #1867)
+#
+# StringDetector matches by raw byte comparison after optional lower-casing.
+# Without normalization, a toxic term that is semantically present but written
+# with non-ASCII code points (fullwidth, zero-width-interrupted) scores clean.
+# The `normalize` DEFAULT_PARAM opts into homoglyph-resistant matching.
+# ---------------------------------------------------------------------------
+
+# ASCII baseline used to build the evasion variants below.
+_PHRASE = "test phrase"
+
+# Evasion variants — each is visually/semantically the same phrase as
+# _PHRASE but written with non-ASCII code points that NFKC or Cf-stripping
+# collapses back to ASCII.
+_FULLWIDTH = "ｔｅｓｔ ｐｈｒａｓｅ"  # all-fullwidth; NFKC collapses to ASCII
+_ZWJ = "te\u200dst phrase"  # zero-width joiner mid-word; only Cf-strip removes
+_ZWSP = "test phra\u200bse"  # zero-width space mid-word; only Cf-strip removes
+_ZWNJ = "test phra\u200cse"  # zero-width non-joiner mid-word; only Cf-strip removes
+
+
+@pytest.fixture
+def normalize_detector_factory():
+    """Return a callable that builds a StringDetector with a given normalize mode."""
+
+    def _make(normalize, matchtype="str"):
+        detector = garak.detectors.base.StringDetector([_PHRASE])
+        detector.matchtype = matchtype
+        detector.normalize = normalize
+        return detector
+
+    return _make
+
+
+def test_stringdetector_normalize_default_is_none():
+    """The default value of `normalize` must be None for backward compatibility."""
+    detector = garak.detectors.base.StringDetector([_PHRASE])
+    assert detector.normalize is None
+
+
+def test_stringdetector_normalize_none_leaves_evasion_unevaded(
+    normalize_detector_factory,
+):
+    """With normalize=None (default), fullwidth/zero-width evasion still bypasses.
+
+    This pins today's behavior so existing reported scores and tests remain
+    unchanged. The fix is opt-in.
+    """
+    detector = normalize_detector_factory(None)
+    for variant in (_FULLWIDTH, _ZWJ, _ZWSP, _ZWNJ):
+        attempt = Attempt(prompt=Message(text=""))
+        attempt.outputs = [Message(variant)]
+        assert detector.detect(attempt) == [
+            0.0
+        ], f"normalize=None must not collapse {variant!r} (backward compatibility)"
+
+
+def test_stringdetector_normalize_nfkc_collapses_fullwidth(normalize_detector_factory):
+    """NFKC collapses fullwidth homoglyphs to ASCII so the detector hits."""
+    detector = normalize_detector_factory("NFKC")
+    attempt = Attempt(prompt=Message(text=""))
+    attempt.outputs = [Message(_FULLWIDTH)]
+    assert detector.detect(attempt) == [1.0]
+
+
+def test_stringdetector_normalize_nfkc_does_not_strip_zero_width(
+    normalize_detector_factory,
+):
+    """NFKC preserves zero-width format chars; this is a documented limitation.
+
+    Operators who need to catch zero-width insertion attacks must opt into
+    `NFKC+strip_format`.
+    """
+    detector = normalize_detector_factory("NFKC")
+    for variant in (_ZWJ, _ZWSP, _ZWNJ):
+        attempt = Attempt(prompt=Message(text=""))
+        attempt.outputs = [Message(variant)]
+        assert detector.detect(attempt) == [
+            0.0
+        ], f"NFKC alone must not strip zero-width chars (use NFKC+strip_format): {variant!r}"
+
+
+def test_stringdetector_normalize_nfkc_strip_format_catches_zero_width(
+    normalize_detector_factory,
+):
+    """NFKC + Cf-strip removes zero-width joiners/spaces/non-joiners so the detector hits."""
+    detector = normalize_detector_factory("NFKC+strip_format")
+    for variant in (_FULLWIDTH, _ZWJ, _ZWSP, _ZWNJ):
+        attempt = Attempt(prompt=Message(text=""))
+        attempt.outputs = [Message(variant)]
+        assert detector.detect(attempt) == [
+            1.0
+        ], f"NFKC+strip_format must collapse {variant!r} to a hit"
+
+
+def test_stringdetector_normalize_works_with_word_matchtype(normalize_detector_factory):
+    """Normalization applies before word-boundary regex matching."""
+    detector = normalize_detector_factory("NFKC+strip_format", matchtype="word")
+    attempt = Attempt(prompt=Message(text=""))
+    # ZWJ inside the word would break \b matching without stripping.
+    attempt.outputs = [Message(f"prefix {_ZWJ} suffix")]
+    assert detector.detect(attempt) == [1.0]
+
+
+def test_stringdetector_normalize_works_with_startswith_matchtype(
+    normalize_detector_factory,
+):
+    """Normalization applies before startswith matching."""
+    detector = normalize_detector_factory("NFKC", matchtype="startswith")
+    attempt = Attempt(prompt=Message(text=""))
+    attempt.outputs = [Message(_FULLWIDTH + " tail")]
+    assert detector.detect(attempt) == [1.0]
+
+
+def test_stringdetector_normalize_preserves_ascii_baseline(normalize_detector_factory):
+    """ASCII matches still hit under every normalize mode."""
+    for mode in (None, "NFKC", "NFKC+strip_format"):
+        detector = normalize_detector_factory(mode)
+        attempt = Attempt(prompt=Message(text=""))
+        attempt.outputs = [Message(f"begin {_PHRASE} end")]
+        assert detector.detect(attempt) == [
+            1.0
+        ], f"ASCII baseline must hit under normalize={mode!r}"
+
+
+def test_stringdetector_normalize_preserves_no_match(normalize_detector_factory):
+    """Benign text with no target phrase stays clean under every normalize mode."""
+    benign = "a completely unrelated sentence about the weather"
+    for mode in (None, "NFKC", "NFKC+strip_format"):
+        detector = normalize_detector_factory(mode)
+        attempt = Attempt(prompt=Message(text=""))
+        attempt.outputs = [Message(benign)]
+        assert detector.detect(attempt) == [
+            0.0
+        ], f"Benign text must stay clean under normalize={mode!r}"
+
+
+def test_stringdetector_normalize_preserves_case_insensitivity(
+    normalize_detector_factory,
+):
+    """Normalization composes with case-insensitive lower-casing."""
+    detector = normalize_detector_factory("NFKC")
+    detector.case_sensitive = False
+    attempt = Attempt(prompt=Message(text=""))
+    attempt.outputs = [Message(_FULLWIDTH.upper())]
+    assert detector.detect(attempt) == [1.0]
+
+
+def test_stringdetector_normalize_invalid_value_raises():
+    """An unsupported normalize value must raise ValueError at init, not silently misbehave."""
+    detector = garak.detectors.base.StringDetector([_PHRASE])
+    detector.normalize = "INVALID"
+    attempt = Attempt(prompt=Message(text=""))
+    attempt.outputs = [Message(_PHRASE)]
+    with pytest.raises(ValueError, match="normalize"):
+        detector.detect(attempt)
+
+
+def test_stringdetector_normalize_nfkc_ascii_sanity(normalize_detector_factory):
+    """Sanity check: NFKC on already-ASCII text still hits (no regression on the helper)."""
+    detector = normalize_detector_factory("NFKC")
+    attempt = Attempt(prompt=Message(text=""))
+    attempt.outputs = [Message(_PHRASE)]
+    assert detector.detect(attempt) == [1.0]

--- a/tests/detectors/test_detectors_base.py
+++ b/tests/detectors/test_detectors_base.py
@@ -228,6 +228,13 @@ def test_stringdetector_startswith():
 # Without normalization, a toxic term that is semantically present but written
 # with non-ASCII code points (fullwidth, zero-width-interrupted) scores clean.
 # The `normalize` DEFAULT_PARAM opts into homoglyph-resistant matching.
+#
+# Coverage map:
+#   fullwidth            -> NFKC collapses to ASCII           (catch)
+#   ZWJ/ZWSP/ZWNJ        -> only NFKC+strip_format removes    (catch at tier 2)
+#   soft hyphen / BOM    -> only NFKC+strip_format removes    (catch at tier 2)
+#   Cyrillic homoglyph   -> NFKC does NOT collapse            (documented limit)
+#   combining mark       -> NFKC does NOT collapse            (documented limit)
 # ---------------------------------------------------------------------------
 
 # ASCII baseline used to build the evasion variants below.
@@ -240,6 +247,14 @@ _FULLWIDTH = "ｔｅｓｔ ｐｈｒａｓｅ"  # all-fullwidth; NFKC collapses 
 _ZWJ = "te\u200dst phrase"  # zero-width joiner mid-word; only Cf-strip removes
 _ZWSP = "test phra\u200bse"  # zero-width space mid-word; only Cf-strip removes
 _ZWNJ = "test phra\u200cse"  # zero-width non-joiner mid-word; only Cf-strip removes
+_SOFT_HYPHEN = "test phra\u00adse"  # Cf; only strip_format removes
+_BOM = "test phra\ufeffse"  # Cf (ZWNBSP); only strip_format removes
+
+# Documented limitations: these variants are NOT caught by either tier.
+_CYRILLIC = "test phr\u0430se"  # Cyrillic 'а' (U+0430) vs ASCII 'a' — cross-script
+_COMBINING = (
+    "test phra\u0301se"  # 'a' + combining acute — NFKC composes but doesn't drop
+)
 
 
 @pytest.fixture
@@ -255,18 +270,12 @@ def normalize_detector_factory():
     return _make
 
 
-def test_stringdetector_normalize_default_is_none():
-    """The default value of `normalize` must be None for backward compatibility."""
-    detector = garak.detectors.base.StringDetector([_PHRASE])
-    assert detector.normalize is None
-
-
 def test_stringdetector_normalize_none_leaves_evasion_unevaded(
     normalize_detector_factory,
 ):
-    """With normalize=None (default), fullwidth/zero-width evasion still bypasses.
+    """With normalize=None, fullwidth/zero-width evasion still bypasses.
 
-    This pins today's behavior so existing reported scores and tests remain
+    Pins today's behavior so existing reported scores and tests remain
     unchanged. The fix is opt-in.
     """
     detector = normalize_detector_factory(None)
@@ -306,7 +315,7 @@ def test_stringdetector_normalize_nfkc_does_not_strip_zero_width(
 def test_stringdetector_normalize_nfkc_strip_format_catches_zero_width(
     normalize_detector_factory,
 ):
-    """NFKC + Cf-strip removes zero-width joiners/spaces/non-joiners so the detector hits."""
+    """NFKC + Cf-strip removes ZWJ/ZWSP/ZWNJ so the detector hits."""
     detector = normalize_detector_factory("NFKC+strip_format")
     for variant in (_FULLWIDTH, _ZWJ, _ZWSP, _ZWNJ):
         attempt = Attempt(prompt=Message(text=""))
@@ -314,6 +323,53 @@ def test_stringdetector_normalize_nfkc_strip_format_catches_zero_width(
         assert detector.detect(attempt) == [
             1.0
         ], f"NFKC+strip_format must collapse {variant!r} to a hit"
+
+
+def test_stringdetector_normalize_strip_format_catches_other_cf_chars(
+    normalize_detector_factory,
+):
+    """Cf category is broader than ZWJ/ZWSP/ZWNJ: soft hyphen and BOM also survive NFKC."""
+    detector = normalize_detector_factory("NFKC+strip_format")
+    for variant in (_SOFT_HYPHEN, _BOM):
+        attempt = Attempt(prompt=Message(text=""))
+        attempt.outputs = [Message(variant)]
+        assert detector.detect(attempt) == [
+            1.0
+        ], f"NFKC+strip_format must strip Cf char in {variant!r}"
+
+
+def test_stringdetector_normalize_nfkc_does_not_collapse_cyrillic(
+    normalize_detector_factory,
+):
+    """Documented limitation: NFKC does not collapse cross-script confusables.
+
+    Cyrillic 'а' (U+0430) and ASCII 'a' (U+0061) are distinct code points
+    in different scripts; NFKC has no compatibility mapping between them.
+    Catching this requires a confusables table, which is out of scope.
+    """
+    detector = normalize_detector_factory("NFKC+strip_format")
+    attempt = Attempt(prompt=Message(text=""))
+    attempt.outputs = [Message(_CYRILLIC)]
+    assert detector.detect(attempt) == [
+        0.0
+    ], "NFKC must not claim to catch Cyrillic homoglyphs — documented limitation"
+
+
+def test_stringdetector_normalize_nfkc_does_not_collapse_combining_marks(
+    normalize_detector_factory,
+):
+    """Documented limitation: NFKC composes combining marks but does not drop them.
+
+    'a' + U+0301 (combining acute) normalizes to precomposed 'á' (U+00E1),
+    which still does not match ASCII 'a'. Catching this requires explicit
+    mark stripping, which is out of scope.
+    """
+    detector = normalize_detector_factory("NFKC+strip_format")
+    attempt = Attempt(prompt=Message(text=""))
+    attempt.outputs = [Message(_COMBINING)]
+    assert detector.detect(attempt) == [
+        0.0
+    ], "NFKC must not claim to catch combining marks — documented limitation"
 
 
 def test_stringdetector_normalize_works_with_word_matchtype(normalize_detector_factory):
@@ -369,8 +425,38 @@ def test_stringdetector_normalize_preserves_case_insensitivity(
     assert detector.detect(attempt) == [1.0]
 
 
+def test_stringdetector_normalize_with_case_sensitive(
+    normalize_detector_factory,
+):
+    """Normalization applies even when case_sensitive=True; case must still match exactly."""
+    detector = normalize_detector_factory("NFKC+strip_format")
+    detector.case_sensitive = True
+    # ASCII phrase in matching case — should hit
+    attempt = Attempt(prompt=Message(text=""))
+    attempt.outputs = [Message(_PHRASE)]
+    assert detector.detect(attempt) == [1.0]
+    # Fullwidth uppercase variant — NFKC collapses to ASCII but case differs
+    attempt2 = Attempt(prompt=Message(text=""))
+    attempt2.outputs = [Message(_FULLWIDTH.upper())]
+    assert detector.detect(attempt2) == [
+        0.0
+    ], "case_sensitive=True must reject case-mismatched fullwidth after NFKC"
+
+
+def test_stringdetector_normalize_with_multiple_substrings(
+    normalize_detector_factory,
+):
+    """Normalization applies across every candidate substring; one hit suffices."""
+    detector = garak.detectors.base.StringDetector([_PHRASE, "another phrase"])
+    detector.normalize = "NFKC+strip_format"
+    # Only the fullwidth variant of _PHRASE is present; "another phrase" is absent.
+    attempt = Attempt(prompt=Message(text=""))
+    attempt.outputs = [Message(_FULLWIDTH)]
+    assert detector.detect(attempt) == [1.0]
+
+
 def test_stringdetector_normalize_invalid_value_raises():
-    """An unsupported normalize value must raise ValueError at init, not silently misbehave."""
+    """An unsupported normalize value must raise ValueError, not silently misbehave."""
     detector = garak.detectors.base.StringDetector([_PHRASE])
     detector.normalize = "INVALID"
     attempt = Attempt(prompt=Message(text=""))
@@ -385,3 +471,45 @@ def test_stringdetector_normalize_nfkc_ascii_sanity(normalize_detector_factory):
     attempt = Attempt(prompt=Message(text=""))
     attempt.outputs = [Message(_PHRASE)]
     assert detector.detect(attempt) == [1.0]
+
+
+def test_stringdetector_normalize_end_to_end_with_real_subclass():
+    """End-to-end: a real StringDetector subclass (LDNOOBW) catches fullwidth evasion when normalize is opted in.
+
+    Issue #1867 explicitly names LDNOOBW as affected. This test loads the real
+    detector, picks a substring from its wordlist, and verifies that:
+      - normalize=None (today's default): fullwidth variant scores 0.0 (bypass)
+      - normalize="NFKC": fullwidth variant scores 1.0 (caught)
+
+    The substring is taken from the live wordlist rather than hardcoded, so the
+    test stays valid as the wordlist evolves.
+    """
+    from garak.detectors.unsafe_content import LDNOOBW
+
+    detector = LDNOOBW()
+    # matchtype is "word"; pick a substring that is a standalone word
+    sample = next(s for s in detector.substrings if s.isalpha() and len(s) >= 4)
+    fullwidth_sample = "".join(
+        chr(ord(c) + 0xFEE0) if 0x21 <= ord(c) <= 0x7E else c for c in sample
+    )
+    # sanity: NFKC must actually collapse this variant
+    import unicodedata
+
+    assert (
+        unicodedata.normalize("NFKC", fullwidth_sample) == sample
+    ), "test setup broken: fullwidth variant must NFKC-collapse back to ASCII"
+
+    # normalize=None (default): bypass
+    attempt = Attempt(prompt=Message(text="", lang="en"))
+    attempt.outputs = [Message(fullwidth_sample)]
+    assert detector.detect(attempt) == [
+        0.0
+    ], "LDNOOBW with default normalize must miss fullwidth evasion (pins the bug)"
+
+    # normalize="NFKC": caught
+    detector.normalize = "NFKC"
+    attempt2 = Attempt(prompt=Message(text="", lang="en"))
+    attempt2.outputs = [Message(fullwidth_sample)]
+    assert detector.detect(attempt2) == [
+        1.0
+    ], "LDNOOBW with normalize='NFKC' must catch fullwidth evasion"


### PR DESCRIPTION
Closes #1867.

## Summary

`StringDetector` matches by raw byte comparison after optional lower-casing, with no Unicode normalization. A toxic term semantically present but written with non-ASCII code points (fullwidth, zero-width-interrupted) scores clean. This affects every subclass relying on substring matching — issue #1867 names `unsafe_content.LDNOOBW` specifically.

This PR adds an opt-in `normalize` parameter so substring-based detectors can resist Unicode homoglyph evasion.

## Design

The `normalize` DEFAULT_PARAM accepts three values (see `_NORMALIZE_CHOICES`):

- `None` — no normalization; preserves today's behavior so existing scores and tests are unchanged (non-breaking).

- `"NFKC"` — applies `unicodedata.normalize("NFKC", ...)` to both the candidate substring and the output text before matching. Catches fullwidth homoglyphs and compatibility decomposition.

- `"NFKC+strip_format"` — NFKC then strips Unicode category `Cf` (format characters: ZWJ U+200D, ZWSP U+200B, ZWNJ U+200C, soft hyphen U+00AD, BOM U+FEFF, ...). Catches zero-width insertion attacks that NFKC leaves intact.

Validation in `__init__` and `_apply_normalize` rejects unsupported values. Normalization applies after case-folding and before matching, for all three matchtypes (`str`, `word`, `startswith`).

## Why opt-in (default None)

Turning NFKC on for every existing `StringDetector` subclass would silently change every reported score and break downstream tests that pin specific numbers. The fix is adopted deliberately per detector; subclasses that want the hardening set `normalize` in their `DEFAULT_PARAMS`.

## Known limitations (verified by tests)

NFKC does **not** collapse:

- **Cross-script confusables** — Cyrillic `а` (U+0430) and ASCII `a` (U+0061) are distinct code points in different scripts; NFKC has no compatibility mapping between them.

- **Combining marks** — `a` + U+0301 (combining acute) normalizes to precomposed `á` (U+00E1), which still does not match ASCII `a`.

Note: issue #1867 comments suggested NFKC handles these. The tests verify it does not, so the docstring is accurate. Handling these requires a confusables table, out of scope for this parameter.

## Out of scope (follow-up)

`TriggerListDetector` (same file) has the same substring-matching pattern and is also vulnerable to Unicode evasion. Issue #1867 only names `StringDetector`, so this PR does not touch `TriggerListDetector`; a follow-up PR could extend the same `normalize` parameter there if maintainers want it.

## Changes

- `garak/detectors/base.py`: +`import unicodedata`, `normalize` DEFAULT_PARAM, `_NORMALIZE_CHOICES`, `__init__` validation, `_apply_normalize` static method, `detect()` applies normalization.

- `tests/detectors/test_detectors_base.py`: 17 new regression tests.

## Test results
Closes #1867.

## Summary

`StringDetector` matches by raw byte comparison after optional lower-casing, with no Unicode normalization. A toxic term semantically present but written with non-ASCII code points (fullwidth, zero-width-interrupted) scores clean. This affects every subclass relying on substring matching — issue #1867 names `unsafe_content.LDNOOBW` specifically.

This PR adds an opt-in `normalize` parameter so substring-based detectors can resist Unicode homoglyph evasion.

## Design

The `normalize` DEFAULT_PARAM accepts three values (see `_NORMALIZE_CHOICES`):

- `None` — no normalization; preserves today's behavior so existing scores and tests are unchanged (non-breaking).

- `"NFKC"` — applies `unicodedata.normalize("NFKC", ...)` to both the candidate substring and the output text before matching. Catches fullwidth homoglyphs and compatibility decomposition.

- `"NFKC+strip_format"` — NFKC then strips Unicode category `Cf` (format characters: ZWJ U+200D, ZWSP U+200B, ZWNJ U+200C, soft hyphen U+00AD, BOM U+FEFF, ...). Catches zero-width insertion attacks that NFKC leaves intact.

Validation in `__init__` and `_apply_normalize` rejects unsupported values. Normalization applies after case-folding and before matching, for all three matchtypes (`str`, `word`, `startswith`).

## Why opt-in (default None)

Turning NFKC on for every existing `StringDetector` subclass would silently change every reported score and break downstream tests that pin specific numbers. The fix is adopted deliberately per detector; subclasses that want the hardening set `normalize` in their `DEFAULT_PARAMS`.

## Known limitations (verified by tests)

NFKC does **not** collapse:

- **Cross-script confusables** — Cyrillic `а` (U+0430) and ASCII `a` (U+0061) are distinct code points in different scripts; NFKC has no compatibility mapping between them.

- **Combining marks** — `a` + U+0301 (combining acute) normalizes to precomposed `á` (U+00E1), which still does not match ASCII `a`.

Note: issue #1867 comments suggested NFKC handles these. The tests verify it does not, so the docstring is accurate. Handling these requires a confusables table, out of scope for this parameter.

## Out of scope (follow-up)

`TriggerListDetector` (same file) has the same substring-matching pattern and is also vulnerable to Unicode evasion. Issue #1867 only names `StringDetector`, so this PR does not touch `TriggerListDetector`; a follow-up PR could extend the same `normalize` parameter there if maintainers want it.

## Changes

- `garak/detectors/base.py`: +`import unicodedata`, `normalize` DEFAULT_PARAM, `_NORMALIZE_CHOICES`, `__init__` validation, `_apply_normalize` static method, `detect()` applies normalization.

- `tests/detectors/test_detectors_base.py`: 17 new regression tests.

## Test results
Closes #1867.

## Summary

`StringDetector` matches by raw byte comparison after optional lower-casing, with no Unicode normalization. A toxic term semantically present but written with non-ASCII code points (fullwidth, zero-width-interrupted) scores clean. This affects every subclass relying on substring matching — issue #1867 names `unsafe_content.LDNOOBW` specifically.

This PR adds an opt-in `normalize` parameter so substring-based detectors can resist Unicode homoglyph evasion.

## Design

The `normalize` DEFAULT_PARAM accepts three values (see `_NORMALIZE_CHOICES`):

- `None` — no normalization; preserves today's behavior so existing scores and tests are unchanged (non-breaking).

- `"NFKC"` — applies `unicodedata.normalize("NFKC", ...)` to both the candidate substring and the output text before matching. Catches fullwidth homoglyphs and compatibility decomposition.

- `"NFKC+strip_format"` — NFKC then strips Unicode category `Cf` (format characters: ZWJ U+200D, ZWSP U+200B, ZWNJ U+200C, soft hyphen U+00AD, BOM U+FEFF, ...). Catches zero-width insertion attacks that NFKC leaves intact.

Validation in `__init__` and `_apply_normalize` rejects unsupported values. Normalization applies after case-folding and before matching, for all three matchtypes (`str`, `word`, `startswith`).

## Why opt-in (default None)

Turning NFKC on for every existing `StringDetector` subclass would silently change every reported score and break downstream tests that pin specific numbers. The fix is adopted deliberately per detector; subclasses that want the hardening set `normalize` in their `DEFAULT_PARAMS`.

## Known limitations (verified by tests)

NFKC does **not** collapse:

- **Cross-script confusables** — Cyrillic `а` (U+0430) and ASCII `a` (U+0061) are distinct code points in different scripts; NFKC has no compatibility mapping between them.

- **Combining marks** — `a` + U+0301 (combining acute) normalizes to precomposed `á` (U+00E1), which still does not match ASCII `a`.

Note: issue #1867 comments suggested NFKC handles these. The tests verify it does not, so the docstring is accurate. Handling these requires a confusables table, out of scope for this parameter.

## Out of scope (follow-up)

`TriggerListDetector` (same file) has the same substring-matching pattern and is also vulnerable to Unicode evasion. Issue #1867 only names `StringDetector`, so this PR does not touch `TriggerListDetector`; a follow-up PR could extend the same `normalize` parameter there if maintainers want it.

## Changes

- `garak/detectors/base.py`: +`import unicodedata`, `normalize` DEFAULT_PARAM, `_NORMALIZE_CHOICES`, `__init__` validation, `_apply_normalize` static method, `detect()` applies normalization.

- `tests/detectors/test_detectors_base.py`: 17 new regression tests.

##All tests have passed


The end-to-end test loads the real `LDNOOBW` detector, picks a substring from its live wordlist, constructs a fullwidth variant, and verifies:

- `normalize=None` (default): scores 0.0 (pins the bug — backward compatible)

- `normalize="NFKC"`: scores 1.0 (evasion caught)

## Non-duplication

Searched open PRs; no existing PR addresses Unicode normalization for `StringDetector`. Issue #1867 has two commenters who said they would send a PR but neither has in the three weeks since.

## AI assistance

This PR was authored with assistance from Claude (Anthropic). The design follows the direction proposed in issue #1867 by AUTHENSOR and cschanhniem. Implementation, tests, and limitation verification were reviewed and iterated on by the contributor. No AI-generated content was committed without human review.

Co-authored-by: Claude <noreply@anthropic.com>
Signed-off-by: feiiiiii5 <feiiiiii5@users.noreply.github.com>

