### PR TITLE
docs: add OWASP LLM Top 10 mapping tutorial

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -39,6 +39,7 @@ Check out the :doc:`usage` section for further information, including :doc:`inst
    cliref
    reporting
    faster
+   owasp_top10
    FAQ <https://github.com/NVIDIA/garak/blob/main/FAQ.md>
 
 .. toctree::

--- a/docs/source/owasp_top10.rst
+++ b/docs/source/owasp_top10.rst
@@ -1,0 +1,81 @@
+Mapping a garak scan to the OWASP LLM Top 10
+==============================================
+
+This walkthrough shows how to run garak against a target model and interpret the
+results in terms of the `OWASP Top 10 for Large Language Model Applications
+<https://owasp.org/www-project-top-10-for-large-language-model-applications/>`_ —
+the de-facto industry taxonomy of LLM security risks.
+
+It is aimed at defenders: security engineers, red teams operating under written
+authorization, and anyone hardening an LLM-powered product.
+
+Why map to OWASP?
+-----------------
+
+garak organises its checks by *probe* and *detector*. The OWASP list organises
+risk by *impact category*. Mapping one to the other lets you hand a non-technical
+stakeholder a report that reads "we tested for LLM01 (Prompt Injection) and
+LLM07 (System Prompt Leakage)" instead of "we ran probe X and detector Y".
+
+The ten categories
+------------------
+
+==========  ============================================
+OWASP ID    Risk
+==========  ============================================
+LLM01       Prompt Injection
+LLM02       Sensitive Information Disclosure
+LLM03       Supply Chain Vulnerabilities
+LLM04       Data and Model Poisoning
+LLM05       Improper Output Handling
+LLM06       Excessive Agency
+LLM07       System Prompt Leakage
+LLM08       Vector and Embedding Weaknesses
+LLM09       Misinformation
+LLM10       Unbounded Consumption
+==========  ============================================
+
+Running a focused scan
+-----------------------
+
+The example below targets a local model served over a REST endpoint. Replace the
+``rest*`` generator with whichever garak generator matches your target (see
+:doc:`generators/index`).
+
+.. code-block:: bash
+
+   # Scan for prompt injection (LLM01) and system-prompt leakage (LLM07)
+   python -m garak -m rest -n <your_endpoint> \
+       --probes prompt_injection,leakage
+
+Run ``python -m garak --list_probes`` to see every available probe, and
+``python -m garak --list_detectors`` for the detectors that score the outputs.
+
+Reading the results
+-------------------
+
+garak prints a per-probe pass/fail table and writes a full report. A *fail*
+means the target model behaved in a way we do not want — i.e. it was vulnerable
+to that probe.
+
+================  ============================================================
+Probe family      Maps to OWASP
+================  ============================================================
+prompt_injection  LLM01 Prompt Injection
+leakage           LLM07 System Prompt Leakage
+donotanswer       LLM01 / LLM02 (refusal robustness)
+encoding          LLM01 (multilingual / encoding evasion)
+xss               LLM05 Improper Output Handling
+================  ============================================================
+
+This table is not exhaustive; garak ships many more probes. The principle is the
+same: each probe tests a behaviour, and that behaviour corresponds to one or more
+OWASP categories. When you report findings, cite both the garak probe name and
+the OWASP ID so the reader can look up remediation guidance on the OWASP site.
+
+Responsible disclosure
+---------------------
+
+Only scan systems you are authorized to test. Garak is a research and defense
+tool; findings should be reported to the affected party under a coordinated
+disclosure window before any public release.


### PR DESCRIPTION
## Summary
Adds a new tutorial, `docs/source/owasp_top10.rst`, showing defenders how to run garak against a target and interpret results against the **OWASP LLM Top 10** (LLM01–LLM10). Wired into the "Using garak" toctree in `index.rst`.

The tutorial maps garak probe families (e.g. `prompt_injection`, `leakage`) to the corresponding OWASP category, so findings can be reported to non-technical stakeholders in industry-standard language. It is framed for **defenders / authorized red teams** and includes a responsible-disclosure note.

## Not duplicating an existing PR
Checked open PRs (`gh pr list --repo nvidia/garak --state open`); no open PR adds an OWASP Top 10 walkthrough. Related PRs (#1920 retag, #1856 intent stubs) are unrelated to this doc.

## AI assistance disclosure
This contribution was prepared with AI assistance (SEB). The submitting human (Malik) has reviewed every changed line. Changes are documentation-only (a new `.rst` + one toctree entry); no code or test behaviour is altered.

## Test commands run
- `git status` / `git diff --stat` confirm only the two doc files changed.
- `.rst` content reviewed for valid reStructuredText.
- No existing tests affected (doc-only change).

Co-authored-by: SEB (AI assistance)
Signed-off-by: Malik <malik@seb.security>