### PR TITLE
Guard analyze_log eval division against zero / missing total

### DIFF
--- a/garak/analyze/analyze_log.py
+++ b/garak/analyze/analyze_log.py
@@ -74,6 +74,14 @@ def analyze_log(report_path: str) -> None:
                             )
                         )
             elif record["entry_type"] == "eval":
+                # Older reports use "total" rather than "total_evaluated"; and
+                # total_evaluated can be 0 (a probe/detector pair with no
+                # evaluable outputs), so guard the division like the sibling
+                # analyzers (perf_stats/qual_review/report_digest/ci_calculator).
+                total_evaluated = record.get("total_evaluated", record.get("total", 0))
+                pass_rate = (
+                    record["passed"] / total_evaluated if total_evaluated else 0.0
+                )
                 print(
                     "\t".join(
                         map(
@@ -81,9 +89,8 @@ def analyze_log(report_path: str) -> None:
                             [
                                 record["probe"],
                                 record["detector"],
-                                "%0.4f"
-                                % (record["passed"] / record["total_evaluated"]),
-                                record["total_processed"],
+                                "%0.4f" % pass_rate,
+                                record.get("total_processed", total_evaluated),
                             ],
                         )
                     )

--- a/tests/analyze/test_analyze_log.py
+++ b/tests/analyze/test_analyze_log.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import garak.analyze.analyze_log
+
+
+def test_analyze_log_zero_total_evaluated(tmp_path):
+    """An eval record with total_evaluated == 0 must not raise ZeroDivisionError.
+
+    total_evaluated is passes + fails, which is 0 when a probe/detector pair
+    scored no evaluable outputs (all detector scores None). Every sibling
+    analyzer guards this division.
+    """
+    report = tmp_path / "report.jsonl"
+    report.write_text(
+        json.dumps(
+            {
+                "entry_type": "eval",
+                "probe": "test.Probe",
+                "detector": "test.Detector",
+                "passed": 0,
+                "total_evaluated": 0,
+                "total_processed": 0,
+            }
+        )
+        + "\n"
+    )
+    garak.analyze.analyze_log.analyze_log(str(report))  # must not raise
+
+
+def test_analyze_log_legacy_total_key(tmp_path):
+    """Older reports use 'total' rather than 'total_evaluated'/'total_processed'."""
+    report = tmp_path / "report.jsonl"
+    report.write_text(
+        json.dumps(
+            {
+                "entry_type": "eval",
+                "probe": "test.Probe",
+                "detector": "test.Detector",
+                "passed": 3,
+                "total": 5,
+            }
+        )
+        + "\n"
+    )
+    garak.analyze.analyze_log.analyze_log(str(report))  # must not raise


### PR DESCRIPTION
## What

`analyze_log`'s `eval` branch computed the pass-rate with an unguarded division and direct key access:

```python
"%0.4f" % (record["passed"] / record["total_evaluated"]),
record["total_processed"],
```

Two crash paths on real reports:

1. **`ZeroDivisionError`** — `total_evaluated` is `passes + fails`, which is `0` when a probe/detector pair had no evaluable outputs (all detector scores `None`, e.g. a flaky/failing generator returning `None`). The eval record is written unconditionally, so `0 / 0` aborts the whole analysis.
2. **`KeyError`** — older reports use the key `"total"` (and have no `"total_processed"`), so direct subscripting raises.

Every sibling analyzer already guards both — `perf_stats.py` (`if r["total_evaluated"] != 0`), `qual_review.py`, `report_digest.py` (`if instances else 0`), `ci_calculator.py` (`if total == 0`). `analyze_log` was the sole omission.

## Fix

Fall back to `"total"` and guard the division (rate `0.0` when the total is `0`), matching the sibling pattern:

```python
total_evaluated = record.get("total_evaluated", record.get("total", 0))
pass_rate = record["passed"] / total_evaluated if total_evaluated else 0.0
...
record.get("total_processed", total_evaluated),
```

## Test

Adds `tests/analyze/test_analyze_log.py` (no analyze_log test module existed): a report with `total_evaluated == 0` and a legacy `"total"`-only report each run through `analyze_log` without raising. Both fail before the change (`ZeroDivisionError`, `KeyError`), pass after. `black --check` clean.

---
*Disclosure: this contribution was prepared with the assistance of an AI agent (Claude Code). The analysis, fix, and tests were reviewed by me before submission.*