### PR TITLE
Escape substrings in StringDetector word matchtype

### DIFF
--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -223,7 +223,7 @@ class StringDetector(Detector):
                     if s in output_text:
                         match = True
                 elif self.matchtype == "word":
-                    if re.search(r"\b" + s + r"\b", output_text):
+                    if re.search(r"\b" + re.escape(s) + r"\b", output_text):
                         match = True
                 elif self.matchtype == "startswith":
                     if output_text.startswith(s):

--- a/tests/detectors/test_detectors_base.py
+++ b/tests/detectors/test_detectors_base.py
@@ -125,6 +125,25 @@ def test_none_outputs(string_detector):
     assert results == [None, 1.0, None], "Failed to handle None outputs correctly"
 
 
+def test_word_matchtype_treats_substring_as_literal():
+    """`word` matchtype must match substrings literally, not as regex.
+
+    Substrings come from literal wordlists that can contain regex
+    metacharacters. Without escaping, ``\\b`` + s + ``\\b`` interprets those
+    metacharacters: ``a.c`` matches ``abc`` (false positive) and ``c$t`` can
+    never match (false negative), producing wrong detector scores.
+    """
+    detector = garak.detectors.base.StringDetector(["a.c", "c$t"])
+    detector.matchtype = "word"
+    attempt = Attempt(prompt=Message(text="hi"))
+    attempt.outputs = [Message("abc"), Message("a.c"), Message("c$t")]
+
+    results = detector.detect(attempt)
+
+    # "abc" is not the literal "a.c"; "a.c" and "c$t" are literal matches.
+    assert results == [0.0, 1.0, 1.0]
+
+
 MATCHTYPE_AND_CASING_CASES = {
     "str": [
         (f"begin {TEST_STRINGS[0]}ing", True),  # should match


### PR DESCRIPTION
## What

`StringDetector`'s `word` matchtype builds its pattern by splicing the substring straight into a regex without escaping:

```python
# garak/detectors/base.py, matchtype == "word"
if re.search(r"\b" + s + r"\b", output_text):
```

Substrings for these detectors are **literal terms** loaded from wordlists (there is no `regex` matchtype — only `str`, `word`, `startswith`), and several shipped terms contain regex metacharacters. That corrupts the pattern's meaning, producing wrong detector scores:

- `a.c` → `\ba.c\b` matches `abc` (the `.` is treated as any-char) → **false positive**
- `c$t` → `\bc$t\b` can never match (the `$` is treated as an end anchor) → **false negative**

This is not hypothetical: `unsafe_content.SurgeProfanitySexual` (and sibling Surge/Ofcom profanity detectors) subclass `StringDetector` with `matchtype="word"` and draw their terms directly from the shipped `data/profanity_en.csv`, which contains leetspeak terms like `pu$sy`, `c*nt`, `d!ck`, etc. Those detectors currently mis-score outputs — missing the literal terms and matching benign tokens — during a normal scan (e.g. `garak -p lmrc.SexualContent`).

## Fix

Escape the substring before wrapping it in word boundaries:

```python
if re.search(r"\b" + re.escape(s) + r"\b", output_text):
```

`re.escape` is a no-op for plain alphanumeric terms, so detectors whose wordlists contain no metacharacters are unaffected — this only restores correct **literal** matching for the `word` matchtype, consistent with its purpose.

## Test

Added `test_word_matchtype_treats_substring_as_literal`: with substrings `["a.c", "c$t"]` and `matchtype="word"`, `"abc"` must score `0.0` (not a literal `a.c`) while `"a.c"` and `"c$t"` score `1.0`. The test fails before the change (`[1.0, 1.0, 0.0]`) and passes after. Full `tests/detectors/test_detectors_base.py` + `test_detectors_unsafe_content.py` pass; `black --check` clean.

---
*Disclosure: this contribution was prepared with the assistance of an AI agent (Claude Code). The analysis, fix, and test were reviewed by me before submission.*