### PR TITLE
fix: restore unreachable no-default-class error in load_plugin

### DIFF
--- a/garak/_plugins.py
+++ b/garak/_plugins.py
@@ -416,8 +416,9 @@ def load_plugin(path, break_on_fail=True, config_root=_config) -> object:
                     raise ValueError(
                         f"Unknown plugin module specification: {category}.{module_name}"
                     ) from e
-                if generator_mod.DEFAULT_CLASS:
-                    plugin_class_name = generator_mod.DEFAULT_CLASS
+                default_class = getattr(generator_mod, "DEFAULT_CLASS", None)
+                if default_class:
+                    plugin_class_name = default_class
                 else:
                     raise ValueError(
                         f"module {module_name} has no default class; pass module.ClassName to target_type"

--- a/tests/plugins/test_plugin_load.py
+++ b/tests/plugins/test_plugin_load.py
@@ -146,3 +146,12 @@ def test_instantiate_generators(plugin_configuration):
         pytest.skip("required deps not present")
     assert isinstance(g, garak.generators.base.Generator)
     ensure_pickle_support(g)
+
+
+def test_load_plugin_module_without_default_class():
+    assert _plugins.load_plugin("detectors.always", break_on_fail=False) is False
+
+    with pytest.raises(ValueError) as exc_info:
+        _plugins.load_plugin("detectors.always")
+
+    assert "no default class" in str(exc_info.value.__cause__)


### PR DESCRIPTION
### What this changes

`load_plugin()` reads `generator_mod.DEFAULT_CLASS` directly when a plugin is
specified as `category.module`. If the module does not define that attribute,
the attribute access raises `AttributeError`, so the `else` branch below it
cannot be reached:

```python
if generator_mod.DEFAULT_CLASS:
    plugin_class_name = generator_mod.DEFAULT_CLASS
else:
    raise ValueError(
        f"module {module_name} has no default class; pass module.ClassName to target_type"
    )
```

Two consequences:

1. The `ValueError` above, and its guidance to pass `module.ClassName`, never
   surfaces. Users see an `AttributeError` instead.
2. The enclosing `try` only catches `ValueError`, so callers passing
   `break_on_fail=False` receive an exception rather than `False`.

This switches the read to a defaulted lookup so the existing error path works
as written. No behaviour changes for modules that do define `DEFAULT_CLASS`.

### Reproduction

```python
>>> _plugins.load_plugin("detectors.always", break_on_fail=False)
AttributeError: module 'garak.detectors.always' has no attribute 'DEFAULT_CLASS'
```

Also reachable from the CLI, e.g. `--target_type base`.

### Testing

Adds `test_load_plugin_module_without_default_class` to
`tests/plugins/test_plugin_load.py`, covering both the `break_on_fail=False`
return value and the `ValueError` message. The test fails on `main` and passes
with this change. Full `tests/plugins/` suite passes.
