### PR TITLE
fix: default config_root to _config in InjectAtbash

### DIFF
--- a/garak/probes/encoding.py
+++ b/garak/probes/encoding.py
@@ -503,7 +503,7 @@ class InjectAtbash(EncodingMixin, garak.probes.Probe):
 
     encoding_funcs = [atbash]
 
-    def __init__(self, config_root=None):
+    def __init__(self, config_root=_config):
         garak.probes.Probe.__init__(self, config_root=config_root)
         EncodingMixin.__init__(self)
 

--- a/tests/plugins/test_plugins.py
+++ b/tests/plugins/test_plugins.py
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib
+import inspect
 import pytest
 
 import garak._plugins
+from garak import _config
 
 PLUGINS = []
 for plugin_type in garak._plugins.PLUGIN_TYPES:
@@ -24,3 +26,15 @@ def test_plugin_structure(classname):
     assert hasattr(c, "extra_dependency_names") and isinstance(
         c.extra_dependency_names, list
     ), "extra_dependency_names must be a list"
+
+
+@pytest.mark.parametrize("classname", PLUGINS)
+def test_plugin_config_root_default(classname):
+    m = importlib.import_module("garak." + ".".join(classname.split(".")[:-1]))
+    c = getattr(m, classname.split(".")[-1])
+
+    param = inspect.signature(c.__init__).parameters.get("config_root")
+    assert param is not None, "plugin __init__ must accept config_root"
+    assert (
+        param.default is _config
+    ), "config_root must default to garak._config so direct instantiation honours global config"


### PR DESCRIPTION
## What

`garak.probes.encoding.InjectAtbash` declared `__init__(self, config_root=None)`.
Every other plugin in the project uses `config_root=_config` — 188 of 189
`__init__` definitions taking `config_root`, with this as the sole exception.

Tracing `Configurable._load_config(None)`:

- `hasattr(None, "plugins")` is False, so `local_root = None`
- `isinstance(None, dict)` is False
- `hasattr(None, "probes")` is False
- `plugins_config` stays `{}`, the namespace lookup misses, and
  `_apply_config()` is never called

The result is that configuration targeting this probe is silently discarded and
`DEFAULT_PARAMS` win instead.

## Scope of impact

Direct instantiation only. `_plugins.load_plugin()` calls
`klass(config_root=config_root)` explicitly, so probes loaded through the normal
plugin machinery — which is every CLI run — were unaffected. The bug surfaces
when `InjectAtbash()` is constructed directly, e.g. from library code, a
notebook, or a test.

## Reproduction

Setting a narrowed payload list for two sibling encoding probes on
`_config.plugins.probes["encoding"]`:

```python
_config.plugins.probes["encoding"] = {
    "InjectROT13": {"payloads": ["default"]},
    "InjectAtbash": {"payloads": ["default"]},
}
```

Before the fix:

```
InjectROT13  payloads: ['default']
InjectAtbash payloads: ['default', 'xss', 'slur_terms']
```

After the fix:

```
InjectROT13  payloads: ['default']
InjectAtbash payloads: ['default']
```

## Changes

- `garak/probes/encoding.py` — `InjectAtbash.__init__` now defaults
  `config_root` to `_config`, matching every other plugin.
- `tests/plugins/test_plugins.py` — new `test_plugin_config_root_default`,
  parametrized over all plugins, asserting `__init__` declares `config_root`
  with `_config` as its default. This turns the convention into an enforced
  invariant rather than something maintained by hand.

The test was written first and observed failing on exactly one case before the
fix was applied.

## Tests run

Before the fix, with the new test in place:

```
$ python -m pytest tests/plugins/test_plugins.py -k config_root -v
FAILED tests/plugins/test_plugins.py::test_plugin_config_root_default[probes.encoding.InjectAtbash]
  - AssertionError: config_root must default to garak._config so direct
    instantiation honours global config
    assert None is _config
     +  where None = <Parameter "config_root=None">.default

1 failed, 359 passed, 360 deselected in 3.41s
```

After the fix:

```
$ python -m pytest tests/plugins/test_plugins.py -v
720 passed
```

Wider suite:

```
$ python -m pytest tests/probes/ tests/plugins/ -q
2839 passed, 1 skipped in 601.61s (0:10:01)
```

Formatted with `black --config pyproject.toml`.
Environment: Python 3.12.3, Linux.

## Not a duplicate

```
$ gh pr list --repo nvidia/garak --state open --search "InjectAtbash"
no pull requests match your search in nvidia/garak
```

```
$ gh pr list --repo nvidia/garak --state open --search "config_root"
Showing 6 of 6 pull requests in nvidia/garak that match your search
#1673  fix: modernize Cohere generator (#1384)
#1806  Implement OpenAIResponsesGenerator
#1261  Branch jailbreakv
#1291  Generator that allows for multiple requests
#1306  Generator: Add support for Google Gemini models
#1289  Feature: translation cache
```

All six are generator changes that reference `config_root` incidentally, as any
new generator `__init__` does. Confirmed none touch the files changed here:

```
$ for n in 1673 1806 1261 1291 1306 1289; do
    printf "PR #%s: " "$n"
    gh pr diff "$n" --repo nvidia/garak --name-only 2>/dev/null \
      | grep -E "probes/encoding\.py|plugins/test_plugins\.py" || echo "no overlap"
  done
PR #1673: no overlap
PR #1806: no overlap
PR #1261: no overlap
PR #1291: no overlap
PR #1306: no overlap
PR #1289: no overlap
```

## AI assistance

AI assistance was used in investigating this issue, drafting the test, and
preparing this description. I have reviewed every changed line, run the tests
above myself, and understand the config-loading path the change affects.