### PR TITLE
fix: reverse_translation_outputs reassembled in wrong order via list.pop()

### DIFF
--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -290,7 +290,7 @@ class Probe(Configurable):
             for output in all_outputs:
                 if output is not None:
                     this_attempt.reverse_translation_outputs.append(
-                        reverse_translation_outputs.pop()
+                        reverse_translation_outputs.pop(0)
                     )
                 else:
                     this_attempt.reverse_translation_outputs.append(None)

--- a/tests/langservice/probes/test_probes_base.py
+++ b/tests/langservice/probes/test_probes_base.py
@@ -145,6 +145,50 @@ def test_base_postprocess_attempt(responses, mocker):
         ), "translation index outputs should align with output types"
 
 
+@pytest.mark.parametrize("classname", ["probes.base.Probe"])
+def test_base_postprocess_attempt_preserves_output_order(classname, mocker):
+    """reverse_translation_outputs must align position-for-position with outputs.
+
+    _postprocess_attempt built reverse_translation_outputs in forward order but
+    reassembled it against `all_outputs` via list.pop() (LIFO), reversing the
+    order among non-None outputs whenever there are 2 or more of them.
+    """
+    import garak.langservice
+    import garak.probes.base
+    from garak.langproviders.local import Passthru
+
+    null_provider = Passthru(
+        {
+            "langproviders": {
+                "local": {
+                    "language": "en,en",
+                }
+            }
+        }
+    )
+
+    mocker.patch.object(
+        garak.langservice, "get_langprovider", return_value=null_provider
+    )
+
+    a = Attempt(prompt=Message("just a test attempt", lang="fr"))
+    a.outputs = [
+        Message("first", lang="fr"),
+        Message("second", lang="fr"),
+        Message("third", lang="fr"),
+    ]
+    p = garak.probes.base.Probe()
+    p.lang = "en"
+    r = p._postprocess_attempt(a)
+
+    reverse_texts = [msg.text for msg in r.reverse_translation_outputs]
+    assert reverse_texts == [
+        "first",
+        "second",
+        "third",
+    ], "reverse_translation_outputs must stay aligned with the original output order"
+
+
 """
 Skip probes.tap.PAIR because it needs openai api key and large gpu resource
 """


### PR DESCRIPTION
## What

`_postprocess_attempt` builds `reverse_translation_outputs` in forward order (a list comprehension over `results_text`, itself built in forward order from `all_outputs`), but reassembles it against `all_outputs` by calling `list.pop()` — which removes from the **end** of the list (LIFO) instead of preserving order.

For any attempt with 2+ non-None outputs, output N's reverse translation ends up assigned to output `(total - 1 - N)` instead of output N, silently misaligning translated text with the output it actually belongs to.

## Fix

Use `list.pop(0)` to consume `reverse_translation_outputs` in the same forward order it was built in.

## How I verified this

- Added `test_base_postprocess_attempt_preserves_output_order`, using **distinct** text per `Message` — the existing `test_base_postprocess_attempt` parametrize cases all use identical text (`"text to translate"`) across every message, so that test structurally cannot detect a reordering bug, and its assertion only checks `type(response) == type(output)`, not content, so it wouldn't catch this even with distinct text.
- Confirmed the new test fails with `['third', 'second', 'first']` instead of `['first', 'second', 'third']` before the fix, and passes after.
- Ran the full `tests/langservice/probes/test_probes_base.py` (150 passed, 37 skipped — optional deps) and `tests/probes/test_probes.py` (1148 passed, 1 pre-existing unrelated failure from a missing optional audio dependency, `soundfile`/`librosa`).

## Disclosure

I used AI assistance (Claude) to help investigate and draft this fix, but I personally wrote the repro, reviewed the root cause, and reviewed the final diff before submitting.

Signed-off-by: Andrew Chen <48723787+chuenchen309@users.noreply.github.com>