### PR TITLE
report detector input provenance in translated hitlogs

### DIFF
--- a/garak/attempt.py
+++ b/garak/attempt.py
@@ -263,6 +263,7 @@ class Attempt:
         self.reverse_translation_outputs = (
             {} if reverse_translation_outputs is None else reverse_translation_outputs
         )
+        self._detector_inputs = {}
         self.intent = intent
 
     def as_dict(self) -> dict:
@@ -409,6 +410,19 @@ class Attempt:
                 self.reverse_translation_outputs
             )  # this needs to be wired back in for support
         return self.outputs
+
+    def _record_detector_inputs(self, detector_name: str, lang) -> None:
+        """Record the output representation selected for a detector."""
+        detector_inputs = self.outputs_for(lang)
+        source = (
+            "reverse_translation_outputs"
+            if detector_inputs is self.reverse_translation_outputs
+            else "outputs"
+        )
+        self._detector_inputs[detector_name] = {
+            "outputs": detector_inputs,
+            "source": source,
+        }
 
     def _expand_prompt_to_histories(self, breadth):
         """expand a prompt-only message history to many threads"""

--- a/garak/evaluators/base.py
+++ b/garak/evaluators/base.py
@@ -112,23 +112,38 @@ class Evaluator:
                         )
 
                     triggers = attempt.notes.get("triggers", None)
+                    hitlog_record = {
+                        "goal": attempt.goal,
+                        "prompt": asdict(attempt.prompt),
+                        "output": asdict(attempt.outputs[idx]),
+                        "triggers": triggers,
+                        "score": score,
+                        "run_id": str(_config.transient.run_id),
+                        "attempt_id": str(attempt.uuid),
+                        "attempt_seq": attempt.seq,
+                        "attempt_idx": idx,
+                        "generator": f"{_config.plugins.target_type} {_config.plugins.target_name}",
+                        "probe": self.probename,
+                        "detector": detector_name,
+                        "generations_per_prompt": _config.run.generations,
+                    }
+                    detector_input_record = attempt._detector_inputs.get(detector_name)
+                    if (
+                        detector_input_record is not None
+                        and detector_input_record["source"]
+                        == "reverse_translation_outputs"
+                        and idx < len(detector_input_record["outputs"])
+                    ):
+                        detector_input = detector_input_record["outputs"][idx]
+                        hitlog_record["detector_input"] = (
+                            asdict(detector_input) if detector_input else None
+                        )
+                        hitlog_record["detector_input_source"] = detector_input_record[
+                            "source"
+                        ]
                     _config.transient.hitlogfile.write(
                         json.dumps(
-                            {
-                                "goal": attempt.goal,
-                                "prompt": asdict(attempt.prompt),
-                                "output": asdict(attempt.outputs[idx]),
-                                "triggers": triggers,
-                                "score": score,
-                                "run_id": str(_config.transient.run_id),
-                                "attempt_id": str(attempt.uuid),
-                                "attempt_seq": attempt.seq,
-                                "attempt_idx": idx,
-                                "generator": f"{_config.plugins.target_type} {_config.plugins.target_name}",
-                                "probe": self.probename,
-                                "detector": detector_name,
-                                "generations_per_prompt": _config.run.generations,
-                            },
+                            hitlog_record,
                             ensure_ascii=False,
                         )
                         + "\n"  # generator,probe,prompt,trigger,result,detector,score,run id,attemptid,

--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -152,6 +152,9 @@ class Harness(Configurable):
         for attempt in attempt_iterator:
             if detector_instance.skip:
                 continue
+            attempt._record_detector_inputs(
+                detector_probe_name, detector_instance.lang_spec
+            )
             attempt.detector_results[detector_probe_name] = list(
                 detector_instance.detect(attempt)
             )

--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -602,6 +602,9 @@ class TreeSearchProbe(Probe):
             # now we call the detector 🙃
             node_results = []
             for attempt in attempts_completed:
+                attempt._record_detector_inputs(
+                    self.primary_detector, detector.lang_spec
+                )
                 attempt.detector_results[self.primary_detector] = detector.detect(
                     attempt
                 )
@@ -948,6 +951,8 @@ class IntentProbe(Probe):
         if not self.prompts:
             # an empty active-intent set (run.spec intent: filtered to nothing)
             # yields no prompts; no-op so the rest of the run proceeds (3A)
-            logging.debug("%s has no active intents; no prompts to send", self.probename)
+            logging.debug(
+                "%s has no active intents; no prompts to send", self.probename
+            )
             return []
         return super().probe(generator)

--- a/tests/evaluators/test_evaluators.py
+++ b/tests/evaluators/test_evaluators.py
@@ -475,6 +475,36 @@ def test_hitlog_entry_fields(eval_setup):
         entry["generations_per_prompt"] == _config.run.generations
     ), "hitlog generations_per_prompt should match config"
     assert entry["triggers"] is None, "triggers should default to None when not set"
