### PR TITLE
fix(generators): retry transient HTTP errors (408/502/503/504) in OpenAICompatible

### DIFF
--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -150,6 +150,7 @@ class OpenAICompatible(Generator):
         "seed": None,
         "stop": ["#", ";"],
         "suppressed_params": set(),
+        "transient_retry_codes": [408, 429, 502, 503, 504],
         "retry_json": True,
         "extra_params": {},
     }
@@ -335,6 +336,17 @@ class OpenAICompatible(Generator):
             msg = "Bad request: " + str(repr(prompt))
             logging.exception(e)
             logging.error(msg)
+            return [None]
+        except openai.APIStatusError as e:
+            if e.status_code in self.transient_retry_codes:
+                raise garak.exception.GeneratorBackoffTrigger(
+                    f"Transient HTTP {e.status_code}, retrying with backoff"
+                ) from None
+            logging.warning(
+                "OpenAI API returned non-retryable HTTP %s for %s",
+                e.status_code,
+                self.fullname,
+            )
             return [None]
         except json.decoder.JSONDecodeError as e:
             logging.exception(e)

--- a/tests/generators/test_openai_compatible.py
+++ b/tests/generators/test_openai_compatible.py
@@ -141,3 +141,47 @@ def test_openai_multiple_generations():
     assert (
         oai_klass.supports_multiple_generations == True
     ), "OpenAI access expected to correctly support multiple generations by default"
+
+# Tests for transient HTTP error handling via GeneratorBackoffTrigger (issue #1967)
+
+
+def test_transient_408_raises_generator_backoff_trigger():
+    import openai, httpx, garak.exception
+
+    request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    response = httpx.Response(408, request=request)
+    exc = openai.APIStatusError(message="Timeout", response=response, body=None)
+    with pytest.raises(garak.exception.GeneratorBackoffTrigger):
+        raise garak.exception.GeneratorBackoffTrigger(
+            f"Transient HTTP {exc.status_code}, retrying with backoff"
+        ) from None
+
+
+def test_transient_429_raises_generator_backoff_trigger():
+    import garak.exception
+
+    with pytest.raises(garak.exception.GeneratorBackoffTrigger):
+        raise garak.exception.GeneratorBackoffTrigger(
+            "Transient HTTP 429, retrying with backoff"
+        ) from None
+
+
+def test_transient_502_raises_generator_backoff_trigger():
+    import garak.exception
+
+    with pytest.raises(garak.exception.GeneratorBackoffTrigger):
+        raise garak.exception.GeneratorBackoffTrigger(
+            "Transient HTTP 502, retrying with backoff"
+        ) from None
+
+
+def test_transient_status_code_tuple_members():
+    transient_codes = {408, 429, 502, 503, 504}
+    assert 408 in transient_codes
+    assert 429 in transient_codes
+    assert 502 in transient_codes
+    assert 503 in transient_codes
+    assert 408 in transient_codes
+    assert 404 not in transient_codes
+    assert 500 not in transient_codes
+    assert 403 not in transient_codes


### PR DESCRIPTION
Fixes #1967

When an OpenAI-compatible endpoint returns an HTTP error that doesn't have a dedicated SDK exception subclass (408, 429, 502, 503, 504), it arrives as a generic openai.APIStatusError and bypasses the backoff decorator, aborting the probe run on a single transient hiccup.

## What changed

Catch openai.APIStatusError inside _call_model. Transient status codes default to [408, 429, 502, 503, 504] and are configurable via a new transient_retry_codes DEFAULT_PARAMS field. Transient codes raise GeneratorBackoffTrigger so the existing fibonacci backoff retries them. Non-transient codes log a warning and return [None] so other probes can continue.

No changes to backoff decorator arguments. No giveup predicate. Follows the same pattern as the json.decoder.JSONDecodeError handler in the same method and applies to all OpenAICompatible subclasses.

## Files

garak/generators/openai.py
tests/generators/test_openai_compatible.py

Signed-off-by: Varshith Puli <pulivarshit@gmail.com>