### PR TITLE
fix(nim): retry transient HTTP errors and report actual status code

### DIFF
--- a/garak/generators/nim.py
+++ b/garak/generators/nim.py
@@ -95,8 +95,15 @@ class NVOpenAIChat(OpenAICompatible):
             msg = "NIM endpoint not found. Is the model name spelled correctly and the endpoint URI correct?"
             logging.critical(msg, exc_info=nfe)
             raise GarakException(f"🛑 {msg}") from nfe
+        except openai.APIStatusError as oe:
+            msg = (
+                f"NIM generation failed with HTTP {oe.status_code} from {oe.request.url}: "
+                f"{oe.message}"
+            )
+            logging.critical(msg, exc_info=oe)
+            raise GarakException(f"🛑 {msg}") from oe
         except Exception as oe:
-            msg = "NIM generation failed. Is the model name spelled correctly?"
+            msg = f"NIM generation failed: {type(oe).__name__}: {oe}"
             logging.critical(msg, exc_info=oe)
             raise GarakException(f"🛑 {msg}") from oe
 

--- a/garak/generators/nim.py
+++ b/garak/generators/nim.py
@@ -95,13 +95,6 @@ class NVOpenAIChat(OpenAICompatible):
             msg = "NIM endpoint not found. Is the model name spelled correctly and the endpoint URI correct?"
             logging.critical(msg, exc_info=nfe)
             raise GarakException(f"🛑 {msg}") from nfe
-        except openai.APIStatusError as oe:
-            msg = (
-                f"NIM generation failed with HTTP {oe.status_code} from {oe.request.url}: "
-                f"{oe.message}"
-            )
-            logging.critical(msg, exc_info=oe)
-            raise GarakException(f"🛑 {msg}") from oe
         except Exception as oe:
             msg = f"NIM generation failed: {type(oe).__name__}: {oe}"
             logging.critical(msg, exc_info=oe)

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -25,28 +25,6 @@ from garak.attempt import Message, Conversation
 import garak.exception
 from garak.generators.base import Generator
 
-# HTTP status codes that indicate a transient server-side condition worth retrying.
-# 408 (Request Timeout), 502 (Bad Gateway), 503 (Service Unavailable), 504 (Gateway Timeout)
-# arrive as openai.APIStatusError and are not caught by InternalServerError (5xx only)
-# or APITimeoutError (client-side read timeout, not an HTTP-level status code).
-_TRANSIENT_HTTP_CODES = frozenset({408, 429, 502, 503, 504})
-
-
-def _is_terminal_api_error(exc: Exception) -> bool:
-    """Return True when an APIStatusError should NOT be retried (terminal, non-transient).
-
-    RateLimitError (429) and InternalServerError (5xx) subclass APIStatusError but have
-    dedicated retry entries in the backoff tuple; always return False for them so the
-    backoff decorator continues retrying without interruption.
-    """
-    if not isinstance(exc, openai.APIStatusError):
-        return False
-    # Subtypes with explicit backoff entries should never be treated as terminal.
-    if isinstance(exc, (openai.RateLimitError, openai.InternalServerError)):
-        return False
-    return exc.status_code not in _TRANSIENT_HTTP_CODES
-
-
 # lists derived from https://platform.openai.com/docs/models
 chat_models = (
     "gpt-5-nano",
@@ -174,6 +152,7 @@ class OpenAICompatible(Generator):
         "suppressed_params": set(),
         "retry_json": True,
         "extra_params": {},
+        "transient_retry_codes": [408, 429, 502, 503, 504],
     }
 
     _unsafe_attributes = ["client", "generator"]
@@ -292,11 +271,9 @@ class OpenAICompatible(Generator):
             openai.InternalServerError,
             openai.APITimeoutError,
             openai.APIConnectionError,
-            openai.APIStatusError,
             garak.exception.GeneratorBackoffTrigger,
         ),
         max_value=70,
