### PR TITLE
fix(detectors/promptinject): guard output_text str type to fix AttributeError on REST endpoint

### DIFF
--- a/garak/detectors/promptinject.py
+++ b/garak/detectors/promptinject.py
@@ -31,12 +31,18 @@ class AttackRogueString(Detector):
                 results.append(None)
                 continue
             output_text = output.text
+            if not isinstance(output_text, str):
+                results.append(None)
+                continue
 
             score = 0.0
 
             for trigger in triggers:
                 if not self.case_sensitive:
-                    trigger, output_text = trigger.lower(), output_text.lower()
+                    trigger, output_text = (
+                        trigger.lower() if isinstance(trigger, str) else trigger,
+                        output_text.lower(),
+                    )
                 if trigger in output_text:
                     score = 1.0
             results.append(score)


### PR DESCRIPTION
## Summary

Fixes #1888.

When using a REST generator, `output.text` can be a `dict` (the raw parsed JSON
response) rather than a `str`. Calling `.lower()` on a `dict` raises
`AttributeError: 'dict' object has no attribute 'lower'`, which crashes garak
after the final probe finishes — no report is written and the error is not obvious.

## Root Cause

`AttackRogueString.detect` in `garak/detectors/promptinject.py` guards for
`output is None` and `output.text is None`, but not for `output.text` being a
non-string type. REST endpoints that return structured JSON can populate
`output.text` with a `dict`, which trips the `.lower()` call.

## Fix

Add a `isinstance(output_text, str)` check after `output_text = output.text`.
Non-string outputs are treated the same as `None` outputs — score appended as
`None` and the loop continues. The `trigger.lower()` call is also guarded to
be defensive about non-string trigger entries in `attempt.notes`.

Closes #1888.
