### PR TITLE
double escape for 'dot' literal match in regex

### DIFF
--- a/garak/analyze/report_digest.py
+++ b/garak/analyze/report_digest.py
@@ -114,7 +114,7 @@ def _extract_to_probespec(setup: dict) -> str:
         active_probes = setup.get("plugins.probe_spec") or "probes.*"
     if isinstance(active_probes, list):
         # # aggregated reports may store a pre-rendered string, newer reports store a list
-        active_probes = ",".join([re.sub("^probes\.", "", p) for p in active_probes])
+        active_probes = ",".join([re.sub("^probes\\.", "", p) for p in active_probes])
     return active_probes
 
 


### PR DESCRIPTION
Silence warning from core python about single character literal escape in `str`.

```
>>> active_probes = ['probes.adaptive_attacks.AdaptiveAttacks', 'probes.ansiescape.AnsiEscaped', 'probes.ansiescape.AnsiRaw']
>>> test_val = ",".join([re.sub("^probes\.", "", p) for p in active_probes])
<stdin>:1: SyntaxWarning: invalid escape sequence '\.'
>>> test_fix_val = ",".join([re.sub("^probes\\.", "", p) for p in active_probes])
>>> test_val == test_fix_val
True
```


## Verification

- [ ] Run the tests and ensure they pass `python -m pytest tests/`
