### PR TITLE
fix(cli): report file path in plugin option-file errors

### DIFF
--- a/garak/cli.py
+++ b/garak/cli.py
@@ -25,13 +25,13 @@ def parse_cli_plugin_config(plugin_type, args):
         elif opts_file in args:
             file_arg = getattr(args, opts_file)
             if not os.path.isfile(file_arg):
-                raise FileNotFoundError(f"Path provided is not a file: {opts_file}")
+                raise FileNotFoundError(f"Path provided is not a file: {file_arg}")
             with open(file_arg, encoding="utf-8") as f:
                 options_json = f.read().strip()
             try:
                 opts_cli_config = json.loads(options_json)
             except json.decoder.JSONDecodeError as e:
-                logging.warning("Failed to parse JSON %s: %s", opts_file, {e.args[0]})
+                logging.warning("Failed to parse JSON %s: %s", file_arg, e.args[0])
                 raise e
     return opts_cli_config
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,3 +1,6 @@
+import argparse
+import json
+import logging
 import re
 import pytest
 import os
@@ -94,3 +97,34 @@ def test_run_all_active_detectors(capsys):
     result = capsys.readouterr()
     last_line = result.out.strip().split("\n")[-1]
     assert re.match("^✔️  garak run complete in [0-9]+\\.[0-9]+s$", last_line)
+
+
+def test_plugin_option_file_missing_reports_path():
+    # a missing --<plugin>_option_file must name the offending path, not the flag,
+    # so the user can find the file they meant
+    bad_path = os.path.join("no", "such", "options.json")
+    args = argparse.Namespace(generator_option_file=bad_path)
+    with pytest.raises(FileNotFoundError) as excinfo:
+        cli.parse_cli_plugin_config("generator", args)
+    message = str(excinfo.value)
+    assert bad_path in message, "error should name the offending path"
+    assert (
+        "generator_option_file" not in message
+    ), "error should not name the argparse flag instead of the path"
+
+
+def test_plugin_option_file_bad_json_warning_is_wellformed(tmp_path, caplog):
+    # a malformed --<plugin>_option_file must warn with the file path and the raw
+    # parser message, with no stray set-literal braces around the error
+    options_file = tmp_path / "options.json"
+    options_file.write_text("this is not json", encoding="utf-8")
+    args = argparse.Namespace(generator_option_file=str(options_file))
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(json.JSONDecodeError):
+            cli.parse_cli_plugin_config("generator", args)
+    message = caplog.text
+    assert str(options_file) in message, "warning should name the file path"
+    assert (
+        "generator_option_file" not in message
+    ), "warning should name the file path, not the argparse flag"
+    assert "{" not in message, "warning should not wrap the error in a set literal"


### PR DESCRIPTION

<!-- Fill the repo's PULL_REQUEST_TEMPLATE.md, then the AGENTS.md-mandated
     AI-assistance / dedupe / test disclosures. -->

`garak.cli.parse_cli_plugin_config` emitted two misleading diagnostics when a
plugin options **file** was passed via `--<plugin>_option_file` (e.g.
`--generator_option_file`):

1. **Missing file:** the `FileNotFoundError` interpolated `opts_file`, which is the
   argparse *dest* string (`"generator_option_file"`), not the path the user
   actually passed. So a wrong path produced
   `Path provided is not a file: generator_option_file`, which does not tell the
   user which file was wrong.
2. **Malformed JSON:** the warning did two things wrong. It logged `opts_file` (the
   flag name again, not the path), and it wrapped the parser message in a **set
   literal** - `logging.warning(..., opts_file, {e.args[0]})` - so it printed
   `Failed to parse JSON generator_option_file: {'Expecting value: line 1 column 1 (char 0)'}`.
   The stray `{...}` is a real defect: `{e.args[0]}` builds a one-element `set`,
   not an f-string, so the message is malformed. Its inline-options twin a few
   lines up (line 23) already does this correctly.

The fix interpolates `file_arg` (the actual path) in both places and drops the
stray braces, so the file-based warning mirrors the inline-options branch:

```python
# missing file
raise FileNotFoundError(f"Path provided is not a file: {file_arg}")
# malformed JSON
logging.warning("Failed to parse JSON %s: %s", file_arg, e.args[0])
```

No behavioural change beyond message content: a valid `--<plugin>_option_file`
still returns the parsed dict, and the inline `--<plugin>_options` path is
untouched. Two lines in `garak/cli.py`; two regression tests added.

### Verification

- [x] Run the tests and ensure they pass: `python -m pytest tests/cli/` -> **18
      passed** (16 pre-existing + the 2 new tests below). Full command output ends
      `18 passed in ~61s`.
- [x] New tests are genuine regressions (fail on `main`, pass with this change):
      `python -m pytest tests/cli/test_cli.py -k plugin_option_file` -> 2 passed.
    - `test_plugin_option_file_missing_reports_path`: builds
      `argparse.Namespace(generator_option_file="no/such/options.json")`, asserts
      the `FileNotFoundError` message contains that path and NOT the flag name.
    - `test_plugin_option_file_bad_json_warning_is_wellformed`: writes a temp file
      of non-JSON, captures the warning via `caplog`, asserts it contains the file
      path, not the flag name, and has no `{` set-literal.
- [x] **Verify** it does what it should: with the fix, a bad path yields
      `Path provided is not a file: no/such/options.json` and bad JSON yields
      `Failed to parse JSON <path>: Expecting value: line 1 column 1 (char 0)`.
- [x] **Verify** it does not do what it should not: valid file still parses and
      returns the config dict; the inline-options branch and the `--list_config`
      path are unchanged.
- [x] Formatting: `black --config pyproject.toml --check tests/cli/test_cli.py` is
      clean. (The two edited `cli.py` lines are black-clean; pre-existing black
      drift elsewhere in `cli.py` is identical on `main` and left untouched to keep
