### PR TITLE
buffs: add FormatSpread prompt-format-sensitivity buff (#396)

### DIFF
--- a/garak/buffs/formatspread.py
+++ b/garak/buffs/formatspread.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Buff that re-expresses a prompt across a range of surface formats.
+
+FormatSpread (Sclar et al., 2023) reports that a model can respond differently to
+the same request depending on spurious formatting: the label placed before the
+text, the separator after it, the casing of that label, and the spacing between
+fields. This buff emits a fixed, repeatable set of such formats for each prompt
+so a probe can measure how much formatting alone moves the result.
+"""
+
+from collections.abc import Iterable
+
+import garak.attempt
+from garak.buffs.base import Buff
+
+
+class FormatSpread(Buff):
+    """Spread one prompt across a small, repeatable set of text formats."""
+
+    doc_uri = "https://arxiv.org/abs/2310.11324"
+    lang = "en"
+
+    # format templates; the {descriptor}, {separator}, {field_spacing} and
+    # {answer_descriptor} markers are filled per spec, and PROMPT_MARKER last
+    PROMPT_MARKER = "{prompt}"
+    templates = [
+        "{descriptor}{separator}{prompt}",
+        "{descriptor}{separator}{prompt}{field_spacing}{answer_descriptor}:",
+    ]
+
+    def _format_variants(self, text: str) -> Iterable[str]:
+        seen = set()
+        format_specs = (
+            ("Instruction", ": ", "identity", "", ""),
+            ("Instruction", "\n", "upper", "", ""),
+            ("Instruction", "::", "lower", "\n\n", "Answer"),
+            ("Instruction", " - ", "title", " || ", "Answer"),
+            ("Task", "::", "identity", "", ""),
+            ("Task", " - ", "upper", "", ""),
+            ("Task", "\n", "lower", "\n\n", "Response"),
+            ("Task", ": ", "title", " || ", "Response"),
+            ("Request", " - ", "identity", "", ""),
+            ("Request", ": ", "upper", "", ""),
+            ("Request", "::", "lower", "\n\n", "Answer"),
+            ("Request", "\n", "title", " || ", "Answer"),
+        )
+
+        for descriptor, separator, casing, field_spacing, answer in format_specs:
+            if casing == "upper":
+                descriptor = descriptor.upper()
+                answer = answer.upper()
+            elif casing == "lower":
+                descriptor = descriptor.lower()
+                answer = answer.lower()
+            elif casing == "title":
+                descriptor = descriptor.title()
+                answer = answer.title()
+
+            template = self.templates[1] if answer else self.templates[0]
+            variant = template.replace("{descriptor}", descriptor)
+            variant = variant.replace("{separator}", separator)
+            variant = variant.replace("{field_spacing}", field_spacing)
+            variant = variant.replace("{answer_descriptor}", answer)
+            # insert the prompt last so its text is never treated as a marker
+            variant = variant.replace(self.PROMPT_MARKER, text)
+
+            if variant != text and variant not in seen:
+                seen.add(variant)
+                yield variant
+
+    def transform(
+        self, attempt: garak.attempt.Attempt
+    ) -> Iterable[garak.attempt.Attempt]:
+        last_message = attempt.prompt.last_message()
+        for variant in self._format_variants(last_message.text):
+            new_attempt = self._derive_new_attempt(attempt)
+            delattr(new_attempt, "_prompt")  # hack to allow prompt set
+            new_attempt.prompt = garak.attempt.Message(
+                text=variant, lang=last_message.lang
+            )
+            yield new_attempt


### PR DESCRIPTION
### Summary
Adds a `formatspread` buff (`garak/buffs/formatspread.py`) motivated by
FormatSpread (Sclar et al., ICLR 2024): models are sensitive to spurious prompt
formatting. Addresses #396.

### What it does
`FormatSpread` rewrites each prompt into a fixed, deterministic set of surface-
format variants composed from the paper's format grammar: descriptor
(Instruction / Task / Request), separator (`": "`, `"::"`, `" - "`, `"\n"`),
casing (identity / upper / lower / title), and field spacing (`"\n\n"`, `" || "`)
with an optional answer descriptor. Buffing a probe with it surfaces how much
formatting alone moves model behavior.

### Detection
None added. Buffs transform prompts; detection is handled by the probe or
detector the buff is applied to.

### Testing
- `black` clean, pylint 10/10
- `tests/buffs/test_buffs.py` and `test_buff_config.py` pass (structural and
  load/transform tests auto-cover the new buff)
- end-to-end: buffing a real probe (`latentinjection.LatentWhois`) expands
  prompts 12x and completes

Closes #396.
