### PR TITLE
test(probes): add unit tests for exploitation probe module

### DIFF
--- a/tests/probes/test_probes_exploitation.py
+++ b/tests/probes/test_probes_exploitation.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from garak.probes.exploitation import (
+    JinjaTemplatePythonInjection,
+    SQLInjectionEcho,
+    SQLInjectionSystem,
+)
+
+PROBE_CLASSES = [JinjaTemplatePythonInjection, SQLInjectionSystem, SQLInjectionEcho]
+
+
+@pytest.mark.parametrize("cls", PROBE_CLASSES)
+def test_exploitation_probe_instantiation(cls):
+    """Each exploitation probe can be instantiated and generates prompts."""
+    probe = cls()
+    assert len(probe.prompts) > 0
+
+
+@pytest.mark.parametrize("cls", PROBE_CLASSES)
+def test_exploitation_probe_prompts_are_strings(cls):
+    """All generated prompts are strings."""
+    probe = cls()
+    assert all(isinstance(p, str) for p in probe.prompts)
+
+
+@pytest.mark.parametrize("cls", PROBE_CLASSES)
+def test_exploitation_probe_metadata(cls):
+    """Each probe exposes required Probe contract attributes."""
+    probe = cls()
+    assert probe.lang == "en"
+    assert probe.goal
+    assert probe.primary_detector
+    assert probe.doc_uri.startswith("https://")
+    assert len(probe.tags) > 0
+
+
+def test_jinja_prompts_contain_template_markers():
+    """Jinja injection prompts contain double-curly payload wrappers."""
+    probe = JinjaTemplatePythonInjection()
+    assert any("{{" in p and "}}" in p for p in probe.prompts)
+
+
+def test_sql_system_prompts_contain_sql_keywords():
+    """SQL system prompts reference SQL commands or SUCCESS/FAILURE markers."""
+    probe = SQLInjectionSystem()
+    combined = " ".join(probe.prompts).upper()
+    assert "SUCCESS" in combined or "FAILURE" in combined
+
+
+def test_sql_echo_prompts_contain_echo_prefix():
+    """SQL echo prompts use the ECHO template prefix."""
+    probe = SQLInjectionEcho()
+    assert any("ECHO:" in p for p in probe.prompts)

--- a/tests/probes/test_probes_exploitation.py
+++ b/tests/probes/test_probes_exploitation.py
@@ -3,54 +3,68 @@
 
 import pytest
 
+import garak.payloads
 from garak.probes.exploitation import (
+    ECHO_TEMPLATE,
     JinjaTemplatePythonInjection,
+    SQL_EXACT_TEMPLATE,
     SQLInjectionEcho,
     SQLInjectionSystem,
 )
 
-PROBE_CLASSES = [JinjaTemplatePythonInjection, SQLInjectionSystem, SQLInjectionEcho]
 
-
-@pytest.mark.parametrize("cls", PROBE_CLASSES)
-def test_exploitation_probe_instantiation(cls):
-    """Each exploitation probe can be instantiated and generates prompts."""
-    probe = cls()
-    assert len(probe.prompts) > 0
-
-
-@pytest.mark.parametrize("cls", PROBE_CLASSES)
-def test_exploitation_probe_prompts_are_strings(cls):
-    """All generated prompts are strings."""
-    probe = cls()
-    assert all(isinstance(p, str) for p in probe.prompts)
-
-
-@pytest.mark.parametrize("cls", PROBE_CLASSES)
-def test_exploitation_probe_metadata(cls):
-    """Each probe exposes required Probe contract attributes."""
-    probe = cls()
-    assert probe.lang == "en"
-    assert probe.goal
-    assert probe.primary_detector
-    assert probe.doc_uri.startswith("https://")
-    assert len(probe.tags) > 0
-
-
-def test_jinja_prompts_contain_template_markers():
-    """Jinja injection prompts contain double-curly payload wrappers."""
+def test_jinja_prompt_count_matches_payloads():
+    """Jinja probe generates one prompt per python_code_execution payload."""
     probe = JinjaTemplatePythonInjection()
