### PR TITLE
Fix: continuation probe not pruning triggers with prompts

### DIFF
--- a/garak/probes/continuation.py
+++ b/garak/probes/continuation.py
@@ -78,7 +78,7 @@ class ContinueSlursReclaimedSlursFull(garak.probes.Probe):
                     self.triggers.append(term)
 
         if self.follow_prompt_cap:
-            self._prune_data(self.soft_probe_prompt_cap)
+            self._prune_data(self.soft_probe_prompt_cap, prune_triggers=True)
 
         if self.langprovider is not None:
             preparation_bar = tqdm.tqdm(

--- a/tests/probes/test_probes_continuation.py
+++ b/tests/probes/test_probes_continuation.py
@@ -56,3 +56,24 @@ def test_continuation_continuations_valid(probename):
             assert (
                 matched == True
             ), "Prompts should end with starting substring of trigger"
+
+
+@pytest.mark.parametrize("probename", CONTINUATION_PROBES)
+def test_continuation_prompt_trigger_alignment(probename):
+    # prompts and triggers are parallel, index-aligned lists (prompts[i] pairs with
+    # triggers[i]). The soft prompt cap must prune them together so they stay the same
+    # length; otherwise _attempt_prestore_hook annotates each prompt with the wrong
+    # trigger. Regression test for triggers not being pruned alongside prompts.
+    p = garak._plugins.load_plugin(probename)
+    assert len(p.prompts) == len(
+        p.triggers
+    ), "prompts and triggers must stay aligned (equal length) after prompt-cap pruning"
+
+    # Each surviving prompt must still correspond to its own trigger.
+    for seq, prompt in enumerate(p.prompts):
+        if not prompt.endswith(" "):
+            trigger = p.triggers[seq]
+            candidate_matches = [trigger[1:n] for n in range(len(trigger) - 1)]
+            assert any(prompt.endswith(candidate) for candidate in candidate_matches), (
+                "each prompt must align with its own trigger after pruning"
+            )


### PR DESCRIPTION
## Problem

`Continuation` builds `self.prompts` and `self.triggers` as index-aligned parallel lists, then applies the soft prompt cap:

```python
if self.follow_prompt_cap:
    self._prune_data(self.soft_probe_prompt_cap)
```

`Probe._prune_data` (`probes/base.py`) randomly deletes entries from `self.prompts`, but only deletes the matching `self.triggers[id]` when `prune_triggers=True` — which defaults to `False`:

```python
def _prune_data(self, cap, prune_triggers=False):
    ...
    for id in ids_to_rm:
        del self.prompts[id]
        if prune_triggers:
            del self.triggers[id]
```

So `self.prompts` shrinks while `self.triggers` keeps its full length. `_attempt_prestore_hook` then reads triggers by the **pruned-prompt** index:

```python
attempt.notes["triggers"] = [str(self.triggers[seq])]
```

Every prompt at or after the first pruned index is annotated with **another prompt's trigger term**, and the paired `Continuation` detector scans each output for the wrong trigger → wrong hit/miss scores (both false negatives and false positives).

## Evidence (siblings prove intent)

Every other probe that keeps a parallel `self.triggers` list passes the flag:
- `probes/leakreplay.py` → `self._prune_data(self.soft_probe_prompt_cap, prune_triggers=True)` (×2)
- `probes/glitch.py` → `self._prune_data(self.soft_probe_prompt_cap, prune_triggers=True)`

`continuation` is the only probe that maintains `self.triggers` *and* omits the flag. (The other omitters — `dan`, `phrasing`, `suffix`, `apikey`, `packagehallucination`, `adaptive_attacks` — have no `self.triggers`, so their omission is harmless.)

## Reachability

`ContinueSlursReclaimedSlurs` is `active = True` and sets `follow_prompt_cap = True`. Its `slurprompts_mini.jsonl` expands to 285 unique prompts, over the default `soft_probe_prompt_cap = 256`, so `_prune_data` deletes 29 prompts on a normal run — corrupting trigger alignment by default.

## Reproduction

Building 160 aligned prompt/trigger pairs with cap 30:

| | prompts kept | triggers kept | misaligned prompts |
|---|---|---|---|
| before (flag omitted) | 30 | 160 | 30 ❌ |
| after (`prune_triggers=True`) | 30 | 30 | 0 ✅ |

## Fix

```python
self._prune_data(self.soft_probe_prompt_cap, prune_triggers=True)
```
