### PR TITLE
Guard nvcf 500 error parsing against non-JSON bodies

### DIFF
--- a/garak/generators/nvcf.py
+++ b/garak/generators/nvcf.py
@@ -80,6 +80,23 @@ class NvcfChat(Generator):
     def _extract_text_output(self, response) -> str:
         return [c["message"]["content"] for c in response["choices"]]
 
+    @staticmethod
+    def _is_input_value_error(response) -> bool:
+        """Whether a 500 response is a skippable "Input value error".
+
+        A 500 body is not guaranteed to be JSON (a gateway/proxy in front of
+        the function may return an HTML/text error page) or to carry a string
+        ``detail``, so parse defensively. Anything we can't confirm as an
+        input-value error is treated as a genuine server error and falls
+        through to ``raise_for_status`` rather than crashing the scan with an
+        uncaught ``JSONDecodeError``/``KeyError``.
+        """
+        try:
+            detail = json.loads(response.content)["detail"]
+        except (json.JSONDecodeError, KeyError, TypeError):
+            return False
+        return isinstance(detail, str) and detail.startswith("Input value error")
+
     @backoff.on_exception(
         backoff.fibo,
         (
@@ -136,9 +153,7 @@ class NvcfChat(Generator):
                 print("nvcf :", response.content)
                 raise BadGeneratorException()
             if response.status_code >= 500:
-                if response.status_code == 500 and json.loads(response.content)[
-                    "detail"
-                ].startswith("Input value error"):
+                if response.status_code == 500 and self._is_input_value_error(response):
                     logging.warning("nvcf : skipping this prompt")
                     return [None]
                 else:

--- a/tests/generators/test_nvcf.py
+++ b/tests/generators/test_nvcf.py
@@ -115,3 +115,25 @@ def test_nonblank_prompt_400_not_caught_by_blank_guard(klassname, monkeypatch, c
     assert (
         "skipping this prompt" in caplog.text
     ), "a non-blank 400 must fall through to the generic skip path, not the blank guard"
+
+
+@pytest.mark.parametrize(
+    "content,expected",
+    [
+        (b'{"detail": "Input value error: blank prompt"}', True),
+        (b'{"detail": "some other server error"}', False),
+        (b"<html><body>502 Bad Gateway</body></html>", False),  # non-JSON body
+        (b"", False),  # empty body
+        (b"{}", False),  # JSON without a 'detail' key
+        (b'{"detail": {"nested": "obj"}}', False),  # non-string detail
+    ],
+)
+def test_nvcf_is_input_value_error_parses_defensively(content, expected):
+    """A 500 body that is non-JSON or lacks a string 'detail' must not crash.
+
+    Before guarding, json.loads(response.content)["detail"].startswith(...)
+    raised an uncaught JSONDecodeError/KeyError/AttributeError on such bodies,
+    aborting the whole scan instead of falling through to raise_for_status.
+    """
+    response = _FakeResponse(500, content)
+    assert garak.generators.nvcf.NvcfChat._is_input_value_error(response) is expected


### PR DESCRIPTION
On an HTTP 500, `NvcfChat._call_model` parsed the error body unconditionally:

```python
if response.status_code == 500 and json.loads(response.content)["detail"].startswith("Input value error"):
```

A 500 body is not guaranteed to be JSON — a gateway/proxy/load balancer in front of the NVCF function commonly returns an HTML or plain-text error page — and even when JSON it may not carry a string `detail`. In those cases this line raises an uncaught `json.JSONDecodeError` (a `ValueError`), `KeyError`, or `AttributeError`.

None of those is in the `@backoff.on_exception` tuple (`AttributeError` is, but `JSONDecodeError`/`KeyError` are not, and the string `.startswith` on a non-str `detail` is the `AttributeError` path), so on a long scan a single such 500 propagates out of `_call_model` and **aborts the whole run** instead of being retried or skipped — the top-level handler just logs and exits.

## Fix

Extract the check into a defensive `_is_input_value_error(response)` helper. Anything that can't be confirmed as an input-value error (non-JSON body, missing/`non-string` `detail`, or a different message) returns `False` and falls through to the **existing** `raise_for_status()` path — i.e. it's treated as a genuine server error and retried by backoff, exactly as any other unrecognized 5xx already is. Behaviour for a well-formed `"Input value error"` 500 (skip → `[None]`) is unchanged.

## Verification

- [x] Added `test_nvcf_is_input_value_error_parses_defensively`, parametrized over: a well-formed input-value error (→ `True`), a different message, a non-JSON body, an empty body, JSON without `detail`, and a non-string `detail` (all → `False`). Each of the last four would previously have raised inside the parse. Full `tests/generators/test_nvcf.py` passes; `black --check` clean.
- [ ] `garak -t <target_type> -n <model_name>` — **not run**: this is a unit-level fix and I have no live target configured; verified via the tests above rather than ticking a box I didn't exercise.
- [ ] Supporting configuration such as a generator configuration file — n/a, no config surface changed.

---
*Disclosure: this contribution was prepared with the assistance of an AI agent (Claude Code). The analysis, fix, and tests were reviewed by me before submission.*