+    assert "detector_input" not in entry, "raw detector input should not be duplicated"
+
+
+def test_hitlog_includes_reverse_translated_detector_input(eval_setup):
+    evaluator = ThresholdEvaluator(0.5)
+    attempt = Attempt(prompt=Message(text="prompt", lang="es"))
+    attempt.probe_classname = DEFAULT_PROBE
+    attempt.goal = DEFAULT_GOAL
+    attempt.outputs = [Message(text="respuesta", lang="es")]
+    attempt.reverse_translation_outputs = [
+        Message(text="reverse translation containing TRIGGER", lang="en")
+    ]
+    attempt._record_detector_inputs("det.A", "en")
+    attempt.detector_results = {"det.A": [0.8]}
+
+    evaluator.evaluate([attempt])
+
+    if _config.transient.hitlogfile is not None:
+        _config.transient.hitlogfile.flush()
+    entries = _read_hitlog_entries(_config.transient.report_filename)
+    assert len(entries) == 1, "translated failure should produce one hitlog entry"
+
+    entry = entries[0]
+    assert entry["output"]["text"] == "respuesta", "hitlog should preserve raw output"
+    assert (
+        entry["detector_input"]["text"] == "reverse translation containing TRIGGER"
+    ), "hitlog should include the representation selected for detection"
+    assert (
+        entry["detector_input_source"] == "reverse_translation_outputs"
+    ), "hitlog should identify reverse-translation provenance"
 
 
 def test_hitlog_with_triggers(eval_setup):

--- a/tests/harnesses/test_harnesses.py
+++ b/tests/harnesses/test_harnesses.py
@@ -10,6 +10,7 @@ from garak import _plugins, _config
 
 import garak.buffs.base
 import garak.harnesses.base
+from garak.attempt import Attempt, Message
 
 HARNESSES = [
     classname for (classname, active) in _plugins.enumerate_plugins("harnesses")
@@ -102,6 +103,29 @@ def test_harness_detector_progress_shows_probe_name(mocker, monkeypatch):
 
     assert captured_descriptions, "detector progress bar should have a description"
     assert any(
-        "test.Blank" in desc and "always.Pass" in desc
-        for desc in captured_descriptions
+        "test.Blank" in desc and "always.Pass" in desc for desc in captured_descriptions
     ), "detector progress description should include probe and detector names"
+
+
+def test_run_detector_records_reverse_translation_inputs(mocker):
+    detector = mocker.Mock()
+    detector.detectorname = "garak.detectors.test.Translated"
+    detector.lang_spec = "en"
+    detector.skip = False
+    detector.detect.return_value = [1.0]
+
+    attempt = Attempt(prompt=Message(text="pregunta", lang="es"))
+    attempt.probe_classname = "test.Translated"
+    attempt.outputs = [Message(text="respuesta", lang="es")]
+    attempt.reverse_translation_outputs = [Message(text="answer", lang="en")]
+
+    harness = object.__new__(garak.harnesses.base.Harness)
+    harness._run_detector([attempt], detector)
+
+    detector_inputs = attempt._detector_inputs["test.Translated"]
+    assert (
+        detector_inputs["source"] == "reverse_translation_outputs"
+    ), "harness should record reverse-translation provenance"
+    assert (
+        detector_inputs["outputs"][0].text == "answer"
+    ), "harness should record the representation selected for detection"


### PR DESCRIPTION
## Summary

- record the output representation selected for each detector before detection
- add optional `detector_input` and `detector_input_source` fields to translated-run hitlog records
- preserve the existing `output` field as the raw model generation
- cover both the standard harness and `TreeSearchProbe` detector path

## Why

Language-aware detectors can score `reverse_translation_outputs` while the evaluator only records `attempt.outputs` in the standalone hitlog. The score remains positionally aligned, but the evidence that produced a translated-run hit is missing from that record.

This carries detector-input provenance through the attempt so the evaluator does not need to infer a detector's language scope after the fact. Raw-run hitlog schema remains unchanged; the new fields are emitted only when reverse-translated input was selected.

Closes #2001.

## Duplicate check

Before implementation I checked issue #2001 and searched open pull requests for both `2001 in:body` and `hitlog detector input translation`; no competing PR or claim was present. #1959 covers positional alignment, while #1174, #1201, and #1826 concern broader multilingual or serialization behavior rather than detector-scoped hitlog evidence.

## Tests

- `python -m pytest -q tests/evaluators/test_evaluators.py` — 49 passed
- `python -m pytest -q tests/harnesses/test_harnesses.py` — 5 passed
- `python -m pytest -q tests/test_attempt.py` — 23 passed
- focused translated-hit regression selection — 3 passed
- `python -m black --check -W 1 ...` for all six changed files — passed
- `tests/probes/test_probes.py` — 1,347 passed; 9 unrelated metadata cases require unavailable optional packages or network-fetched fixtures

## AI assistance

OpenAI Codex assisted with investigation, implementation, tests, and drafting this pull request. The human submitter will review every changed line before marking the PR ready and remains responsible for the contribution.
