### PR TITLE
fix: print the failing output text in verbose evaluator results

### DIFF
--- a/garak/evaluators/base.py
+++ b/garak/evaluators/base.py
@@ -6,6 +6,7 @@ These describe evaluators for assessing detector results.
 from collections import defaultdict
 import json
 import logging
+import re
 from pathlib import Path
 
 from typing import Iterable, Optional, Tuple, List
@@ -23,6 +24,21 @@ import garak.resources.theme
 # Minimum CI width (in percentage points) to display in output
 # CIs narrower than this provide no meaningful uncertainty information
 CI_DISPLAY_MIN_WIDTH = 0.001
+
+# C0 controls, DEL, and the C1 range that carries the single-byte CSI/OSC introducers
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
+
+def _escape_control_chars(text: str) -> str:
+    """Show control characters instead of sending them to the terminal.
+
+    Verbose output prints generator responses, and probes.ansiescape exists to elicit
+    escape sequences. Without this, a probe that succeeded would replay the payload
+    into the console running garak. resources.ansi keeps its own payloads in code
+    rather than a text file for the same reason.
+    """
+
+    return _CONTROL_CHARS.sub(lambda match: repr(match.group())[1:-1], text)
 
 
 class Evaluator:
@@ -400,7 +416,10 @@ class Evaluator:
                 if m is None or m.text is None:
                     continue
                 try:
-                    print("❌", m.text.strip().replace("\n", " "))
+                    print(
+                        "❌",
+                        _escape_control_chars(m.text.strip().replace("\n", " ")),
+                    )
                 except Exception:
                     pass
 
@@ -477,7 +496,10 @@ class Evaluator:
                 if m is None or m.text is None:
                     continue
                 try:
-                    print("❌", m.text.strip().replace("\n", " "))
+                    print(
+                        "❌",
+                        _escape_control_chars(m.text.strip().replace("\n", " ")),
+                    )
                 except Exception:
                     pass
 

--- a/garak/evaluators/base.py
+++ b/garak/evaluators/base.py
@@ -397,9 +397,11 @@ class Evaluator:
 
         if _config.system.verbose > 0 and messages:
             for m in messages:
+                if m is None or m.text is None:
+                    continue
                 try:
-                    print("❌", m.strip().replace("\n", " "))
-                except:
+                    print("❌", m.text.strip().replace("\n", " "))
+                except Exception:
                     pass
 
     def print_results_narrow(
@@ -472,9 +474,11 @@ class Evaluator:
 
         if _config.system.verbose > 0 and messages:
             for m in messages:
+                if m is None or m.text is None:
+                    continue
                 try:
-                    print("❌", m.strip().replace("\n", " "))
-                except:
+                    print("❌", m.text.strip().replace("\n", " "))
+                except Exception:
                     pass
 
 

--- a/tests/evaluators/test_base.py
+++ b/tests/evaluators/test_base.py
@@ -182,3 +182,18 @@ def test_eval_row_intents_scoped_per_detector(tmp_path):
     }
     assert "manipulation" not in rows["d.D2"]["intents"]
     assert rows["d.D2"]["total_evaluated"] == 2
+
+
+@pytest.mark.parametrize(
+    "print_func_name", ["print_results_wide", "print_results_narrow"]
+)
+def test_print_results_prints_failing_output(capsys, monkeypatch, print_func_name):
+    # messages hold Message objects, so the text has to come from .text
+    monkeypatch.setattr(garak._config.system, "verbose", 1, raising=False)
+    monkeypatch.setattr(garak._config.system, "show_z", False, raising=False)
+    ev = garak.evaluators.base.Evaluator.__new__(garak.evaluators.base.Evaluator)
+    ev.probename = "probe.Probe"
+    messages = [garak.attempt.Message(text="unsafe\noutput"), None]
+    getattr(ev, print_func_name)("detector.Detector", 0, 1, messages)
+    assert "unsafe output" in capsys.readouterr().out
+

--- a/tests/evaluators/test_base.py
+++ b/tests/evaluators/test_base.py
@@ -13,6 +13,7 @@ import garak._config
 import garak.analyze
 import garak.attempt
 import garak.evaluators.base
+import garak.resources.ansi
 
 
 class _CalibrationStub:
@@ -197,3 +198,34 @@ def test_print_results_prints_failing_output(capsys, monkeypatch, print_func_nam
     getattr(ev, print_func_name)("detector.Detector", 0, 1, messages)
     assert "unsafe output" in capsys.readouterr().out
 
+
+@pytest.mark.parametrize(
+    "print_func_name", ["print_results_wide", "print_results_narrow"]
+)
+@pytest.mark.parametrize("payload", garak.resources.ansi.LIVE_PAYLOADS)
+def test_print_results_escapes_ansi_payloads(
+    capsys, monkeypatch, print_func_name, payload
+):
+    # a successful ansiescape probe must not replay its payload into the terminal
+    monkeypatch.setattr(garak._config.system, "verbose", 1, raising=False)
+    monkeypatch.setattr(garak._config.system, "show_z", False, raising=False)
+    ev = garak.evaluators.base.Evaluator.__new__(garak.evaluators.base.Evaluator)
+    ev.probename = "probe.Probe"
+    getattr(ev, print_func_name)(
+        "detector.Detector", 0, 1, [garak.attempt.Message(text=payload)]
+    )
+    # garak colours its own status line, so only the response line is in scope here
+    response_lines = [
+        line for line in capsys.readouterr().out.splitlines() if line.startswith("❌")
+    ]
+    assert response_lines
+    for line in response_lines:
+        assert not any(
+            ord(char) < 0x20 or 0x7F <= ord(char) <= 0x9F for char in line
+        ), f"control character survived into {line!r}"
+
+
+def test_escape_control_chars_keeps_ordinary_text():
+    # non-control characters, including non-ASCII, have to survive untouched
+    text = "plain text with unicode: é中文 and symbols !@#"
+    assert garak.evaluators.base._escape_control_chars(text) == text


### PR DESCRIPTION
With `-v`, the evaluator is meant to print each failing generation after the score line. It never prints anything.

`messages` is filled with `attempt.outputs[idx]`, which are `Message` objects, but the print does `m.strip()`. `Message` has no `strip`, so every iteration raises `AttributeError` into a bare `except:` and the line is silently dropped:

```python
>>> Message(text="unsafe output").strip()
AttributeError: 'Message' object has no attribute 'strip'
```

So the summary line shows `FAIL ... attack success rate: 100.00%` and the failing outputs it is supposed to list are all swallowed.

Fix: take the text from `m.text` (the same way `detectors/exploitation.py` reads outputs), skip entries with no text, and narrow the bare `except:` to `except Exception:` so it no longer swallows `KeyboardInterrupt` / `SystemExit`. Both `print_results_wide` and `print_results_narrow` had the same code.

Added a regression test parametrized over both methods. It fails on `main` (nothing is printed) and passes with this change