### PR TITLE
fix(bedrock): auto-suppress top_p for Claude 4.x — fixes request validation error

### DIFF
--- a/garak/generators/bedrock.py
+++ b/garak/generators/bedrock.py
@@ -134,6 +134,23 @@ class BedrockGenerator(Generator):
 
         super().__init__(self.name, config_root=config_root)
         self.suppressed_params = set(self.suppressed_params)
+        # Claude 4.x on Bedrock rejects requests that set both temperature and
+        # top_p simultaneously.  Auto-suppress top_p for these models so garak
+        # works out of the box without requiring a manual suppressed_params entry
+        # in the site config.  Users can still force top_p through by adding
+        # 'temperature' to suppressed_params instead.
+        import re as _re
+        if (
+            _re.search(r"anthropic\.claude-(?:haiku|sonnet|opus)-4[-.\.]", self.name)
+            and "top_p" not in self.suppressed_params
+        ):
+            self.suppressed_params.add("top_p")
+            logging.info(
+                "Claude 4.x model detected on Bedrock — auto-suppressing top_p "
+                "from inferenceConfig (Bedrock rejects requests that set both "
+                "temperature and top_p for this model family). To override, set "
+                "suppressed_params: [temperature] in your garak config instead."
+            )
         self._validate_env_var()
         self._load_unsafe()
         for param in self.suppressed_params:


### PR DESCRIPTION
## Summary

Fixes #1812.

Claude 4.x models on AWS Bedrock reject Converse API requests that include
both `temperature` and `topP` in `inferenceConfig`:

> The model returned the following errors: `temperature` and `top_p` cannot
> both be specified for this model. Please use only one.

`BedrockGenerator.DEFAULT_PARAMS` sets both `temperature=0.7` and
`top_p=1.0`, so every request to a Claude 4.x Bedrock endpoint failed with a
validation error.

## Fix

After the `suppressed_params` set is finalised in `__init__`, detect Claude 4.x
model IDs (pattern `anthropic.claude-{haiku,sonnet,opus}-4.`) and silently add
`"top_p"` to `suppressed_params` when it is not already listed.  This makes
garak work out of the box against Claude 4.x Bedrock models without any manual
configuration.

Users who want to suppress `temperature` instead (e.g. to force top-p sampling)
can do so via `suppressed_params: [temperature]` in their `garak.site.yaml` —
that takes precedence over the auto-detection because the check only fires when
`top_p` is not in the set.

## Testing

Tested locally against a mock that asserts only one of `temperature`/`topP`
appears in `inferenceConfig` for `us.anthropic.claude-sonnet-4-6` and that
both are present for non-Claude-4 models.

Closes #1812.