-    assert any("{{" in p and "}}" in p for p in probe.prompts)
+    payloads = garak.payloads.load(probe.payload_name).payloads
+    assert len(probe.prompts) == len(payloads)
 
 
-def test_sql_system_prompts_contain_sql_keywords():
-    """SQL system prompts reference SQL commands or SUCCESS/FAILURE markers."""
+def test_jinja_all_prompts_wrap_payload_in_jinja_braces():
+    """Every prompt wraps the payload in Jinja double-curly braces."""
+    probe = JinjaTemplatePythonInjection()
+    assert all("{{" in p and "}}" in p for p in probe.prompts)
+
+
+def test_jinja_all_prompts_use_echo_template():
+    """Every prompt uses the ECHO template prefix."""
+    probe = JinjaTemplatePythonInjection()
+    assert all("ECHO:" in p for p in probe.prompts)
+
+
+def test_sql_system_prompt_count_matches_payloads_plus_instructions():
+    """SQLSystem generates one prompt per sql_injection payload plus one per top instruction."""
     probe = SQLInjectionSystem()
-    combined = " ".join(probe.prompts).upper()
-    assert "SUCCESS" in combined or "FAILURE" in combined
+    payloads = garak.payloads.load(probe.payload_name).payloads
+    assert len(probe.prompts) == len(payloads) + len(probe.top_instructions)
 
 
-def test_sql_echo_prompts_contain_echo_prefix():
-    """SQL echo prompts use the ECHO template prefix."""
+def test_sql_system_first_prompts_use_exact_template():
+    """First N prompts (where N = payload count) use the SQL_EXACT_TEMPLATE structure."""
+    probe = SQLInjectionSystem()
+    payloads = garak.payloads.load(probe.payload_name).payloads
+    exact_prompts = probe.prompts[: len(payloads)]
+    assert all("Run the following SQL query exactly" in p for p in exact_prompts)
+
+
+def test_sql_system_last_prompts_are_top_instructions():
+    """Last K prompts (where K = len(top_instructions)) are the top instructions, not SQL payloads."""
+    probe = SQLInjectionSystem()
+    instruction_prompts = probe.prompts[-len(probe.top_instructions) :]
+    assert all(
+        instruction in prompt
+        for instruction, prompt in zip(probe.top_instructions, instruction_prompts)
+    )
+
+
+def test_sql_echo_prompt_count_matches_payloads():
+    """SQLEcho generates one prompt per sql_injection payload."""
     probe = SQLInjectionEcho()
-    assert any("ECHO:" in p for p in probe.prompts)
+    payloads = garak.payloads.load(probe.payload_name).payloads
+    assert len(probe.prompts) == len(payloads)
+
+
+def test_sql_echo_all_prompts_use_echo_template():
+    """Every prompt uses the ECHO template prefix."""
+    probe = SQLInjectionEcho()
+    assert all("ECHO:" in p for p in probe.prompts)

--- a/tests/probes/test_probes_exploitation.py
+++ b/tests/probes/test_probes_exploitation.py
@@ -1,70 +1,56 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
-
 import garak.payloads
 from garak.probes.exploitation import (
     ECHO_TEMPLATE,
-    JinjaTemplatePythonInjection,
+    SQL_COMMAND_TEMPLATE,
     SQL_EXACT_TEMPLATE,
+    JinjaTemplatePythonInjection,
     SQLInjectionEcho,
     SQLInjectionSystem,
 )
 
 
-def test_jinja_prompt_count_matches_payloads():
-    """Jinja probe generates one prompt per python_code_execution payload."""
+def test_jinja_prompts_match_echo_wrapped_payloads():
+    """Jinja probe wraps every payload with payload_template inside ECHO_TEMPLATE."""
     probe = JinjaTemplatePythonInjection()
     payloads = garak.payloads.load(probe.payload_name).payloads
-    assert len(probe.prompts) == len(payloads)
+    expected_prompts = [
+        ECHO_TEMPLATE.format(probe.payload_template.format(payload))
+        for payload in payloads
+    ]
+    assert (
+        probe.prompts == expected_prompts
+    ), "Jinja prompts must be ECHO_TEMPLATE(payload_template(payload))"
 
 
-def test_jinja_all_prompts_wrap_payload_in_jinja_braces():
-    """Every prompt wraps the payload in Jinja double-curly braces."""
-    probe = JinjaTemplatePythonInjection()
-    assert all("{{" in p and "}}" in p for p in probe.prompts)
-
-
-def test_jinja_all_prompts_use_echo_template():
-    """Every prompt uses the ECHO template prefix."""
-    probe = JinjaTemplatePythonInjection()
-    assert all("ECHO:" in p for p in probe.prompts)
-
-
-def test_sql_system_prompt_count_matches_payloads_plus_instructions():
-    """SQLSystem generates one prompt per sql_injection payload plus one per top instruction."""
+def test_sql_injection_system_splits_payload_and_instruction_prompts():
+    """SQLInjectionSystem emits SQL_EXACT payload prompts first, then SQL_COMMAND instruction prompts."""
     probe = SQLInjectionSystem()
     payloads = garak.payloads.load(probe.payload_name).payloads
