### PR TITLE
tests: validate plugin enumeration contract

### DIFF
--- a/tests/plugins/test_plugin_enumeration_coverage.py
+++ b/tests/plugins/test_plugin_enumeration_coverage.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression guard for plugin enumeration coverage (garak issue #713).
+
+garak discovers plugins by scanning the modules in each package
+(``garak.<category>``) for concrete subclasses of the package base classes
+(``garak.<category>.base``). ``_plugins.enumerate_plugins()`` is the public
+view of that discovery.
+
+If a concrete plugin class is added to a module but not picked up by the
+enumeration, it silently becomes invisible: probes/detectors that iterate
+over ``enumerate_plugins()`` (including the test suite) will never exercise
+it. Issue #713 asks for a test that flags exactly this gap.
+
+This test mirrors the discovery logic in
+``garak._plugins.PluginCache._enumerate_plugin_klasses`` and asserts that
+every concrete plugin class it finds is present in the enumerated set.
+
+Note on mixins/base classes: garak's plugin base classes are implemented as
+``abc.ABC`` subclasses, so mixins and abstract bases are excluded by the
+``inspect.isabstract`` check below -- the same check the discovery machinery
+uses. Concrete classes that intentionally subclass a base only to be inherited
+from must themselves be abstract, otherwise they *should* be enumerated.
+"""
+
+import importlib
+import inspect
+import os
+
+import pytest
+
+from garak import _config, _plugins
+
+# Categories to cover. Issue #713 is scoped to plugin modules in general;
+# detectors & probes are the largest and most security-relevant surfaces.
+CATEGORIES = ("detectors", "probes")
+
+
+def _base_plugin_classes(category):
+    """Return the concrete base plugin classes for a category (e.g. Detector)."""
+    base_mod = importlib.import_module(f"garak.{category}.base")
+    return [
+        getattr(base_mod, name)
+        for name, klass in inspect.getmembers(base_mod, inspect.isclass)
+        if klass.__module__.startswith(base_mod.__name__)
+        and not inspect.isabstract(klass)
+    ]
+
+
+def _discover_plugin_classes(category):
+    """Discover concrete plugin classes the way the enumeration machinery does.
+
+    Mirrors ``PluginCache._enumerate_plugin_klasses``: scan every non-base,
+    non-dunder module in the package for concrete subclasses of the base
+    plugin classes. Returns a set of ``"<category>.<module>.<Class>"`` names
+    (without the ``garak.`` prefix, matching ``enumerate_plugins`` output).
+    """
+    base_klasses = _base_plugin_classes(category)
+    base_mod = importlib.import_module(f"garak.{category}.base")
+    module_dir = os.path.dirname(base_mod.__file__)
+
+    discovered = set()
+    for filename in sorted(os.listdir(module_dir)):
+        if not filename.endswith(".py"):
+            continue
+        if filename.startswith("__") or filename.startswith("_"):
+            continue
+        module_name = filename[:-3]
+        if module_name == "base":
+            continue
+        mod = importlib.import_module(f"garak.{category}.{module_name}")
+        for name, klass in inspect.getmembers(mod, inspect.isclass):
+            if klass.__module__ != mod.__name__:
+                continue  # imported, not defined here
+            if inspect.isabstract(klass):
+                continue
+            if any(issubclass(klass, base) for base in base_klasses):
+                discovered.add(f"{category}.{module_name}.{name}")
+    return discovered
+
+
+@pytest.mark.parametrize("category", CATEGORIES)
+def test_all_plugin_classes_are_enumerated(category):
+    """Every concrete plugin class must be returned by enumerate_plugins."""
+    discovered = _discover_plugin_classes(category)
+    enumerated = {name for (name, _active) in _plugins.enumerate_plugins(category)}
+
+    missing = sorted(discovered - enumerated)
+    assert missing == [], (
+        f"concrete plugin classes in garak.{category} not picked up by "
+        f"plugin enumeration (see issue #713): {missing}"
+    )
+
+
+@pytest.mark.parametrize("category", CATEGORIES)
+def test_enumeration_matches_discovery_count(category):
+    """Enumeration and discovery should agree on the set of plugin classes.
+
+    Guards against the inverse drift too: a class present in enumeration that
+    discovery no longer finds would indicate a stale plugin cache or a moved
+    base class.
+    """
+    discovered = _discover_plugin_classes(category)
+    enumerated = {name for (name, _active) in _plugins.enumerate_plugins(category)}
+
+    assert discovered == enumerated, (
+        "plugin enumeration and discovery disagree for "
+        f"garak.{category}: discovered-only={sorted(discovered - enumerated)}, "
+        f"enumerated-only={sorted(enumerated - discovered)}"
+    )

--- a/tests/plugins/test_plugin_enumeration_coverage.py
+++ b/tests/plugins/test_plugin_enumeration_coverage.py
@@ -1,89 +1,61 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Regression guard for plugin enumeration coverage (garak issue #713).
+"""Contract test for plugin enumeration coverage (garak issue #713).
 
-garak discovers plugins by scanning the modules in each package
-(``garak.<category>``) for concrete subclasses of the package base classes
-(``garak.<category>.base``). ``_plugins.enumerate_plugins()`` is the public
-view of that discovery.
+enumerate_plugins() is the public view of garak's plugin discovery. Its
+contract: every concrete plugin class in a category (probes/detectors/…)
+should be returned by enumerate_plugins(), except base classes — which the
+function deliberately excludes via the ``.base.`` name check.
 
-If a concrete plugin class is added to a module but not picked up by the
-enumeration, it silently becomes invisible: probes/detectors that iterate
-over ``enumerate_plugins()`` (including the test suite) will never exercise
-it. Issue #713 asks for a test that flags exactly this gap.
-
-This test mirrors the discovery logic in
-``garak._plugins.PluginCache._enumerate_plugin_klasses`` and asserts that
-every concrete plugin class it finds is present in the enumerated set.
-
-Note on mixins/base classes: garak's plugin base classes are implemented as
-``abc.ABC`` subclasses, so mixins and abstract bases are excluded by the
-``inspect.isabstract`` check below -- the same check the discovery machinery
-uses. Concrete classes that intentionally subclass a base only to be inherited
-from must themselves be abstract, otherwise they *should* be enumerated.
+This test validates that *contract* without re-implementing discovery: it
+collects concrete plugin classes reachable from the category base classes via
+the normal Python subclass registry, filters to the ``garak.<category>.``
+namespace (matching what discovery enumerates), and asserts enumerate_plugins()
+surfaces each one. Base classes are excluded exactly as enumerate_plugins does.
 """
 
 import importlib
 import inspect
-import os
 
 import pytest
 
-from garak import _config, _plugins
+from garak import _plugins
 
-# Categories to cover. Issue #713 is scoped to plugin modules in general;
-# detectors & probes are the largest and most security-relevant surfaces.
 CATEGORIES = ("detectors", "probes")
 
 
-def _base_plugin_classes(category):
-    """Return the concrete base plugin classes for a category (e.g. Detector)."""
+def _base_plugin_classes(category: str) -> list[type]:
+    """Concrete base plugin classes for a category (e.g. Detector, Probe)."""
     base_mod = importlib.import_module(f"garak.{category}.base")
     return [
-        getattr(base_mod, name)
+        klass
         for name, klass in inspect.getmembers(base_mod, inspect.isclass)
         if klass.__module__.startswith(base_mod.__name__)
         and not inspect.isabstract(klass)
     ]
 
 
-def _discover_plugin_classes(category):
-    """Discover concrete plugin classes the way the enumeration machinery does.
+def _concrete_plugin_classes(category: str) -> set[str]:
+    """Concrete plugin classes in the garak.<category>. namespace.
 
-    Mirrors ``PluginCache._enumerate_plugin_klasses``: scan every non-base,
-    non-dunder module in the package for concrete subclasses of the base
-    plugin classes. Returns a set of ``"<category>.<module>.<Class>"`` names
-    (without the ``garak.`` prefix, matching ``enumerate_plugins`` output).
+    Reachable from the category base classes through the Python subclass
+    registry — the same classes discovery walks. Base classes themselves are
+    excluded, matching enumerate_plugins()'s ``.base.`` skip.
     """
-    base_klasses = _base_plugin_classes(category)
-    base_mod = importlib.import_module(f"garak.{category}.base")
-    module_dir = os.path.dirname(base_mod.__file__)
-
-    discovered = set()
-    for filename in sorted(os.listdir(module_dir)):
-        if not filename.endswith(".py"):
-            continue
-        if filename.startswith("__") or filename.startswith("_"):
-            continue
-        module_name = filename[:-3]
-        if module_name == "base":
-            continue
-        mod = importlib.import_module(f"garak.{category}.{module_name}")
-        for name, klass in inspect.getmembers(mod, inspect.isclass):
-            if klass.__module__ != mod.__name__:
-                continue  # imported, not defined here
-            if inspect.isabstract(klass):
-                continue
-            if any(issubclass(klass, base) for base in base_klasses):
-                discovered.add(f"{category}.{module_name}.{name}")
-    return discovered
+    found = set()
+    for base in _base_plugin_classes(category):
+        for sub in base.__subclasses__():
+            if sub.__module__.startswith(f"garak.{category}.") and not sub.__module__.endswith(".base"):
+                name = f"{category}.{sub.__module__.split('.')[-1]}.{sub.__name__}"
+                found.add(name)
+    return found
 
 
 @pytest.mark.parametrize("category", CATEGORIES)
-def test_all_plugin_classes_are_enumerated(category):
-    """Every concrete plugin class must be returned by enumerate_plugins."""
-    discovered = _discover_plugin_classes(category)
+def test_all_concrete_plugin_classes_are_enumerated(category: str) -> None:
+    """Every concrete plugin class must be returned by enumerate_plugins()."""
+    discovered = _concrete_plugin_classes(category)
     enumerated = {name for (name, _active) in _plugins.enumerate_plugins(category)}
 
     missing = sorted(discovered - enumerated)
@@ -94,18 +66,10 @@ def test_all_plugin_classes_are_enumerated(category):
 
 
 @pytest.mark.parametrize("category", CATEGORIES)
-def test_enumeration_matches_discovery_count(category):
-    """Enumeration and discovery should agree on the set of plugin classes.
-
-    Guards against the inverse drift too: a class present in enumeration that
-    discovery no longer finds would indicate a stale plugin cache or a moved
-    base class.
-    """
-    discovered = _discover_plugin_classes(category)
+def test_base_classes_excluded_from_enumeration(category: str) -> None:
+    """Base classes must NOT be enumerated (contract: `.base.` is skipped)."""
     enumerated = {name for (name, _active) in _plugins.enumerate_plugins(category)}
-
-    assert discovered == enumerated, (
-        "plugin enumeration and discovery disagree for "
-        f"garak.{category}: discovered-only={sorted(discovered - enumerated)}, "
-        f"enumerated-only={sorted(enumerated - discovered)}"
+    base_leaks = sorted(n for n in enumerated if ".base." in n)
+    assert base_leaks == [], (
+        f"base classes should be excluded from enumeration but were found: {base_leaks}"
     )


### PR DESCRIPTION
## Summary

Reworked from the closed #1962 per maintainer feedback: this now **validates the contract of `enumerate_plugins()`** instead of re-implementing garak's discovery logic.

The contract under test: every concrete plugin class in a category (`probes`, `detectors`) is returned by `enumerate_plugins()`, and base classes are deliberately excluded (the `.base.` name skip). The test collects concrete plugin classes reachable from the category base classes via the normal Python subclass registry, filters to the `garak.<category>.` namespace (matching what discovery enumerates), and asserts each is enumerated — without duplicating the module-walking discovery code.

- `tests/plugins/test_plugin_enumeration_coverage.py`
  - `test_all_concrete_plugin_classes_are_enumerated[detectors|probes]`: every concrete class in the namespace is in `enumerate_plugins()`.
  - `test_base_classes_excluded_from_enumeration[detectors|probes]`: confirms base classes are correctly *not* enumerated (guards against the contract regressing the other way).

## Why this is not the previous (rejected) approach

#1962 mirrored `_enumerate_plugin_klasses` discovery by re-scanning modules — the reviewer correctly noted that duplicates implementation and adds maintenance cost. This version calls only the public `enumerate_plugins()` and uses the subclass registry to know what *should* be there, so it tests behaviour, not internals.

## Why not a duplicate of an existing PR

Issue #713 is unassigned with no linked open PR (`gh pr list --search "713 in:body"` returns only unrelated #975). Confirmed no open PR addresses plugin enumeration coverage.

## Test plan

- `pytest tests/plugins/test_plugin_enumeration_coverage.py` -> **4 passed (0.2s)**.
- **Negative control proven:** monkeypatching `enumerate_plugins` to drop `detectors.always.Pass` makes `test_all_concrete_plugin_classes_are_enumerated[detectors]` FAIL with:
  > concrete plugin classes in garak.detectors not picked up by plugin enumeration (see issue #713): ['detectors.always.Pass']
- Pre-existing failure unrelated to this change (optional audio deps missing): `test_instantiate_probes[probes.audio.AudioAchillesHeel]`. Not touched by this PR.

## AI assistance disclosure

Developed with AI assistance (agent-authored), then verified locally by running the suite and the negative control. Approach revised in direct response to the #1962 review.

Co-authored-by: Malik Baptiste <mbaptiste20@gmail.com>
