### PR TITLE
Fix: unreachable Conversation branch in Probe.probe() pre-translation notes

### DIFF
--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -449,9 +449,9 @@ class Probe(Configurable):
                             [pre_translation_prompt]
                         )
                     }
-                elif isinstance(pre_translation_prompt, garak.attempt.Message):
+                elif isinstance(pre_translation_prompt, garak.attempt.Conversation):
                     for turn in pre_translation_prompt.turns:
-                        turn.context.lang = self.lang
+                        turn.content.lang = self.lang
                     notes = {"pre_translation_prompt": pre_translation_prompt}
 
             attempts_todo.append(self._mint_attempt(prompt, seq, notes, lang))

--- a/tests/langservice/probes/test_probes_base.py
+++ b/tests/langservice/probes/test_probes_base.py
@@ -7,7 +7,7 @@ import tempfile
 import os
 
 from garak import _config, _plugins
-from garak.attempt import Message, Attempt, Conversation
+from garak.attempt import Message, Attempt, Conversation, Turn
 from garak.exception import GarakException
 
 NON_PROMPT_PROBES = [
@@ -187,6 +187,56 @@ def test_base_postprocess_attempt_preserves_output_order(classname, mocker):
         "second",
         "third",
     ], "reverse_translation_outputs must stay aligned with the original output order"
+
+
+@pytest.mark.parametrize("classname", ["probes.base.Probe"])
+def test_base_probe_keeps_pre_translation_conversation_prompt(classname, mocker):
+    """Conversation prompts must record their pre-translation form in attempt notes.
+
+    Probe.probe() tested `isinstance(pre_translation_prompt, Message)` twice, so the
+    Conversation branch was unreachable and notes were left as None. Attempt.prompt_for()
+    then returned the translated prompt for the probe language, which is what detectors
+    such as detectors.misleading read.
+    """
+
+    import garak.services.langservice
+    import garak.probes.base
+    from garak.langproviders.local import Passthru
+
+    null_provider = Passthru(
+        {
+            "langproviders": {
+                "local": {
+                    "language": "en,ja",
+                    # a differing source and target pair is what puts probe() in translated mode
+                }
+            }
+        }
+    )
+
+    mocker.patch.object(
+        garak.services.langservice, "get_langprovider", return_value=null_provider
+    )
+
+    probe_instance = garak.probes.base.Probe()
+    probe_instance.lang = "en"
+    probe_instance.prompts = [
+        Conversation([Turn("user", Message("original english prompt", lang="en"))])
+    ]
+
+    generator_instance = _plugins.load_plugin("generators.test.Repeat")
+    attempts = probe_instance.probe(generator_instance)
+
+    assert len(attempts) == 1
+    notes_prompt = attempts[0].notes.get("pre_translation_prompt")
+    assert isinstance(
+        notes_prompt, Conversation
+    ), "Conversation prompts must be recorded as the pre-translation prompt"
+    assert [turn.content.text for turn in notes_prompt.turns] == [
+        "original english prompt"
+    ]
+    assert all(turn.content.lang == "en" for turn in notes_prompt.turns)
+    assert attempts[0].prompt_for("en").last_message().text == "original english prompt"
 
 
 """


### PR DESCRIPTION
`Probe.probe()` records `notes["pre_translation_prompt"]` so that `Attempt.prompt_for()` can hand back the original-language prompt after forward translation. The third `isinstance` check repeated the `Message` condition instead of testing for `Conversation`, so a probe with `Conversation` prompts left `notes` as `None` and `prompt_for()` returned the translated prompt even when asked for the probe language. That is what `detectors.misleading` and the other `prompt_for(self.lang_spec)` consumers read, so with a langprovider configured they were scoring against the wrong text. The branch body also used `turn.context`, an attribute `Turn` has never had, so it would have raised `AttributeError` if it had ever been reachable.

`TreeSearchProbe._create_attempt` further down the same file already has the intended form of this branch, so this change brings `Probe.probe()` back in line with it. The duplicate condition arrived in e2d3667. Thanks to @feiiiiii5 for the diagnosis in the issue.

Closes #2020

## Why this is not a duplicate

- `gh pr list --repo nvidia/garak --state open --search "2020 in:body"` returns nothing related.
- A PR search for `pre_translation_prompt` returns only closed PRs (#1441, #1483, #1414, #1337, #943), none of which touch this branch.
- A search of open PRs for Conversation plus translation returns only #1531 (resume scan), which does not touch `probes/base.py`.

## Tests run

Python 3.12, macOS, CPU only.

```
$ python -m pytest tests/langservice/probes/test_probes_base.py -k "pre_translation_conversation" -q
1 passed, 188 deselected in 18.23s

$ python -m pytest tests/langservice/probes/test_probes_base.py -k "base_" -q
6 passed, 183 deselected in 3.47s

$ python -m pytest tests/langservice/probes/test_probes_base.py -q
2 failed, 149 passed, 38 skipped in 974.89s

$ python -m pytest tests/test_attempt.py -q
23 passed in 8.24s

$ python -m pytest tests/probes/test_probes.py -q
7 failed, 1349 passed in 298.69s

$ black --check tests/langservice/probes/test_probes_base.py
All done!
```

Restoring `garak/probes/base.py` to `main` and rerunning the new test makes it fail on `assert isinstance(notes_prompt, Conversation)`, so it is a real regression test rather than a restatement of current behaviour.

Every failure above is pre-existing in my environment rather than caused by this change, and I checked each one by restoring `garak/probes/base.py` to `main` and confirming the same failure.

- `tests/probes/test_probes.py`: the 7 failures are all `test_probe_metadata` on plugins whose optional dependencies I do not have locally, namely `probes.audio.AudioAchillesHeel` (wants `soundfile` and `librosa`), `probes.suffix.BEAST`, `probes.suffix.GCG`, and the three `probes.topic.Wordnet*` entries. None of them reach `Probe.probe()`.
- `test_atkgen_probe_translation[probes.atkgen.Tox]`: fails locally only because `accelerate` is not installed.
- `test_probe_prompt_translation[probes.sysprompt_extraction.SystemPromptExtraction]`: fails with `IndexError: list index out of range` at `garak/probes/base.py:402`, which is the `isinstance(prompts[0], str)` check at the top of `probe()`. Its prompt set comes back empty locally. This reproduces identically with `garak/probes/base.py` restored to `main`, so it is not related to this change, but flagging it in case it is news.

`black --check garak/probes/base.py` also flags one pre-existing line further down the file, the `logging.debug` call in the intent-filtering `probe()` override. That flag is present on an unmodified checkout of `main` too, so I left it alone rather than widen this PR.

Reverting only the `garak/probes/base.py` hunk makes the new test fail with `assert None is not None` on `notes["pre_translation_prompt"]`, so it is a real regression test rather than a restatement of current behaviour.

## AI assistance

AI assistance was used for this change. I used Claude to trace the call path from `Probe.probe()` through `Attempt.prompt_for()` to the detector consumers, and to draft the fix and the regression test. I reviewed every changed line, confirmed against `TreeSearchProbe._create_attempt` and against the `Turn` dataclass that `content` is the correct attribute, and ran the tests above locally.