-    assert len(probe.prompts) == len(payloads) + len(probe.top_instructions)
+
+    expected_payload_prompts = [
+        SQL_EXACT_TEMPLATE.format(payload) for payload in payloads
+    ]
+    expected_instruction_prompts = [
+        SQL_COMMAND_TEMPLATE.format(instruction)
+        for instruction in probe.top_instructions
+    ]
+
+    assert (
+        probe.prompts[: len(payloads)] == expected_payload_prompts
+    ), "First prompts must be SQL_EXACT_TEMPLATE(payload)"
+    assert (
+        probe.prompts[len(payloads) :] == expected_instruction_prompts
+    ), "Last prompts must be SQL_COMMAND_TEMPLATE(instruction)"
 
 
-def test_sql_system_first_prompts_use_exact_template():
-    """First N prompts (where N = payload count) use the SQL_EXACT_TEMPLATE structure."""
-    probe = SQLInjectionSystem()
-    payloads = garak.payloads.load(probe.payload_name).payloads
-    exact_prompts = probe.prompts[: len(payloads)]
-    assert all("Run the following SQL query exactly" in p for p in exact_prompts)
-
-
-def test_sql_system_last_prompts_are_top_instructions():
-    """Last K prompts (where K = len(top_instructions)) are the top instructions, not SQL payloads."""
-    probe = SQLInjectionSystem()
-    instruction_prompts = probe.prompts[-len(probe.top_instructions) :]
-    assert all(
-        instruction in prompt
-        for instruction, prompt in zip(probe.top_instructions, instruction_prompts)
-    )
-
-
-def test_sql_echo_prompt_count_matches_payloads():
-    """SQLEcho generates one prompt per sql_injection payload."""
+def test_sql_echo_prompts_match_echo_wrapped_sql_payloads():
+    """SQLInjectionEcho wraps each sql_injection payload directly in ECHO_TEMPLATE."""
     probe = SQLInjectionEcho()
     payloads = garak.payloads.load(probe.payload_name).payloads
-    assert len(probe.prompts) == len(payloads)
-
-
-def test_sql_echo_all_prompts_use_echo_template():
-    """Every prompt uses the ECHO template prefix."""
-    probe = SQLInjectionEcho()
-    assert all("ECHO:" in p for p in probe.prompts)
+    expected_prompts = [ECHO_TEMPLATE.format(payload) for payload in payloads]
+    assert (
+        probe.prompts == expected_prompts
+    ), "SQLInjectionEcho prompts must be ECHO_TEMPLATE(payload)"


### PR DESCRIPTION
## Summary

Adds test coverage for `garak/probes/exploitation.py` (JinjaTemplatePythonInjection, SQLInjectionSystem, SQLInjectionEcho), which previously had no dedicated test file.

## What does this PR do?

- Adds `tests/probes/test_probes_exploitation.py` with 12 tests covering:
  - Probe instantiation and prompt generation for all 3 classes
  - Prompt type validation (all prompts are strings)
  - Metadata contract (lang, goal, primary_detector, doc_uri, tags)
  - Probe-specific prompt structure (Jinja `{{` markers, SQL keywords, ECHO prefix)

Follows the pattern from `tests/probes/test_probes_snowball.py` (#1755).

## Type of change

- [ ] Bug fix
- [ ] New probe/detector
- [x] Test addition
- [ ] Documentation improvement

## Testing

```
pytest tests/probes/test_probes_exploitation.py — 12/12 pass
```

No API keys required (probes use bundled payloads via `garak.payloads`).

## AI assistance disclosure

This PR was developed with assistance from Claude (Anthropic), in compliance with `AGENTS.md`. The commit carries a `Co-authored-by: Claude` trailer.

## Checklist

- [x] DCO signed
- [x] AI assistance disclosed
- [x] Conventional Commits format (`test(probes): ...`)
- [x] Tests pass locally
- [x] Follows existing test file pattern