### PR TITLE
fix(interactive): do_probe drops a first-time probe name and can crash with UnboundLocalError

### DIFF
--- a/garak/interactive.py
+++ b/garak/interactive.py
@@ -107,7 +107,9 @@ class GarakCommands(cmd2.CommandSet):
             logger.warning(f"Probe already set. Resetting probe to {args.probe}")
             print(f"Executing {args.probe}")
             self._cmd.probe = args.probe
-        elif not args.probe and not self._cmd.probe:
+        elif args.probe:
+            self._cmd.probe = args.probe
+        elif not self._cmd.probe:
             logger.warning("No probe set and no probe specified.")
             return None
         try:
@@ -130,9 +132,11 @@ class GarakCommands(cmd2.CommandSet):
         except ImportError as e:
             logger.error(e)
             print("Could not load generator from Garak generators.")
+            return
         except AttributeError as e:
             logger.error(e)
             print("Please check your generator model name.")
+            return
 
         evaluator = ThresholdEvaluator(self._cmd.eval_threshold)
         harness = garak.harnesses.probewise.ProbewiseHarness()

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from garak.interactive import GarakCommands
+
+# do_probe is wrapped by @cmd2.with_argparser; call the original function
+# directly (functools.wraps preserves __wrapped__) so tests don't need a
+# full cmd2.Cmd/CommandSet registration or a real garak config.
+_do_probe = GarakCommands.do_probe.__wrapped__
+
+
+def _make_cmds(probe=None, generator=None):
+    cmds = GarakCommands()
+    cmds._cmd = SimpleNamespace(
+        target_type="test",
+        target_model="test",
+        probe=probe,
+        generator=generator,
+        eval_threshold=0.5,
+    )
+    return cmds
+
+
+def test_do_probe_sets_probe_when_none_was_previously_set():
+    """A probe name passed on the first `probe <name>` call (no probe set yet)
+    must actually be stored, not silently dropped."""
+    cmds = _make_cmds(probe=None)
+    args = SimpleNamespace(probe="mynewprobe")
+
+    with (
+        patch("garak.interactive.ThresholdEvaluator", MagicMock()),
+        patch("garak.harnesses.probewise.ProbewiseHarness", MagicMock()),
+    ):
+        _do_probe(cmds, args)
+
+    assert cmds._cmd.probe == "mynewprobe"
+
+
+def test_do_probe_does_not_crash_when_generator_fails_to_load():
+    """If loading the generator raises ImportError/AttributeError, do_probe
+    must stop instead of falling through to use the never-assigned
+    `generator` local variable."""
+    cmds = _make_cmds(probe=None)
+    args = SimpleNamespace(probe="mynewprobe")
+
+    threshold_evaluator = MagicMock()
+    harness_cls = MagicMock()
+    with (
+        patch("garak._plugins.load_plugin", side_effect=ImportError("boom")),
+        patch("garak.interactive.ThresholdEvaluator", threshold_evaluator),
+        patch("garak.harnesses.probewise.ProbewiseHarness", harness_cls),
+    ):
+        _do_probe(cmds, args)
+
+    threshold_evaluator.assert_not_called()
+    harness_cls.assert_not_called()
+
+
+def test_do_probe_does_not_crash_when_generator_name_is_invalid():
+    """Same as above, for the AttributeError branch."""
+    cmds = _make_cmds(probe=None)
+    args = SimpleNamespace(probe="mynewprobe")
+
+    threshold_evaluator = MagicMock()
+    harness_cls = MagicMock()
+    with (
+        patch("garak._plugins.load_plugin", side_effect=AttributeError("boom")),
+        patch("garak.interactive.ThresholdEvaluator", threshold_evaluator),
+        patch("garak.harnesses.probewise.ProbewiseHarness", harness_cls),
+    ):
+        _do_probe(cmds, args)
+
+    threshold_evaluator.assert_not_called()
+    harness_cls.assert_not_called()


### PR DESCRIPTION
Two bugs in `GarakCommands.do_probe` (`garak/interactive.py`):

1. The probe-name branch only covers "overwrite an existing probe" (`if args.probe and self._cmd.probe`) and "neither given" (`elif not args.probe and not self._cmd.probe`). The case of a probe name given for the *first time* (`self._cmd.probe` was falsy, `args.probe` is truthy) matches neither branch, so `self._cmd.probe` is silently never set — `probe myprobe` run as the very first `probe` command in a session does nothing.
2. If loading the generator raises `ImportError` or `AttributeError`, the `except` blocks only log/print and fall through — `generator` was never assigned, so the next line, `harness.run(generator, ...)`, raises `UnboundLocalError` instead of the intended graceful message.

## Fix

Add an explicit `elif args.probe: self._cmd.probe = args.probe` branch for the first-time-set case, and `return` after each `except` block so a failed generator load stops the command instead of falling through to code that needs a `generator` that was never created.

## Verification

- [x] Added `tests/test_interactive.py` (no prior test coverage existed for this module): calls `GarakCommands.do_probe.__wrapped__` directly (bypassing the `@cmd2.with_argparser` decorator, so no full `cmd2.Cmd` registration or garak config is needed), with `ThresholdEvaluator` and `ProbewiseHarness` mocked out to isolate the control-flow bug from unrelated config-loading concerns.
- [x] Confirmed red→green: reverting only `interactive.py` reproduces both symptoms exactly (probe stays `None`; `UnboundLocalError` on `generator`); reapplying passes.
- [x] `black --check` clean on both changed files.
- [x] xref: #1793 ("fix(lint): tune pylintrc and fix violations across core modules") also touches `do_probe`, but only for an f-string→`%s` logging conversion and a trailing `return None`, not either of these two logic bugs — not a duplicate, though a trivial rebase may be needed if it merges first.
- [ ] `garak -t <target_type> -n <model_name>` — **not run**: this is a unit-level fix and I have no live target configured; verified via the tests above rather than ticking a box I didn't exercise.
- [ ] Supporting configuration such as a generator configuration file — n/a, no config surface changed.

---
I used AI assistance (Claude) to help investigate and draft this fix, but I personally constructed the repro, reviewed the root cause, and reviewed the final diff before submitting.

Signed-off-by: Andrew Chen <48723787+chuenchen309@users.noreply.github.com>