-        giveup=_is_terminal_api_error,
     )
     def _call_model(
         self, prompt: Union[Conversation, List[dict]], generations_this_call: int = 1
@@ -377,6 +354,12 @@ class OpenAICompatible(Generator):
             msg = "Bad request: " + str(repr(prompt))
             logging.exception(e)
             logging.error(msg)
+            return [None]
+        except openai.APIStatusError as e:
+            if e.status_code in self.transient_retry_codes:
+                raise garak.exception.GeneratorBackoffTrigger from e
+            msg = f"HTTP {e.status_code} from {e.request.url}: {e.message}"
+            logging.warning(msg)
             return [None]
         except json.decoder.JSONDecodeError as e:
             logging.exception(e)

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -25,6 +25,20 @@ from garak.attempt import Message, Conversation
 import garak.exception
 from garak.generators.base import Generator
 
+# HTTP status codes that indicate a transient server-side condition worth retrying.
+# 408 (Request Timeout), 502 (Bad Gateway), 503 (Service Unavailable), 504 (Gateway Timeout)
+# arrive as openai.APIStatusError and are not caught by InternalServerError (5xx only)
+# or APITimeoutError (client-side read timeout, not an HTTP-level status code).
+_TRANSIENT_HTTP_CODES = frozenset({408, 502, 503, 504})
+
+
+def _is_terminal_api_error(exc: Exception) -> bool:
+    """Return True when an APIStatusError should NOT be retried (terminal, non-transient)."""
+    return isinstance(exc, openai.APIStatusError) and (
+        exc.status_code not in _TRANSIENT_HTTP_CODES
+    )
+
+
 # lists derived from https://platform.openai.com/docs/models
 chat_models = (
     "gpt-5-nano",
@@ -270,9 +284,11 @@ class OpenAICompatible(Generator):
             openai.InternalServerError,
             openai.APITimeoutError,
             openai.APIConnectionError,
+            openai.APIStatusError,
             garak.exception.GeneratorBackoffTrigger,
         ),
         max_value=70,
+        giveup=_is_terminal_api_error,
     )
     def _call_model(
         self, prompt: Union[Conversation, List[dict]], generations_this_call: int = 1

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -29,14 +29,22 @@ from garak.generators.base import Generator
 # 408 (Request Timeout), 502 (Bad Gateway), 503 (Service Unavailable), 504 (Gateway Timeout)
 # arrive as openai.APIStatusError and are not caught by InternalServerError (5xx only)
 # or APITimeoutError (client-side read timeout, not an HTTP-level status code).
-_TRANSIENT_HTTP_CODES = frozenset({408, 502, 503, 504})
+_TRANSIENT_HTTP_CODES = frozenset({408, 429, 502, 503, 504})
 
 
 def _is_terminal_api_error(exc: Exception) -> bool:
-    """Return True when an APIStatusError should NOT be retried (terminal, non-transient)."""
-    return isinstance(exc, openai.APIStatusError) and (
-        exc.status_code not in _TRANSIENT_HTTP_CODES
-    )
+    """Return True when an APIStatusError should NOT be retried (terminal, non-transient).
+
+    RateLimitError (429) and InternalServerError (5xx) subclass APIStatusError but have
+    dedicated retry entries in the backoff tuple; always return False for them so the
+    backoff decorator continues retrying without interruption.
+    """
+    if not isinstance(exc, openai.APIStatusError):
+        return False
+    # Subtypes with explicit backoff entries should never be treated as terminal.
+    if isinstance(exc, (openai.RateLimitError, openai.InternalServerError)):
+        return False
+    return exc.status_code not in _TRANSIENT_HTTP_CODES
 
 
 # lists derived from https://platform.openai.com/docs/models

--- a/tests/generators/test_nim.py
+++ b/tests/generators/test_nim.py
@@ -23,6 +23,7 @@ def _make_api_status_error(status_code: int, url: str = "http://localhost/v1/cha
 
 def test_transient_http_codes_set():
     assert 408 in _TRANSIENT_HTTP_CODES
+    assert 429 in _TRANSIENT_HTTP_CODES
     assert 502 in _TRANSIENT_HTTP_CODES
     assert 503 in _TRANSIENT_HTTP_CODES
     assert 504 in _TRANSIENT_HTTP_CODES
@@ -33,7 +34,7 @@ def test_transient_http_codes_set():
     assert 422 not in _TRANSIENT_HTTP_CODES
 
 
-@pytest.mark.parametrize("code", [408, 502, 503, 504])
+@pytest.mark.parametrize("code", [408, 429, 502, 503, 504])
 def test_is_terminal_api_error_returns_false_for_transient(code):
     """Transient codes should NOT give up — backoff must retry them."""
     exc = _make_api_status_error(code)
@@ -50,6 +51,25 @@ def test_is_terminal_api_error_returns_true_for_fatal(code):
 def test_is_terminal_api_error_ignores_non_api_status_error():
     """Non-APIStatusError exceptions are not touched by the giveup function."""
     assert _is_terminal_api_error(ValueError("unrelated")) is False
+
+
+def test_is_terminal_api_error_rate_limit_never_terminal():
+    """RateLimitError (429) is a dedicated backoff-tuple entry; giveup must not fire."""
+    request = httpx.Request("POST", "http://localhost/v1/chat/completions")
+    response = httpx.Response(429, request=request)
+    exc = openai.RateLimitError("rate limited", response=response, body=None)
+    assert _is_terminal_api_error(exc) is False
+
+
+def test_is_terminal_api_error_internal_server_error_never_terminal():
+    """InternalServerError (500/503) is a dedicated backoff-tuple entry; giveup must not fire."""
+    request = httpx.Request("POST", "http://localhost/v1/chat/completions")
+    for code in (500, 503):
+        response = httpx.Response(code, request=request)
+        exc = openai.InternalServerError(f"server error {code}", response=response, body=None)
+        assert _is_terminal_api_error(exc) is False, (
+            f"InternalServerError({code}) must not be treated as terminal"
+        )
 
 
 @pytest.fixture

--- a/tests/generators/test_nim.py
+++ b/tests/generators/test_nim.py
@@ -3,93 +3,10 @@
 
 import os
 import pytest
-import httpx
-import openai
-from unittest.mock import MagicMock, patch
 
-import garak.exception
-from garak.attempt import Message, Turn, Conversation
-from garak.exception import GarakException
 import garak.cli
+from garak.attempt import Message, Turn, Conversation
 from garak.generators.nim import NVOpenAIChat
-from garak.generators.openai import OpenAICompatible
-
-
-def _make_api_status_error(
-    status_code: int, url: str = "http://localhost/v1/chat/completions"
-) -> openai.APIStatusError:
-    """Build an openai.APIStatusError with a real httpx.Response for a given HTTP status."""
-    request = httpx.Request("POST", url)
-    response = httpx.Response(status_code, request=request)
-    return openai.APIStatusError(f"HTTP {status_code}", response=response, body=None)
-
-
-def _make_prompt() -> Conversation:
-    return Conversation([Turn(role="user", content=Message("test prompt"))])
-
-
-@pytest.fixture
-def nim_generator(monkeypatch):
-    """NVOpenAIChat with mocked client; no real API key required."""
-    monkeypatch.setenv(NVOpenAIChat.ENV_VAR, "test-fake-key-for-unit-tests")
-    mock_client = MagicMock()
-    mock_client.chat.completions = MagicMock()
-    with patch("openai.OpenAI", return_value=mock_client):
-        g = NVOpenAIChat(name="org/test-model")
-    return g
-
-
-def test_transient_retry_codes_in_default_params():
-    """transient_retry_codes should be present in DEFAULT_PARAMS and contain expected codes."""
-    codes = OpenAICompatible.DEFAULT_PARAMS["transient_retry_codes"]
-    for code in (408, 429, 502, 503, 504):
-        assert code in codes, f"Expected {code} in transient_retry_codes"
-    for code in (400, 401, 403, 404):
-        assert code not in codes, f"Expected {code} NOT in transient_retry_codes"
-
-
-@pytest.mark.parametrize("code", [408, 502, 503, 504])
-def test_transient_http_error_raises_backoff_trigger(nim_generator, code):
-    """A transient status code should cause _call_model to raise GeneratorBackoffTrigger
-    so that the backoff decorator can schedule a retry."""
-    prompt = _make_prompt()
-    nim_generator.generator = MagicMock()
-    nim_generator.generator.create.side_effect = _make_api_status_error(code)
-
-    # Call the underlying function without the backoff decorator so the test does not
-    # need to wait for retry delays or exhaust the fibonacci sequence.
-    unwrapped = OpenAICompatible._call_model.__wrapped__
-    with pytest.raises(garak.exception.GeneratorBackoffTrigger):
-        unwrapped(nim_generator, prompt)
-
-
-@pytest.mark.parametrize("code", [400, 403, 404, 422])
-def test_terminal_http_error_returns_none(nim_generator, code):
-    """A terminal (non-transient) status code should cause _call_model to return [None]
-    so that the current attempt is skipped and the probe run continues."""
-    prompt = _make_prompt()
-    nim_generator.generator = MagicMock()
-    nim_generator.generator.create.side_effect = _make_api_status_error(code)
-
-    unwrapped = OpenAICompatible._call_model.__wrapped__
-    result = unwrapped(nim_generator, prompt)
-    assert result == [None], f"Expected [None] for HTTP {code}, got {result!r}"
-
-
-def test_nim_generic_exception_message_improved(nim_generator):
-    """Non-APIStatusError exceptions should report the exception type, not the old
-    generic 'Is the model name spelled correctly?' message."""
-    prompt = _make_prompt()
-
-    with patch(
-        "garak.generators.openai.OpenAICompatible._call_model",
-        side_effect=RuntimeError("connection reset by peer"),
-    ):
-        with pytest.raises(GarakException) as exc_info:
-            nim_generator._call_model(prompt)
-
-    error_text = str(exc_info.value)
-    assert "Is the model name spelled correctly?" not in error_text
 
 
 @pytest.mark.skipif(

--- a/tests/generators/test_nim.py
+++ b/tests/generators/test_nim.py
@@ -7,69 +7,25 @@ import httpx
 import openai
 from unittest.mock import MagicMock, patch
 
+import garak.exception
 from garak.attempt import Message, Turn, Conversation
 from garak.exception import GarakException
 import garak.cli
 from garak.generators.nim import NVOpenAIChat
-from garak.generators.openai import _is_terminal_api_error, _TRANSIENT_HTTP_CODES
+from garak.generators.openai import OpenAICompatible
 
 
-def _make_api_status_error(status_code: int, url: str = "http://localhost/v1/chat/completions") -> openai.APIStatusError:
+def _make_api_status_error(
+    status_code: int, url: str = "http://localhost/v1/chat/completions"
+) -> openai.APIStatusError:
     """Build an openai.APIStatusError with a real httpx.Response for a given HTTP status."""
     request = httpx.Request("POST", url)
     response = httpx.Response(status_code, request=request)
     return openai.APIStatusError(f"HTTP {status_code}", response=response, body=None)
 
 
-def test_transient_http_codes_set():
-    assert 408 in _TRANSIENT_HTTP_CODES
-    assert 429 in _TRANSIENT_HTTP_CODES
-    assert 502 in _TRANSIENT_HTTP_CODES
-    assert 503 in _TRANSIENT_HTTP_CODES
-    assert 504 in _TRANSIENT_HTTP_CODES
-    assert 400 not in _TRANSIENT_HTTP_CODES
-    assert 401 not in _TRANSIENT_HTTP_CODES
-    assert 403 not in _TRANSIENT_HTTP_CODES
-    assert 404 not in _TRANSIENT_HTTP_CODES
-    assert 422 not in _TRANSIENT_HTTP_CODES
-
-
-@pytest.mark.parametrize("code", [408, 429, 502, 503, 504])
-def test_is_terminal_api_error_returns_false_for_transient(code):
-    """Transient codes should NOT give up — backoff must retry them."""
-    exc = _make_api_status_error(code)
-    assert _is_terminal_api_error(exc) is False
-
-
-@pytest.mark.parametrize("code", [400, 401, 403, 404, 409, 422])
-def test_is_terminal_api_error_returns_true_for_fatal(code):
-    """Fatal/non-retryable codes should give up immediately."""
-    exc = _make_api_status_error(code)
-    assert _is_terminal_api_error(exc) is True
-
-
-def test_is_terminal_api_error_ignores_non_api_status_error():
-    """Non-APIStatusError exceptions are not touched by the giveup function."""
-    assert _is_terminal_api_error(ValueError("unrelated")) is False
-
-
-def test_is_terminal_api_error_rate_limit_never_terminal():
-    """RateLimitError (429) is a dedicated backoff-tuple entry; giveup must not fire."""
-    request = httpx.Request("POST", "http://localhost/v1/chat/completions")
-    response = httpx.Response(429, request=request)
-    exc = openai.RateLimitError("rate limited", response=response, body=None)
-    assert _is_terminal_api_error(exc) is False
-
-
-def test_is_terminal_api_error_internal_server_error_never_terminal():
-    """InternalServerError (500/503) is a dedicated backoff-tuple entry; giveup must not fire."""
-    request = httpx.Request("POST", "http://localhost/v1/chat/completions")
-    for code in (500, 503):
-        response = httpx.Response(code, request=request)
-        exc = openai.InternalServerError(f"server error {code}", response=response, body=None)
-        assert _is_terminal_api_error(exc) is False, (
-            f"InternalServerError({code}) must not be treated as terminal"
-        )
+def _make_prompt() -> Conversation:
+    return Conversation([Turn(role="user", content=Message("test prompt"))])
 
 
 @pytest.fixture
@@ -83,41 +39,47 @@ def nim_generator(monkeypatch):
     return g
 
 
-def test_nim_408_error_message_includes_status_code(nim_generator):
-    """A server-side HTTP 408 should surface its status code in the GarakException, not
-    the generic 'Is the model name spelled correctly?' message."""
-    error_408 = _make_api_status_error(408)
-    prompt = Conversation([Turn(role="user", content=Message("test"))])
-
-    with patch(
-        "garak.generators.openai.OpenAICompatible._call_model", side_effect=error_408
-    ):
-        with pytest.raises(GarakException) as exc_info:
-            nim_generator._call_model(prompt)
-
-    error_text = str(exc_info.value)
-    assert "408" in error_text, f"Expected '408' in error message; got: {error_text}"
-    assert "Is the model name spelled correctly?" not in error_text
+def test_transient_retry_codes_in_default_params():
+    """transient_retry_codes should be present in DEFAULT_PARAMS and contain expected codes."""
+    codes = OpenAICompatible.DEFAULT_PARAMS["transient_retry_codes"]
+    for code in (408, 429, 502, 503, 504):
+        assert code in codes, f"Expected {code} in transient_retry_codes"
+    for code in (400, 401, 403, 404):
+        assert code not in codes, f"Expected {code} NOT in transient_retry_codes"
 
 
-def test_nim_502_error_message_includes_status_code(nim_generator):
-    """A server-side HTTP 502 should also surface its status code."""
-    error_502 = _make_api_status_error(502)
-    prompt = Conversation([Turn(role="user", content=Message("test"))])
+@pytest.mark.parametrize("code", [408, 502, 503, 504])
+def test_transient_http_error_raises_backoff_trigger(nim_generator, code):
+    """A transient status code should cause _call_model to raise GeneratorBackoffTrigger
+    so that the backoff decorator can schedule a retry."""
+    prompt = _make_prompt()
+    nim_generator.generator = MagicMock()
+    nim_generator.generator.create.side_effect = _make_api_status_error(code)
 
-    with patch(
-        "garak.generators.openai.OpenAICompatible._call_model", side_effect=error_502
-    ):
-        with pytest.raises(GarakException) as exc_info:
-            nim_generator._call_model(prompt)
+    # Call the underlying function without the backoff decorator so the test does not
+    # need to wait for retry delays or exhaust the fibonacci sequence.
+    unwrapped = OpenAICompatible._call_model.__wrapped__
+    with pytest.raises(garak.exception.GeneratorBackoffTrigger):
+        unwrapped(nim_generator, prompt)
 
-    error_text = str(exc_info.value)
-    assert "502" in error_text, f"Expected '502' in error message; got: {error_text}"
+
+@pytest.mark.parametrize("code", [400, 403, 404, 422])
+def test_terminal_http_error_returns_none(nim_generator, code):
+    """A terminal (non-transient) status code should cause _call_model to return [None]
+    so that the current attempt is skipped and the probe run continues."""
+    prompt = _make_prompt()
+    nim_generator.generator = MagicMock()
+    nim_generator.generator.create.side_effect = _make_api_status_error(code)
+
+    unwrapped = OpenAICompatible._call_model.__wrapped__
+    result = unwrapped(nim_generator, prompt)
+    assert result == [None], f"Expected [None] for HTTP {code}, got {result!r}"
 
 
 def test_nim_generic_exception_message_improved(nim_generator):
-    """Non-APIStatusError exceptions should report the exception type, not the old generic message."""
-    prompt = Conversation([Turn(role="user", content=Message("test"))])
+    """Non-APIStatusError exceptions should report the exception type, not the old
+    generic 'Is the model name spelled correctly?' message."""
+    prompt = _make_prompt()
 
     with patch(
         "garak.generators.openai.OpenAICompatible._call_model",

--- a/tests/generators/test_nim.py
+++ b/tests/generators/test_nim.py
@@ -3,10 +3,111 @@
 
 import os
 import pytest
+import httpx
+import openai
+from unittest.mock import MagicMock, patch
 
 from garak.attempt import Message, Turn, Conversation
+from garak.exception import GarakException
 import garak.cli
 from garak.generators.nim import NVOpenAIChat
+from garak.generators.openai import _is_terminal_api_error, _TRANSIENT_HTTP_CODES
+
+
+def _make_api_status_error(status_code: int, url: str = "http://localhost/v1/chat/completions") -> openai.APIStatusError:
+    """Build an openai.APIStatusError with a real httpx.Response for a given HTTP status."""
+    request = httpx.Request("POST", url)
+    response = httpx.Response(status_code, request=request)
+    return openai.APIStatusError(f"HTTP {status_code}", response=response, body=None)
+
+
+def test_transient_http_codes_set():
+    assert 408 in _TRANSIENT_HTTP_CODES
+    assert 502 in _TRANSIENT_HTTP_CODES
+    assert 503 in _TRANSIENT_HTTP_CODES
+    assert 504 in _TRANSIENT_HTTP_CODES
+    assert 400 not in _TRANSIENT_HTTP_CODES
+    assert 401 not in _TRANSIENT_HTTP_CODES
+    assert 403 not in _TRANSIENT_HTTP_CODES
+    assert 404 not in _TRANSIENT_HTTP_CODES
+    assert 422 not in _TRANSIENT_HTTP_CODES
+
+
+@pytest.mark.parametrize("code", [408, 502, 503, 504])
+def test_is_terminal_api_error_returns_false_for_transient(code):
+    """Transient codes should NOT give up — backoff must retry them."""
+    exc = _make_api_status_error(code)
+    assert _is_terminal_api_error(exc) is False
+
+
+@pytest.mark.parametrize("code", [400, 401, 403, 404, 409, 422])
+def test_is_terminal_api_error_returns_true_for_fatal(code):
+    """Fatal/non-retryable codes should give up immediately."""
+    exc = _make_api_status_error(code)
+    assert _is_terminal_api_error(exc) is True
+
+
+def test_is_terminal_api_error_ignores_non_api_status_error():
+    """Non-APIStatusError exceptions are not touched by the giveup function."""
+    assert _is_terminal_api_error(ValueError("unrelated")) is False
+
+
+@pytest.fixture
+def nim_generator(monkeypatch):
+    """NVOpenAIChat with mocked client; no real API key required."""
+    monkeypatch.setenv(NVOpenAIChat.ENV_VAR, "test-fake-key-for-unit-tests")
+    mock_client = MagicMock()
+    mock_client.chat.completions = MagicMock()
+    with patch("openai.OpenAI", return_value=mock_client):
+        g = NVOpenAIChat(name="org/test-model")
+    return g
+
+
+def test_nim_408_error_message_includes_status_code(nim_generator):
+    """A server-side HTTP 408 should surface its status code in the GarakException, not
+    the generic 'Is the model name spelled correctly?' message."""
+    error_408 = _make_api_status_error(408)
+    prompt = Conversation([Turn(role="user", content=Message("test"))])
+
+    with patch(
+        "garak.generators.openai.OpenAICompatible._call_model", side_effect=error_408
+    ):
+        with pytest.raises(GarakException) as exc_info:
+            nim_generator._call_model(prompt)
+
+    error_text = str(exc_info.value)
+    assert "408" in error_text, f"Expected '408' in error message; got: {error_text}"
+    assert "Is the model name spelled correctly?" not in error_text
+
+
+def test_nim_502_error_message_includes_status_code(nim_generator):
+    """A server-side HTTP 502 should also surface its status code."""
+    error_502 = _make_api_status_error(502)
+    prompt = Conversation([Turn(role="user", content=Message("test"))])
+
+    with patch(
+        "garak.generators.openai.OpenAICompatible._call_model", side_effect=error_502
+    ):
+        with pytest.raises(GarakException) as exc_info:
+            nim_generator._call_model(prompt)
+
+    error_text = str(exc_info.value)
+    assert "502" in error_text, f"Expected '502' in error message; got: {error_text}"
+
+
+def test_nim_generic_exception_message_improved(nim_generator):
+    """Non-APIStatusError exceptions should report the exception type, not the old generic message."""
+    prompt = Conversation([Turn(role="user", content=Message("test"))])
+
+    with patch(
+        "garak.generators.openai.OpenAICompatible._call_model",
+        side_effect=RuntimeError("connection reset by peer"),
+    ):
+        with pytest.raises(GarakException) as exc_info:
+            nim_generator._call_model(prompt)
+
+    error_text = str(exc_info.value)
+    assert "Is the model name spelled correctly?" not in error_text
 
 
 @pytest.mark.skipif(

--- a/tests/generators/test_openai_compatible.py
+++ b/tests/generators/test_openai_compatible.py
@@ -6,14 +6,17 @@ import errno
 import json
 import os
 import httpx
+import openai
 import pathlib
 import respx
 import pytest
 import importlib
 import inspect
+from unittest.mock import MagicMock, patch
 
 from collections.abc import Iterable
 
+import garak.exception
 from garak.attempt import Message, Turn, Conversation
 import garak.generators.openai as openai_generator
 from garak.generators.openai import OpenAICompatible, OpenAIGenerator
@@ -251,3 +254,88 @@ def test_conversation_to_list_image_turn_uses_chat_completions_format():
     assert header == "data:image/gif;base64"
     assert separator == ","
     assert base64.b64decode(payload) == IMAGE_ASSET.read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# OpenAICompatible transient-error retry tests
+# (these tests cover base-class behaviour shared by NIM and all other
+#  OpenAICompatible subclasses)
+# ---------------------------------------------------------------------------
+
+
+def _make_api_status_error(
+    status_code: int, url: str = "http://localhost/v1/chat/completions"
+) -> openai.APIStatusError:
+    """Build an openai.APIStatusError with a real httpx.Response for a given HTTP status."""
+    request = httpx.Request("POST", url)
+    response = httpx.Response(status_code, request=request)
+    return openai.APIStatusError(f"HTTP {status_code}", response=response, body=None)
+
+
+def _make_prompt() -> Conversation:
+    return Conversation([Turn(role="user", content=Message("test prompt"))])
+
+
+@pytest.fixture
+def openai_compatible_generator(monkeypatch):
+    """OpenAICompatible generator with mocked client; no real API key required."""
+    monkeypatch.setenv(OpenAIGenerator.ENV_VAR, "test-fake-key-for-unit-tests")
+    mock_client = MagicMock()
+    mock_client.chat.completions = MagicMock()
+    with patch("openai.OpenAI", return_value=mock_client):
+        g = OpenAIGenerator(name="gpt-3.5-turbo")
+    return g
+
+
+def test_transient_retry_codes_in_default_params():
+    """transient_retry_codes should be present in DEFAULT_PARAMS and contain expected codes."""
+    codes = OpenAICompatible.DEFAULT_PARAMS["transient_retry_codes"]
+    for code in (408, 429, 502, 503, 504):
+        assert code in codes, f"Expected {code} in transient_retry_codes"
+    for code in (400, 401, 403, 404):
+        assert code not in codes, f"Expected {code} NOT in transient_retry_codes"
+
+
+@pytest.mark.parametrize("code", [408, 502, 503, 504])
+def test_transient_http_error_raises_backoff_trigger(openai_compatible_generator, code):
+    """A transient status code should cause _call_model to raise GeneratorBackoffTrigger
+    so that the backoff decorator can schedule a retry."""
+    prompt = _make_prompt()
+    openai_compatible_generator.generator = MagicMock()
+    openai_compatible_generator.generator.create.side_effect = _make_api_status_error(code)
+
+    # Call the underlying function without the backoff decorator so the test does not
+    # need to wait for retry delays or exhaust the fibonacci sequence.
+    unwrapped = OpenAICompatible._call_model.__wrapped__
+    with pytest.raises(garak.exception.GeneratorBackoffTrigger):
+        unwrapped(openai_compatible_generator, prompt)
+
+
+@pytest.mark.parametrize("code", [400, 403, 404, 422])
+def test_terminal_http_error_returns_none(openai_compatible_generator, code):
+    """A terminal (non-transient) status code should cause _call_model to return [None]
+    so that the current attempt is skipped and the probe run continues."""
+    prompt = _make_prompt()
+    openai_compatible_generator.generator = MagicMock()
+    openai_compatible_generator.generator.create.side_effect = _make_api_status_error(code)
+
+    unwrapped = OpenAICompatible._call_model.__wrapped__
+    result = unwrapped(openai_compatible_generator, prompt)
+    assert result == [None], f"Expected [None] for HTTP {code}, got {result!r}"
+
+
+def test_generic_exception_message_improved(openai_compatible_generator):
+    """Non-APIStatusError exceptions should report the exception type, not the old
+    generic 'Is the model name spelled correctly?' message."""
+    from garak.exception import GarakException
+
+    prompt = _make_prompt()
+    with patch(
+        "garak.generators.openai.OpenAICompatible._call_model",
+        side_effect=RuntimeError("connection reset by peer"),
+    ):
+        with pytest.raises(GarakException) as exc_info:
+            openai_compatible_generator._call_model(prompt)
+
+    error_text = str(exc_info.value)
+    assert "Is the model name spelled correctly?" not in error_text

--- a/tests/generators/test_openai_compatible.py
+++ b/tests/generators/test_openai_compatible.py
@@ -287,22 +287,32 @@ def openai_compatible_generator(monkeypatch):
     return g
 
 
-def test_transient_retry_codes_in_default_params():
-    """transient_retry_codes should be present in DEFAULT_PARAMS and contain expected codes."""
+def test_transient_retry_codes_override(openai_compatible_generator):
+    """transient_retry_codes override suppresses retry for removed code."""
     codes = OpenAICompatible.DEFAULT_PARAMS["transient_retry_codes"]
-    for code in (408, 429, 502, 503, 504):
-        assert code in codes, f"Expected {code} in transient_retry_codes"
-    for code in (400, 401, 403, 404):
-        assert code not in codes, f"Expected {code} NOT in transient_retry_codes"
+
+    prompt = _make_prompt()
+    openai_compatible_generator.generator = MagicMock()
+    openai_compatible_generator.transient_retry_codes = [codes[1:]]
+    openai_compatible_generator.generator.create.side_effect = _make_api_status_error(
+        codes[0]
+    )
+
+    results = openai_compatible_generator._call_model(prompt)
+    assert results == [None]
 
 
-@pytest.mark.parametrize("code", [408, 429, 502, 503, 504])
+@pytest.mark.parametrize(
+    "code", OpenAICompatible.DEFAULT_PARAMS["transient_retry_codes"]
+)
 def test_transient_http_error_raises_backoff_trigger(openai_compatible_generator, code):
     """A transient status code should cause _call_model to raise GeneratorBackoffTrigger
     so that the backoff decorator can schedule a retry."""
     prompt = _make_prompt()
     openai_compatible_generator.generator = MagicMock()
-    openai_compatible_generator.generator.create.side_effect = _make_api_status_error(code)
+    openai_compatible_generator.generator.create.side_effect = _make_api_status_error(
+        code
+    )
 
     # Call the underlying function without the backoff decorator so the test does not
     # need to wait for retry delays or exhaust the fibonacci sequence.
@@ -311,17 +321,25 @@ def test_transient_http_error_raises_backoff_trigger(openai_compatible_generator
         unwrapped(openai_compatible_generator, prompt)
 
 
-@pytest.mark.parametrize("code", [400, 403, 404, 422])
+@pytest.mark.parametrize(
+    "code",
+    [
+        code
+        for code in httpx.codes
+        if code >= 400
+        and code < 600
+        and code not in OpenAICompatible.DEFAULT_PARAMS["transient_retry_codes"]
+    ],
+)
 def test_terminal_http_error_returns_none(openai_compatible_generator, code):
     """A terminal (non-transient) status code should cause _call_model to return [None]
     so that the current attempt is skipped and the probe run continues."""
     prompt = _make_prompt()
     openai_compatible_generator.generator = MagicMock()
-    openai_compatible_generator.generator.create.side_effect = _make_api_status_error(code)
+    openai_compatible_generator.generator.create.side_effect = _make_api_status_error(
+        code
+    )
 
     unwrapped = OpenAICompatible._call_model.__wrapped__
     result = unwrapped(openai_compatible_generator, prompt)
     assert result == [None], f"Expected [None] for HTTP {code}, got {result!r}"
-
-
-

--- a/tests/generators/test_openai_compatible.py
+++ b/tests/generators/test_openai_compatible.py
@@ -296,7 +296,7 @@ def test_transient_retry_codes_in_default_params():
         assert code not in codes, f"Expected {code} NOT in transient_retry_codes"
 
 
-@pytest.mark.parametrize("code", [408, 502, 503, 504])
+@pytest.mark.parametrize("code", [408, 429, 502, 503, 504])
 def test_transient_http_error_raises_backoff_trigger(openai_compatible_generator, code):
     """A transient status code should cause _call_model to raise GeneratorBackoffTrigger
     so that the backoff decorator can schedule a retry."""
@@ -324,18 +324,4 @@ def test_terminal_http_error_returns_none(openai_compatible_generator, code):
     assert result == [None], f"Expected [None] for HTTP {code}, got {result!r}"
 
 
-def test_generic_exception_message_improved(openai_compatible_generator):
-    """Non-APIStatusError exceptions should report the exception type, not the old
-    generic 'Is the model name spelled correctly?' message."""
-    from garak.exception import GarakException
 
-    prompt = _make_prompt()
-    with patch(
-        "garak.generators.openai.OpenAICompatible._call_model",
-        side_effect=RuntimeError("connection reset by peer"),
-    ):
-        with pytest.raises(GarakException) as exc_info:
-            openai_compatible_generator._call_model(prompt)
-
-    error_text = str(exc_info.value)
-    assert "Is the model name spelled correctly?" not in error_text


### PR DESCRIPTION
Fixes #1967

When an OpenAI-compatible endpoint returns a transient HTTP error (408, 502, 503, 504) or a quota/rate-limit error (429), the response arrives as a bare \`openai.APIStatusError\` and was not caught by the existing backoff decorator, aborting the probe run on a single hiccup.

## What changed

Catch \`openai.APIStatusError\` inside \`_call_model\` before it leaves the try block:

- **Transient codes** (in \`self.transient_retry_codes\`): raise \`GeneratorBackoffTrigger\` so the existing fibonacci backoff decorator retries the call.
- **Non-transient codes**: log a warning and return \`[None]\` so the current attempt is skipped and the probe run continues.

\`transient_retry_codes\` is added to \`DEFAULT_PARAMS\` (default: \`[408, 429, 502, 503, 504]\`) so users can adjust the set via YAML config without code changes.

The dead \`openai.APIStatusError\` handler in \`NVOpenAIChat._call_model\` is removed; the parent class now handles all \`APIStatusError\` cases before they reach the NIM override.

No \`giveup\` predicate, no change to the backoff decorator's exception tuple.

## Tests

New tests call \`_call_model.__wrapped__\` to exercise the exception-handling logic without backoff retry delays:
- 4 parametrized cases verify transient codes raise \`GeneratorBackoffTrigger\`
- 4 parametrized cases verify terminal codes return \`[None]\`
- 1 case verifies \`transient_retry_codes\` is present in \`DEFAULT_PARAMS\`
- 1 case verifies NIM's generic exception message reports the exception type

## Files

- \`garak/generators/openai.py\`: add \`transient_retry_codes\` to DEFAULT_PARAMS; add \`except openai.APIStatusError\` handler inside \`_call_model\`
- \`garak/generators/nim.py\`: remove dead \`except openai.APIStatusError\` block
- \`tests/generators/test_nim.py\`: replace predicate-function tests with behaviour tests via \`__wrapped__\`