### PR TITLE
docs: describe how to add a core config option and CLI switch

### DIFF
--- a/docs/source/extending.cli.rst
+++ b/docs/source/extending.cli.rst
@@ -1,0 +1,142 @@
+Adding a configuration option
+=============================
+
+This page describes how to add a new core ``garak`` configuration value and expose it as a
+command-line switch.
+
+It covers changes to ``garak`` itself. If instead you want to make a *plugin* configurable,
+you don't need any of this -- add the value to the plugin's ``DEFAULT_PARAMS`` and it becomes
+settable from YAML and JSON automatically. See :doc:`configurable`.
+
+
+Where configuration values live
+-------------------------------
+
+Core config is split into sections, each held as an object in ``garak._config``:
+
+* ``system`` -- options that don't affect the security assessment
+* ``run`` -- options that describe how a run is conducted
+* ``plugins`` -- which plugins to use, and their configuration
+* ``reporting`` -- how results are recorded and presented
+
+There's also ``transient``, which holds values internal to a single execution, such as the run
+ID and report filename. It isn't set by users and isn't covered here.
+
+Each of the four user-facing sections has two things attached to it:
+
+* **Defaults**, in ``garak/resources/garak.core.yaml``, under a top-level key of the same name.
+* **A list of the option names the CLI may write into it**, in ``garak/_config.py``:
+  ``system_params``, ``run_params``, ``plugins_params``, and ``reporting_params``.
+
+Once argparse has parsed the command line, ``garak/cli.py`` walks the parsed arguments and
+copies each one into whichever section's ``*_params`` list names it. **An argument that
+appears in none of those lists is discarded**, and only mentioned at debug log level -- so an
+option registered with argparse but not with a section parses without complaint and then
+quietly has no effect. This is the easiest mistake to make here.
+
+For the full precedence order between defaults, config files and the command line, see
+:doc:`configurable`.
+
+
+Adding an option to an existing section
+---------------------------------------
+
+Suppose we want ``--max_retries``, an integer, in the ``run`` section. That's three edits and
+a test.
+
+1. Add the default to core config
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In ``garak/resources/garak.core.yaml``, under the section the option belongs to:
+
+.. code-block:: yaml
+
+    run:
+      seed:
+      deprefix: true
+      max_retries: 3
+
+Every core option should have an entry here, even if the value is empty -- this file is the
+canonical list of what garak understands.
+
+2. Register the name with the section
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In ``garak/_config.py``, add the option name to the matching ``*_params`` string:
+
+.. code-block:: python
+
+    run_params = "seed deprefix eval_threshold generations interactive system_prompt spec max_retries".split()
+
+This is the step that connects the switch to the config section. Without it the value never
+reaches ``_config.run``.
+
+3. Add the command-line switch
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In ``garak/cli.py``, add an argument in the block for that section -- the argument definitions
+are grouped by section, under ``## SYSTEM``, ``## RUN``, and so on. Take the default from the
+config section rather than hard-coding it, so that core config, site config and run config all
+still apply when the switch is absent:
+
+.. code-block:: python
+
+    parser.add_argument(
+        "--max_retries",
+        type=int,
+        default=_config.run.max_retries,
+        help="how many times to retry a failed generator request",
+    )
+
+Long option names are ``snake_case``. Add a short form only if the option is likely to be used
+often; short forms are scarce.
+
+4. Add a test
+~~~~~~~~~~~~~
+
+``tests/test_config.py`` works out which section an option belongs to from the ``*_params``
+lists, so it can route your option as soon as step 2 is done -- but it only exercises options
+that are listed explicitly. Add yours to:
+
+* ``OPTIONS_PARAM``, as an ``(option, value)`` pair, if it takes a value; or
+* ``OPTIONS_SOLO``, if it's an ``action="store_true"`` flag.
+
+That covers it from both the command line and YAML, via ``test_cli_param_settings``,
+``test_cli_solo_settings`` and ``test_yaml_param_settings``.
+
+Checking it worked
+~~~~~~~~~~~~~~~~~~
+
+``--list_config`` dumps the resolved configuration without starting a run:
+
+.. code-block:: console
+
+    $ python -m garak --max_retries 5 --list_config
+
+Your option should appear under the right section, with the value you passed. Run it again
+without the switch, and you should see the default from ``garak.core.yaml``. If the value is
+missing from both, step 2 is where to look.
+
+
+Adding a new configuration section
+----------------------------------
+
+Adding a whole new section is rarer, and worth raising as an issue first. It needs four
+changes, all following what the existing sections do:
+
+* In ``garak/_config.py``, add an instance alongside ``system``, ``run``, ``plugins`` and
+  ``reporting``. They're all instances of the same empty ``GarakSubConfig`` dataclass.
+* In ``garak/_config.py``, add a matching ``<section>_params`` string.
+* In ``_store_config()``, declare the new object ``global`` and populate it from the parsed
+  settings with ``_set_settings()``, as the other sections are.
+* In ``garak/cli.py``, add a branch to the loop that dispatches parsed arguments to sections.
+
+The new section also needs a top-level key in ``garak/resources/garak.core.yaml``.
+
+
+What you don't need to update
+-----------------------------
+
+``docs/source/cliref.rst`` is generated from ``python -m garak --help`` by the ``cliref``
+target in ``docs/source/Makefile``, and is regenerated during release packaging. Don't edit it
+by hand.

