### PR TITLE
lock `nltk` due to incompatible path restrictions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ dependencies = [
   "replicate>=0.8.3",
   "google-api-python-client>=2.0",
   "backoff>=2.1.1",
-  "nltk>=3.10.0",
+  "nltk==3.10.0",
   "accelerate>=0.23.0",
   "avidtools==0.1.2",
   "stdlibs>=2022.10.9",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ openai>=2.0,<3.0
 replicate>=0.8.3
 google-api-python-client>=2.0
 backoff>=2.1.1
-nltk>=3.10.0
+nltk==3.10.0
 accelerate>=0.23.0
 avidtools==0.1.2
 stdlibs>=2022.10.9


### PR DESCRIPTION
release of nltk 3.10.1 introduced a python path manipulation that is not viable for common install patterns of standalone tools and has an open issue and PR to revert.

Locking version until a viable upstream version is available.

## Verification

List the steps needed to make sure this thing works

- [ ] Validate test install 
``` bash
mkdir /tmp/userproj && cd /tmp/userproj
python -m venv .venv && source .venv/bin/activate
# install from root of repo
pip install $PATH_TO_PROJECT/garak/
python -m garak -t test.Blank -S probes.sata.MLM --generations 1
```
- [ ] **Verify** the thing does what it should
