### PR TITLE
tests: regression guard for plugin enumeration coverage (issue #713)

### DIFF
--- a/tests/plugins/test_plugin_enumeration_coverage.py
+++ b/tests/plugins/test_plugin_enumeration_coverage.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression guard for plugin enumeration coverage (garak issue #713).
+
+garak discovers plugins by scanning the modules in each package
+(``garak.<category>``) for concrete subclasses of the package base classes
+(``garak.<category>.base``). ``_plugins.enumerate_plugins()`` is the public
+view of that discovery.
+
+If a concrete plugin class is added to a module but not picked up by the
+enumeration, it silently becomes invisible: probes/detectors that iterate
+over ``enumerate_plugins()`` (including the test suite) will never exercise
+it. Issue #713 asks for a test that flags exactly this gap.
+
+This test mirrors the discovery logic in
+``garak._plugins.PluginCache._enumerate_plugin_klasses`` and asserts that
+every concrete plugin class it finds is present in the enumerated set.
+
+Note on mixins/base classes: garak's plugin base classes are implemented as
+``abc.ABC`` subclasses, so mixins and abstract bases are excluded by the
+``inspect.isabstract`` check below -- the same check the discovery machinery
+uses. Concrete classes that intentionally subclass a base only to be inherited
+from must themselves be abstract, otherwise they *should* be enumerated.
+"""
+
+import importlib
+import inspect
+import os
+
+import pytest
+
+from garak import _config, _plugins
+
+# Categories to cover. Issue #713 is scoped to plugin modules in general;
+# detectors & probes are the largest and most security-relevant surfaces.
+CATEGORIES = ("detectors", "probes")
+
+
+def _base_plugin_classes(category):
+    """Return the concrete base plugin classes for a category (e.g. Detector)."""
+    base_mod = importlib.import_module(f"garak.{category}.base")
+    return [
+        getattr(base_mod, name)
+        for name, klass in inspect.getmembers(base_mod, inspect.isclass)
+        if klass.__module__.startswith(base_mod.__name__)
+        and not inspect.isabstract(klass)
+    ]
+
+
+def _discover_plugin_classes(category):
+    """Discover concrete plugin classes the way the enumeration machinery does.
+
+    Mirrors ``PluginCache._enumerate_plugin_klasses``: scan every non-base,
+    non-dunder module in the package for concrete subclasses of the base
+    plugin classes. Returns a set of ``"<category>.<module>.<Class>"`` names
+    (without the ``garak.`` prefix, matching ``enumerate_plugins`` output).
+    """
+    base_klasses = _base_plugin_classes(category)
+    base_mod = importlib.import_module(f"garak.{category}.base")
+    module_dir = os.path.dirname(base_mod.__file__)
+
+    discovered = set()
+    for filename in sorted(os.listdir(module_dir)):
+        if not filename.endswith(".py"):
+            continue
+        if filename.startswith("__") or filename.startswith("_"):
+            continue
+        module_name = filename[:-3]
+        if module_name == "base":
+            continue
+        mod = importlib.import_module(f"garak.{category}.{module_name}")
+        for name, klass in inspect.getmembers(mod, inspect.isclass):
+            if klass.__module__ != mod.__name__:
+                continue  # imported, not defined here
+            if inspect.isabstract(klass):
+                continue
+            if any(issubclass(klass, base) for base in base_klasses):
+                discovered.add(f"{category}.{module_name}.{name}")
+    return discovered
+
+
+@pytest.mark.parametrize("category", CATEGORIES)
+def test_all_plugin_classes_are_enumerated(category):
+    """Every concrete plugin class must be returned by enumerate_plugins."""
+    discovered = _discover_plugin_classes(category)
+    enumerated = {name for (name, _active) in _plugins.enumerate_plugins(category)}
+
+    missing = sorted(discovered - enumerated)
+    assert missing == [], (
+        f"concrete plugin classes in garak.{category} not picked up by "
+        f"plugin enumeration (see issue #713): {missing}"
+    )
+
+
+@pytest.mark.parametrize("category", CATEGORIES)
+def test_enumeration_matches_discovery_count(category):
+    """Enumeration and discovery should agree on the set of plugin classes.
+
+    Guards against the inverse drift too: a class present in enumeration that
+    discovery no longer finds would indicate a stale plugin cache or a moved
+    base class.
+    """
+    discovered = _discover_plugin_classes(category)
+    enumerated = {name for (name, _active) in _plugins.enumerate_plugins(category)}
+
+    assert discovered == enumerated, (
+        "plugin enumeration and discovery disagree for "
+        f"garak.{category}: discovered-only={sorted(discovered - enumerated)}, "
+        f"enumerated-only={sorted(enumerated - discovered)}"
+    )


### PR DESCRIPTION
## Summary

Adds a regression guard that verifies every concrete plugin class in `garak.detectors` and `garak.probes` is picked up by plugin enumeration — the exact gap described in issue #713 ("tests: check plugin modules for classes that aren't picked up by plugin enumeration").

- `tests/plugins/test_plugin_enumeration_coverage.py`
  - Mirrors `garak._plugins.PluginCache._enumerate_plugin_klasses` discovery logic (scan non-dunder, non-underscore modules for concrete subclasses of the base plugin classes; excludes ABCs exactly as the real machinery does).
  - `test_all_plugin_classes_are_enumerated[detectors|probes]`: asserts every discovered concrete class is in `enumerate_plugins()`.
  - `test_enumeration_matches_discovery_count[detectors|probes]`: asserts the two sets are equal (guards against inverse drift / stale plugin cache too).
  - British-english docstrings, descriptive assert messages, parametrised per `AGENTS.md` testing style.

## Why not a duplicate

This targets issue #713, which is **unassigned** (no assignees) and has **no linked open PR** (verified via `gh pr list --search "713 in:body"`, which returns only an unrelated #975). It is a test-gap task in the doc/test-gaps lane; it does not overlap with the contested PII-extraction work (#219) or any open PR.

## Test plan

- `pytest tests/plugins/test_plugin_enumeration_coverage.py` -> **4 passed (6.4s)**.
- **Negative control proven:** monkeypatching `enumerate_plugins` to drop one real class (`detectors.always.Pass`) makes the test FAIL with:
  > concrete plugin classes in garak.detectors not picked up by plugin enumeration (see issue #713): ['detectors.always.Pass']
  confirming the guard actually fires on a miss.
- **Pre-existing failure (NOT introduced here, reported honestly):** `test_instantiate_probes[probes.audio.AudioAchillesHeel]` fails in the broader suite because optional audio deps (`soundfile`, `librosa`) aren't installed in this environment. This PR does not touch audio code; the failure exists independently.

## AI assistance disclosure

This change was developed with AI assistance (agent-authored), then verified by running the suite locally. The discovery logic mirrors garak's own internal machinery by design so the guard tracks real enumeration behaviour.

Co-authored-by: Malik Baptiste <mbaptiste20@gmail.com>