--- a/docs/source/extending.rst
+++ b/docs/source/extending.rst
@@ -33,6 +33,13 @@ If you use custom modules not included in garak's default list, include these in
 Garak's plugin loader (``garak._plugins.load_plugin()``) will manage the import and inject the requested module as ``self.<module>``.
 
 
+Changing garak's own configuration
+----------------------------------
+
+Plugins get their configurable values from ``DEFAULT_PARAMS``, and need nothing else.
+Adding a value to garak's *core* configuration, with a command-line switch to go with it, takes
+a few more steps -- these are described in :doc:`adding a configuration option <extending.cli>`.
+
 Guides to writing plugins
 -------------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -92,5 +92,6 @@ Check out the :doc:`usage` section for further information, including :doc:`inst
 
    contributing
    extending
+   extending.cli
    extending.generator
    extending.probe


### PR DESCRIPTION
Closes #385

There's currently no documented path for adding a value to garak's core configuration and
exposing it on the command line. The reference docs cover configuration from the user side
(`configurable`), and plugin authoring via `DEFAULT_PARAMS` (`extending.probe`,
`extending.generator`), but nothing describes the core-side procedure. `cli.rst` and
`_config.rst` are autodoc stubs, and `cliref.rst` is generated `--help` output.

That gap matters more than it looks, because the procedure fails silently when you get it
wrong. Registering a switch with argparse but not adding its name to the matching
`*_params` list in `_config.py` means `cli.py` drops the value into `ignored_params`
(cli.py:396-407) — the switch parses, the value shows up in the argparse `Namespace`, and it
never reaches `_config`. Nothing is printed above debug log level.

## Change

Adds `docs/source/extending.cli.rst`, "Adding a configuration option", covering:

- where core config lives — the four sections, their defaults in
  `garak/resources/garak.core.yaml`, and the `*_params` lists in `garak/_config.py`
- the steps for a new option in an existing section: core config default, `*_params` entry,
  argparse definition taking its default from the config section, and the test hooks in
  `tests/test_config.py` (`OPTIONS_PARAM` / `OPTIONS_SOLO`)
- verifying the result with `--list_config`, and what it means if the value is missing
- adding a whole new config section: the instance, the `*_params` string, `_store_config()`,
  the `cli.py` dispatch branch, and the `garak.core.yaml` key
- a note that `cliref.rst` is generated by the `cliref` make target and shouldn't be
  hand-edited

Registered in the `index.rst` "Extending and Contributing" toctree and linked from
`extending.rst`.

The content follows the step list posted on #385, with one correction: that list says "add a
new dataclass in `_config.py`" for a new config group, but current code has all four sections
as instances of the single `GarakSubConfig` dataclass, so the page describes adding an
instance.

Docs only — three `.rst` files, no code, no data, no new dependencies.

## Verification

Each documented step was checked against current `main` behaviour rather than taken from the
issue comment. Two scratch experiments were run in a throwaway working tree and reverted
before writing the page:

- argparse entry alone (`--demo_cap`, no `run_params` entry): the value appears in the parsed
  `Namespace` but `_config.run` has no such attribute — confirming the silent-drop behaviour
  the page warns about.
- all three steps applied: `--demo_cap 3 --list_config` gives `run.demo_cap = 3`;
  `--list_config` alone gives `7`, the `garak.core.yaml` default. Both match the page.

Commands run:

- [x] `cd docs/source && python -m sphinx -T -E -b html -d _build/doctrees -D language=en -W ./ html`
      — exit 0, `build succeeded`, 152 files (151 before). Same command as
      `.github/workflows/docs.yml`, including `-W`. Re-run from a clean `html`/`_build`.
- [x] `python -m pytest tests/test_docs.py -q` — exit 0, 684 passed (682 before; the new page
      is picked up by the parametrised docs checks)
- [x] `python -m pytest tests/test_config.py -q` — exit 0, 85 passed
- [x] `python -m pytest tests/test_configurable.py -q` — exit 0, 10 passed
- [x] Rendered output checked: `extending.cli.html` builds, appears in the index toctree, and
      the cross-links to/from `extending` resolve

Environment: Python 3.12.13, editable install with the `tests` and `lint` extras plus
`docs/requirements-docs.txt`, on `main` at 548619981.

`black` and `pylint` are not applicable — no `.py` file is changed.

A full `python -m pytest tests/` run is slow on this machine and hadn't finished when I wrote
this up — it was still progressing with no failures. Since the diff is three `.rst` files with
no code changes, the Python test surface is unaffected, and CI covers the full matrix.

## Why this isn't a duplicate

No open or closed PR addresses #385 (`gh pr list --state all --search "385 in:body"` returns
nothing, and no PR in the current open list touches CLI or config documentation). #385 is
unassigned; it was marked stale in September 2025, then un-staled and given `dontautoclose` by
@leondz. The related open PR #1964 covers #1511 (calibration/bag reference generation) and
doesn't overlap with this.

## Limitations

- The page documents the procedure as it is, including the `*_params` registration step. #385
  itself notes this "ideally shouldn't need docs" — the underlying duplication between
  argparse definitions and the `*_params` lists is acknowledged in a comment in `cli.py`. This
  PR doesn't attempt that refactor.
- The worked example (`run.max_retries`) is illustrative; no such option is added.
- Placement is a judgement call. `extending.cli.rst` follows the existing
  `extending.<topic>.rst` naming, but it sits next to two plugin-authoring guides while being
  core-level. Happy to fold it into `configurable.rst` or `extending.rst` instead if you'd
  prefer fewer pages.

Note: this contribution was prepared with AI coding-assistant help.
