### PR TITLE
Forward generation parameters to Ollama via options dict

### DIFF
--- a/garak/generators/ollama.py
+++ b/garak/generators/ollama.py
@@ -61,6 +61,7 @@ class OllamaGenerator(Generator):
         "max_tokens": ("num_predict", int),
         "temperature": ("temperature", float),
         "top_k": ("top_k", int),
+        "seed": ("seed", int),
     }
 
     def __init__(self, name="", config_root=_config):

--- a/garak/generators/ollama.py
+++ b/garak/generators/ollama.py
@@ -1,5 +1,6 @@
 """Ollama interface"""
 
+import logging
 from typing import List, Union
 
 import backoff
@@ -23,11 +24,28 @@ class OllamaGenerator(Generator):
     """Interface for Ollama endpoints
 
     Model names can be passed in short form like "llama2" or specific versions or sizes like "gemma:7b" or "llama2:latest"
+
+    suppressed_params (set[str], default empty): garak attribute names to omit from
+    the Ollama request `options` dict, regardless of whether the corresponding
+    attribute is set. Suppression is applied at request-assembly time, so it
+    overrides per-probe parameter mutation (such as promptinject's
+    _generator_precall_hook). Use garak attribute names (max_tokens, temperature,
+    top_k).
+
+    Example garak.site.yaml config to suppress top_k::
+
+        plugins:
+          generators:
+            ollama:
+              OllamaGenerator:
+                suppressed_params:
+                  - top_k
     """
 
     DEFAULT_PARAMS = Generator.DEFAULT_PARAMS | {
         "timeout": 30,  # Add a timeout of 30 seconds. Ollama can tend to hang forever on failures, if this is not present
         "host": "127.0.0.1:11434",  # The default host of an Ollama server. This can be overwritten with a passed config or generator config file.
+        "suppressed_params": set(),
     }
 
     active = True
@@ -35,12 +53,46 @@ class OllamaGenerator(Generator):
     parallel_capable = False
     extra_dependency_names = ["ollama"]
 
+    # Maps garak attribute names to (Ollama options field name, coerce fn).
+    # Ollama takes generation parameters nested under `options`, and names the
+    # output cap `num_predict`, so the mapping is a translation rather than a
+    # passthrough.
+    _PARAM_MAP = {
+        "max_tokens": ("num_predict", int),
+        "temperature": ("temperature", float),
+        "top_k": ("top_k", int),
+    }
+
     def __init__(self, name="", config_root=_config):
         super().__init__(name, config_root)  # Sets the name and generations
 
         self.client = self.ollama.Client(
             self.host, timeout=self.timeout
         )  # Instantiates the client with the timeout
+
+        self.suppressed_params = set(self.suppressed_params)
+        for param in self.suppressed_params:
+            if param not in self._PARAM_MAP:
+                logging.warning(
+                    f"suppressed_params entry '{param}' is not a known OllamaGenerator "
+                    f"parameter. Valid keys are: {sorted(self._PARAM_MAP)}."
+                )
+
+    def _build_options(self):
+        """Assemble the Ollama `options` dict from configured generation params.
+
+        Returns None when nothing is set, which the ollama client treats the same
+        as omitting the argument.
+        """
+        options = {}
+        for attr, (api_field, coerce) in self._PARAM_MAP.items():
+            if attr in self.suppressed_params:
+                continue
+            value = getattr(self, attr, None)
+            if value is None:
+                continue
+            options[api_field] = coerce(value)
+        return options or None
 
     @backoff.on_exception(
         backoff.fibo,
@@ -55,7 +107,11 @@ class OllamaGenerator(Generator):
         self, prompt: Conversation, generations_this_call: int = 1
     ) -> List[Union[Message, None]]:
         try:
