### PR TITLE
Return a single Message from InferenceEndpoint._call_model

### DIFF
--- a/garak/generators/replicate.py
+++ b/garak/generators/replicate.py
@@ -119,7 +119,7 @@ class InferenceEndpoint(ReplicateGenerator):
             raise IOError(
                 "Replicate endpoint didn't generate an Iterable[str]-type response. Make sure the endpoint is active."
             ) from exc
-        return [Message(r) for r in response]
+        return [Message(response)]
 
 
 DEFAULT_CLASS = "ReplicateGenerator"

--- a/tests/generators/test_replicate.py
+++ b/tests/generators/test_replicate.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import MagicMock
+
+from garak.attempt import Message, Turn, Conversation
+import garak.generators.replicate
+
+
+def test_inference_endpoint_returns_single_message(monkeypatch):
+    """InferenceEndpoint must return one Message for the whole output.
+
+    The output is joined into a single string, so ``[Message(r) for r in
+    response]`` iterated over the characters and returned one Message per
+    character. The base class returns a single ``[Message("".join(...))]``.
+    """
+    monkeypatch.setenv("REPLICATE_API_TOKEN", "placeholder")
+    g = garak.generators.replicate.InferenceEndpoint(name="user/deployed-model")
+
+    prediction = MagicMock()
+    prediction.output = ["Hello ", "world"]  # "".join(...) -> "Hello world"
+    g.client = MagicMock()
+    g.client.deployments.get.return_value.predictions.create.return_value = prediction
+
+    conv = Conversation([Turn("user", Message("hi"))])
+    result = g._call_model(conv)
+
+    assert len(result) == 1, "should return one Message, not one per character"
+    assert result[0].text == "Hello world"


### PR DESCRIPTION
## What

`InferenceEndpoint._call_model` joins the prediction output into a single string and then returns it split by character:

```python
response = "".join(prediction.output)   # e.g. "Hello world"
...
return [Message(r) for r in response]   # -> [Message('H'), Message('e'), ...]
```

Iterating over the string yields one `Message` per character. The base class `ReplicateGenerator._call_model` does it correctly:

```python
return [Message("".join(response_iterator))]
```

So every successful generation from a private Replicate endpoint is returned as N single-character `Message` objects instead of one. With `supports_multiple_generations = False`, garak expects a single message, so downstream this mismatches the expected result shape.

## Fix

Return `[Message(response)]`, matching the base class and the single-generation contract.

## Test

Adds `tests/generators/test_replicate.py` (there was no replicate test module): mocks the deployment/prediction so `prediction.output` joins to `"Hello world"`, and asserts `_call_model` returns a single `Message` with that full text. Fails before the change (`len == 11`), passes after. `black --check` clean.

---
*Disclosure: this contribution was prepared with the assistance of an AI agent (Claude Code). The analysis, fix, and test were reviewed by me before submission.*