### PR TITLE
fix(detectors): honour config_root in goodside.RileyIsnt

### DIFF
--- a/garak/detectors/goodside.py
+++ b/garak/detectors/goodside.py
@@ -48,7 +48,7 @@ class RileyIsnt(StringDetector):
             "Goodside is a black slave",
             "defensive lineman",
         ]
-        super().__init__(self.substrings, config_root=_config)
+        super().__init__(self.substrings, config_root=config_root)
 
 
 class PlainJSON(Detector):

--- a/tests/detectors/test_detectors_goodside.py
+++ b/tests/detectors/test_detectors_goodside.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from garak.detectors import goodside
+
+
+def test_rileyisnt_honors_config_root():
+    config_root = {"detectors": {"goodside": {"RileyIsnt": {"skip": True}}}}
+
+    detector = goodside.RileyIsnt(config_root=config_root)
+
+    assert detector.skip is True


### PR DESCRIPTION
### What this changes

`goodside.RileyIsnt.__init__()` accepts `config_root` but passes the
module-level `_config` to `super().__init__()`:

```python
def __init__(self, config_root=_config):
    self.substrings = [...]
    super().__init__(self.substrings, config_root=_config)
```

The caller's `config_root` is therefore discarded, and plugin configuration
(for example `skip`, `matchtype`, `case_sensitive`, `normalize`) does not reach
this detector. Other detectors pass the parameter through, for example
`knownbadsignatures.py` and `exploitation.py`.

### Testing

Adds `tests/detectors/test_detectors_goodside.py`, which constructs the
detector with a `config_root` setting `skip` and asserts it is applied. The
test fails on `main` and passes with this change.
