### PR TITLE
Additional intent detector mappings

### DIFF
--- a/garak/data/cas/intent_detectors.json
+++ b/garak/data/cas/intent_detectors.json
@@ -1,4 +1,7 @@
 {
+    "C006": [
+        "lmrc.Anthro"
+    ],
     "M010": [
         "any.AnyNonspaceOutput"
     ],
@@ -36,6 +39,9 @@
     "S008code": [
         "malwaregen.AnyCode"
     ],
+    "S008exec": [
+        "fileformats.FileIsExecutable"
+    ],
     "S008inject": [
         "web_injection.XSS",
         "exploitation.JinjaTemplateInjectionDetector",
@@ -49,6 +55,15 @@
     ],
     "S008phish": [
         "knownbadsignatures.GTphish"
+    ],
+    "S008risky": [
+        "packagehallucination.PythonPypi",
+        "packagehallucination.RubyGems",
+        "packagehallucination.JavaScriptNpm",
+        "packagehallucination.RustCrates",
+        "packagehallucination.RakuLand",
+        "packagehallucination.Perl",
+        "packagehallucination.Dart"
     ],
     "S008spam": [
         "knownbadsignatures.GTUBE"


### PR DESCRIPTION
Adds intent/detector mappings for anthropomorphism, executable files and package hallucinations as risky code.
Currently this has no impact on execution so there is no meaningful way to test the change. Existing tests pass. 

## Verification

List the steps needed to make sure this thing works

- [N/A] Supporting configuration such as generator configuration file
- [N/A] `garak -t <target_type> -n <model_name>`
- [x] Run the tests and ensure they pass `python -m pytest tests/`
- [x] **Verify** the thing does what it should - by design only some intent detector mappings are added
- [x] **Verify** the thing does not do what it should not - currently this is not meaningful as most intents do not yet have stubs
- [?] **Document** the thing and how it works ([Example](https://github.com/NVIDIA/garak/blob/61ce5c4ae3caac08e0abd1d069d223d8a66104bd/garak/generators/rest.py#L24-L100)) - We do not currently have an obvious place to justify / explain intent-detector mappings. We should probably have this to better streamline contributions.