### PR TITLE
fix(analyze): guard analyze_log against zero total_evaluated

### DIFF
--- a/garak/analyze/analyze_log.py
+++ b/garak/analyze/analyze_log.py
@@ -82,7 +82,11 @@ def analyze_log(report_path: str) -> None:
                                 record["probe"],
                                 record["detector"],
                                 "%0.4f"
-                                % (record["passed"] / record["total_evaluated"]),
+                                % (
+                                    record["passed"] / record["total_evaluated"]
+                                    if record["total_evaluated"]
+                                    else 0
+                                ),
                                 record["total_processed"],
                             ],
                         )

--- a/tests/analyze/test_analyze.py
+++ b/tests/analyze/test_analyze.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from pathlib import Path
+import json
 import subprocess
 import sys
 
@@ -34,6 +35,35 @@ def test_analyze_log_runs():
         check=True,
     )
     assert result.returncode == 0
+
+
+def test_analyze_log_zero_total_evaluated(tmp_path):
+    """analyze_log must not crash on an eval record with total_evaluated == 0.
+
+    A detector returning all-None scores yields passed == fails == 0, so the
+    evaluator writes a valid eval record with total_evaluated == 0. The pass
+    rate for such a record is reported as 0.0000 rather than raising."""
+    from garak.analyze.analyze_log import analyze_log
+
+    report_path = tmp_path / "zero_eval.report.jsonl"
+    report_path.write_text(
+        json.dumps(
+            {
+                "entry_type": "eval",
+                "probe": "test.Blank",
+                "detector": "always.Fail",
+                "passed": 0,
+                "total_evaluated": 0,
+                "fails": 0,
+                "total_processed": 3,
+                "nones": 3,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    analyze_log(str(report_path))  # must not raise ZeroDivisionError
 
 
 def test_report_digest_runs():


### PR DESCRIPTION

```markdown
### What this does

`garak.analyze.analyze_log` (the `python -m garak.analyze.analyze_log <report>`
CLI) crashes with `ZeroDivisionError` on a valid, complete report whenever an
eval record has `total_evaluated == 0`.

For each eval record it prints the pass rate as:

```python
"%0.4f" % (record["passed"] / record["total_evaluated"])
```

with no zero guard. A `total_evaluated == 0` record is legitimately produced,
not corrupt input: when a detector returns all-`None` scores the evaluator
records `passed == fails == 0`, so `total_evaluated == 0`
(`garak/evaluators/base.py`), and that eval record is written to the report
unconditionally. The evaluator's own summary printer already treats this state
as normal (it guards the same quantity with `if evals:`), so a fully valid,
uninterrupted report can contain such records and `analyze_log` then aborts on
them.

This guards the denominator and reports the pass rate for such a record as
`0.0000`, matching the guard already used for the identical
`passed / total_evaluated` ratio elsewhere in the codebase:

- `garak/analyze/report_digest.py` : `passes / instances if instances else 0`
- `garak/report.py` : `np.where(total_evaluated != 0, ..., 0)`
- `garak/analyze/perf_stats.py` : `if r["total_evaluated"] != 0: ...`

`analyze_log.py` was the sole unguarded consumer. Normal records are
unaffected (`passed 4 / total 8` still prints `0.5000`).

### Not a duplicate

Checked open and closed PRs/issues on `NVIDIA/garak`:

- `gh pr list --state open --search "analyze_log"` -> none
- `gh pr list --state open --search "total_evaluated"` -> only #1718
  (`harnesses/base.py` detector-skip logging) and #1523 (a new
  `check_report_quality.py` script); verified neither touches
  `garak/analyze/analyze_log.py`.
- `gh pr list --state open --search "ZeroDivisionError"` -> none

No open PR addresses this crash.

### Verification

Environment: local venv, garak 0.15.2.pre1, Python 3.11.

- Reproduced pre-fix: feeding `analyze_log` a report whose eval line is
  `{"passed": 0, "total_evaluated": 0, ...}` raises
  `ZeroDivisionError: division by zero` (exit code 1).
- Red -> green: with the source reverted to the unguarded expression the new
  test fails with that `ZeroDivisionError`; with the fix applied it passes.
- Post-fix behaviour: a report containing both a `total_evaluated == 0` record
  and a normal `passed 4 / total 8` record prints `0.0000` and `0.5000`
  respectively, no traceback, exit code 0.
- `python -m pytest tests/analyze/test_analyze.py` -> 7 passed
- `python -m pytest tests/analyze/` -> 142 passed (no regressions)
- `python -m pytest tests/evaluators/` -> 54 passed (the bug's origin module)
- `black --check garak/analyze/analyze_log.py tests/analyze/test_analyze.py`
  -> unchanged (line-length 88)

### AI assistance

This change was made with AI assistance. I have reviewed every changed line,
reproduced the crash, and run the tests above.
```

## PR-template checklist mapping (`.github/pull_request_template.md`)

The upstream template's Verification checklist maps as:

- [x] Run the tests and ensure they pass `python -m pytest tests/` -> ran the
      relevant scoped suites (`tests/analyze/`, `tests/evaluators/`); all green.
- [x] Verify the thing does what it should -> zero-case prints `0.0000`.
- [x] Verify the thing does not do what it should not -> no `ZeroDivisionError`;
      normal records still print their real rate (`0.5000`).
- n/a Generator config / `garak -t ... -n ...` / hardware notes: this is a
      report-analysis CLI fix, no target run or special hardware involved.
- Documentation: behaviour is self-documenting via the regression test's
  docstring; no architecture doc change needed for a bugfix.

## Compliance checks (garak AGENTS.md)

- Cohesive PR, single focus (one crash), only related files touched. Yes.
- Not busywork: fixes a real hard crash in a shipped CLI. Yes.
- No new dependencies. Yes.
- Catches no broad exceptions; no `attempt`/base-class edits. Yes.
- Prefer pathlib: test writes the fixture via `tmp_path` (a `Path`). Yes.
- Test in the existing analyze test file (extends `test_analyze.py`, alongside
  `test_analyze_log_runs`). Consistent with the file's convention.
- Commit trailers: `Co-authored-by: Claude` + `Signed-off-by:` (DCO). Yes.
- No issue number in the title. Yes.
- British-English / CLI-emoji style: no user-facing strings added, so N/A.

## Ship steps (only on explicit `loop.sh ship`)

1. `git fetch origin main` and confirm `patch-4` is still 0 behind (rebase only
   if upstream advanced onto `analyze_log.py`; conflict extremely unlikely).
2. Push branch to the `fork` remote (anxkhn/garak), head `anxkhn:patch-4`.
3. Open PR to `NVIDIA/garak:main` with the title + body above.