-            response = self.client.generate(self.name, prompt.last_message().text)
+            response = self.client.generate(
+                self.name,
+                prompt.last_message().text,
+                options=self._build_options(),
+            )
         except Exception as e:
             if (
                 isinstance(e, self.ollama.ResponseError) and e.status_code == 404
@@ -94,6 +150,7 @@ class OllamaGeneratorChat(OllamaGenerator):
             response = self.client.chat(
                 model=self.name,
                 messages=messages,
+                options=self._build_options(),
             )
         except Exception as e:
             if (

--- a/tests/generators/test_ollama.py
+++ b/tests/generators/test_ollama.py
@@ -239,6 +239,7 @@ def test_ollama_chat_forwards_generation_options(respx_mock):
     gen.max_tokens = 10
     gen.temperature = 0.1
     gen.top_k = 3
+    gen.seed = 42
     conv = Conversation([Turn("user", Message("Bla bla"))])
     gen.generate(conv)
 
@@ -246,6 +247,7 @@ def test_ollama_chat_forwards_generation_options(respx_mock):
     assert sent["options"]["num_predict"] == 10
     assert sent["options"]["temperature"] == 0.1
     assert sent["options"]["top_k"] == 3
+    assert sent["options"]["seed"] == 42
 
 
 @pytest.mark.skipif(
@@ -298,7 +300,7 @@ def test_ollama_chat_sends_default_max_tokens(respx_mock):
     gen.generate(conv)
 
     sent = json.loads(respx_mock.calls.last.request.content)
-    assert sent["options"] == {"num_predict": 150}
+    assert sent["options"] == {"num_predict": gen.max_tokens}
 
 
 @pytest.mark.skipif(
@@ -328,4 +330,4 @@ def test_ollama_chat_honours_suppressed_params(respx_mock):
 
     sent = json.loads(respx_mock.calls.last.request.content)
     assert "temperature" not in sent["options"]
-    assert sent["options"]["num_predict"] == 150
+    assert sent["options"]["num_predict"] == gen.max_tokens

--- a/tests/generators/test_ollama.py
+++ b/tests/generators/test_ollama.py
@@ -1,4 +1,5 @@
 import importlib
+import json
 import pytest
 import respx
 import httpx
@@ -214,3 +215,117 @@ def test_error_on_nonexistant_model_chat_mocked(respx_mock):
     with pytest.raises(ollama.ResponseError):
         conv = Conversation([Turn("user", Message("This shouldnt work"))])
         gen.generate(conv)
+
+
+@pytest.mark.skipif(
+    not all(
+        [
+            importlib.util.find_spec(m)
+            for m in OllamaGeneratorChat.extra_dependency_names
+        ]
+    ),
+    reason="missing optional dependency",
+)
+@pytest.mark.respx(base_url="http://" + OllamaGenerator.DEFAULT_PARAMS["host"])
+def test_ollama_chat_forwards_generation_options(respx_mock):
+    mock_response = {
+        "model": "mistral",
+        "message": {"role": "assistant", "content": "Hello how are you?"},
+    }
+    respx_mock.post("/api/chat").mock(
+        return_value=httpx.Response(200, json=mock_response)
+    )
+    gen = OllamaGeneratorChat("mistral")
+    gen.max_tokens = 10
+    gen.temperature = 0.1
+    gen.top_k = 3
+    conv = Conversation([Turn("user", Message("Bla bla"))])
+    gen.generate(conv)
+
+    sent = json.loads(respx_mock.calls.last.request.content)
+    assert sent["options"]["num_predict"] == 10
+    assert sent["options"]["temperature"] == 0.1
+    assert sent["options"]["top_k"] == 3
+
+
+@pytest.mark.skipif(
+    not all(
+        [importlib.util.find_spec(m) for m in OllamaGenerator.extra_dependency_names]
+    ),
+    reason="missing optional dependency",
+)
+@pytest.mark.respx(base_url="http://" + OllamaGenerator.DEFAULT_PARAMS["host"])
+def test_ollama_forwards_generation_options(respx_mock):
+    mock_response = {"model": "mistral", "response": "Hello how are you?"}
+    respx_mock.post("/api/generate").mock(
+        return_value=httpx.Response(200, json=mock_response)
+    )
+    gen = OllamaGenerator("mistral")
+    gen.max_tokens = 10
+    gen.temperature = 0.1
+    gen.top_k = 3
+    conv = Conversation([Turn("user", Message("Bla bla"))])
+    gen.generate(conv)
+
+    sent = json.loads(respx_mock.calls.last.request.content)
+    assert sent["options"]["num_predict"] == 10
+    assert sent["options"]["temperature"] == 0.1
+    assert sent["options"]["top_k"] == 3
+
+
+@pytest.mark.skipif(
+    not all(
+        [
+            importlib.util.find_spec(m)
+            for m in OllamaGeneratorChat.extra_dependency_names
+        ]
+    ),
+    reason="missing optional dependency",
+)
+@pytest.mark.respx(base_url="http://" + OllamaGenerator.DEFAULT_PARAMS["host"])
+def test_ollama_chat_sends_default_max_tokens(respx_mock):
+    # max_tokens defaults to 150 in Generator.DEFAULT_PARAMS, so an unconfigured
+    # generator still caps output. Nothing else is set, so no other option is sent.
+    mock_response = {
+        "model": "mistral",
+        "message": {"role": "assistant", "content": "Hello how are you?"},
+    }
+    respx_mock.post("/api/chat").mock(
+        return_value=httpx.Response(200, json=mock_response)
+    )
+    gen = OllamaGeneratorChat("mistral")
+    conv = Conversation([Turn("user", Message("Bla bla"))])
+    gen.generate(conv)
+
+    sent = json.loads(respx_mock.calls.last.request.content)
+    assert sent["options"] == {"num_predict": 150}
+
+
+@pytest.mark.skipif(
+    not all(
+        [
+            importlib.util.find_spec(m)
+            for m in OllamaGeneratorChat.extra_dependency_names
+        ]
+    ),
+    reason="missing optional dependency",
+)
+@pytest.mark.respx(base_url="http://" + OllamaGenerator.DEFAULT_PARAMS["host"])
+def test_ollama_chat_honours_suppressed_params(respx_mock):
+    # suppression applies at request-assembly time, so it wins over a set attribute
+    mock_response = {
+        "model": "mistral",
+        "message": {"role": "assistant", "content": "Hello how are you?"},
+    }
+    respx_mock.post("/api/chat").mock(
+        return_value=httpx.Response(200, json=mock_response)
+    )
+    gen = OllamaGeneratorChat("mistral")
+    gen.temperature = 0.1
+    gen.suppressed_params = {"temperature"}
+    conv = Conversation([Turn("user", Message("Bla bla"))])
+    gen.generate(conv)
+
+    sent = json.loads(respx_mock.calls.last.request.content)
+    assert "temperature" not in sent["options"]
+    assert sent["options"]["num_predict"] == 150


### PR DESCRIPTION
Fixes #1992.

`OllamaGenerator` and `OllamaGeneratorChat` inherit `max_tokens`, `temperature` and `top_k` from
`Generator.DEFAULT_PARAMS`, accept configured values for them, then send none of them. Ollama takes
generation parameters nested under an `options` key that neither `_call_model` populated, so garak
dropped the values before the request left. Only `timeout` and `host` survived, because `__init__`
consumes those when building the client.

This follows the `_PARAM_MAP` / `suppressed_params` pattern from #1842:

```python
DEFAULT_PARAMS = Generator.DEFAULT_PARAMS | {
    "timeout": 30,
    "host": "127.0.0.1:11434",
    "suppressed_params": set(),
}

_PARAM_MAP = {
    "max_tokens": ("num_predict", int),
    "temperature": ("temperature", float),
    "top_k": ("top_k", int),
}
```

`__init__` coerces `suppressed_params` to a set and warns on keys outside `_PARAM_MAP`, matching
`BedrockGenerator`. `_build_options` returns `None` when the map yields nothing, which the ollama
client treats the same as omitting `options`.

On structure: `BedrockGenerator` assembles `inferenceConfig` inline because it has a single
`_call_model`. Ollama has two, on `OllamaGenerator` and `OllamaGeneratorChat`, so the loop sits in
a `_build_options` helper on the base class that both share. That also means the `OllamaVision`
generator proposed in #1764 inherits it without changes. Happy to inline it twice if you would
rather it match Bedrock line for line.

**`context_len` is not mapped to `num_ctx`.** Elsewhere garak treats `context_len` as a description
of the model's window rather than a request to set one: `openai.py:411` and `azure.py:113` read it
from a table of known windows, and `resources/api/huggingface.py:18` reads it from `config.n_ctx`.
Those read a value in from what the model already is; `num_ctx` writes one out to resize the
server's KV cache. Ollama is one of the few backends where setting it is meaningful, so this seemed
like a maintainer call. With `_PARAM_MAP` in place it is a one-line addition.

**This changes default behaviour.** `Generator.DEFAULT_PARAMS` sets `max_tokens` to 150 rather than
`None`, so an unconfigured Ollama generator now sends `{"num_predict": 150}`. Runs that generate
until the model stops today cap near 600 characters after this.

That brings the generator in line with the documented default and with the rest of the tree.
Existing Ollama users will still see shorter responses, and scans compared across the change will
shift.

## Verification

- [x] Supporting configuration
``` json
{
    "ollama": {
        "OllamaGeneratorChat": {
            "max_tokens": 10,
            "suppressed_params": ["max_tokens"]
        }
    }
}
```
- [x] `garak -t ollama -n llama3.1:8b --probes encoding.InjectROT13`
- [x] Run the tests and ensure they pass `python -m pytest tests/` (365 passed, 13 skipped in
  `tests/generators/`)
- [x] **Verify** the thing does what it should: with `max_tokens: 10`, response length drops from a
  median of 323 characters to 39, matching an `openai.OpenAICompatible` control at 41 against the
  same Ollama server. Wall clock drops from 118.90s to 22.40s.
- [x] **Verify** the thing does not do what it should not: adding `max_tokens` to
  `suppressed_params` restores the old behaviour on demand, median 334 and max 1535, matching
  unpatched `main` at 323 and 1711. Suppression takes effect at request-assembly time.
- [x] **Document** the thing and how it works: the `OllamaGenerator` class docstring covers
  `suppressed_params` with a `garak.site.yaml` example, following `BedrockGenerator`.

Four tests assert on the outgoing HTTP request body, covering the chat endpoint, the generate
endpoint, the unconfigured default, and suppression overriding a set attribute. All four fail
against `main` with `KeyError: 'options'`.