### PR TITLE
Add ollama auth and custom client kwargs

### DIFF
--- a/garak/generators/ollama.py
+++ b/garak/generators/ollama.py
@@ -48,10 +48,10 @@ class OllamaGenerator(Generator):
         if hasattr(self, "verify_ssl") and self.verify_ssl is not None:
             client_kwargs["verify"] = self.verify_ssl
         if self.api_key:
-            client_kwargs["headers"] = {
-                **client_kwargs.get("headers", {}),
+            headers = client_kwargs.get("headers", {}) | {
                 "Authorization": f"Bearer {self.api_key}",
             }
+            client_kwargs["headers"] = headers
 
         self.client = self.ollama.Client(
             self.host, timeout=self.timeout, **client_kwargs

--- a/garak/generators/ollama.py
+++ b/garak/generators/ollama.py
@@ -28,6 +28,7 @@ class OllamaGenerator(Generator):
     DEFAULT_PARAMS = Generator.DEFAULT_PARAMS | {
         "timeout": 30,  # Add a timeout of 30 seconds. Ollama can tend to hang forever on failures, if this is not present
         "host": "127.0.0.1:11434",  # The default host of an Ollama server. This can be overwritten with a passed config or generator config file.
+        "client_kwargs": None,  # Additional kwargs for the Ollama client, which are httpx.client kwargs.
     }
 
     active = True
@@ -39,7 +40,7 @@ class OllamaGenerator(Generator):
         super().__init__(name, config_root)  # Sets the name and generations
 
         self.client = self.ollama.Client(
-            self.host, timeout=self.timeout
+            self.host, timeout=self.timeout, **(self.client_kwargs or {})
         )  # Instantiates the client with the timeout
 
     @backoff.on_exception(

--- a/garak/generators/ollama.py
+++ b/garak/generators/ollama.py
@@ -6,7 +6,7 @@ import backoff
 
 from garak import _config
 from garak.attempt import Message, Conversation
-from garak.exception import GeneratorBackoffTrigger
+from garak.exception import GeneratorBackoffTrigger, APIKeyMissingError
 from garak.generators.base import Generator
 from httpx import TimeoutException
 
@@ -25,10 +25,12 @@ class OllamaGenerator(Generator):
     Model names can be passed in short form like "llama2" or specific versions or sizes like "gemma:7b" or "llama2:latest"
     """
 
+    ENV_VAR = "OLLAMA_API_KEY"
     DEFAULT_PARAMS = Generator.DEFAULT_PARAMS | {
         "timeout": 30,  # Add a timeout of 30 seconds. Ollama can tend to hang forever on failures, if this is not present
         "host": "127.0.0.1:11434",  # The default host of an Ollama server. This can be overwritten with a passed config or generator config file.
-        "client_kwargs": None,  # Additional kwargs for the Ollama client, which are httpx.client kwargs.
+        "verify_ssl": None,  # Whether to verify the server's ssl certificate. This might help when using self-signed certificates.
+        "extra_params": None,  # Additional kwargs for the Ollama client, which are httpx.client kwargs.
     }
 
     active = True
@@ -39,8 +41,20 @@ class OllamaGenerator(Generator):
     def __init__(self, name="", config_root=_config):
         super().__init__(name, config_root)  # Sets the name and generations
 
+        client_kwargs = {}
+        if hasattr(self, "extra_params") and self.extra_params is not None:
+            for k, v in self.extra_params.items():
+                client_kwargs[k] = v
+        if hasattr(self, "verify_ssl") and self.verify_ssl is not None:
+            client_kwargs["verify"] = self.verify_ssl
+        if self.api_key:
+            client_kwargs["headers"] = {
+                **client_kwargs.get("headers", {}),
+                "Authorization": f"Bearer {self.api_key}",
+            }
+
         self.client = self.ollama.Client(
-            self.host, timeout=self.timeout, **(self.client_kwargs or {})
+            self.host, timeout=self.timeout, **client_kwargs
         )  # Instantiates the client with the timeout
 
     @backoff.on_exception(
@@ -69,6 +83,12 @@ class OllamaGenerator(Generator):
             raise e
 
         return [Message(response.get("response", None))]
+
+    def _validate_env_var(self):
+        try:
+            super()._validate_env_var()
+        except APIKeyMissingError as e:
+            pass
 
 
 class OllamaGeneratorChat(OllamaGenerator):

--- a/tests/generators/test_ollama.py
+++ b/tests/generators/test_ollama.py
@@ -226,7 +226,10 @@ def set_fake_env(request) -> None:
         if stored_env is not None:
             os.environ[OllamaGenerator.ENV_VAR] = stored_env
         else:
-            del os.environ[OllamaGenerator.ENV_VAR]
+            try:
+                del os.environ[OllamaGenerator.ENV_VAR]
+            except KeyError:
+                pass
 
     os.environ[OllamaGenerator.ENV_VAR] = "sk-1234567abc"
     request.addfinalizer(restore_env)
@@ -253,6 +256,16 @@ def test_ollama_extra_params():
     }
     gen = OllamaGenerator("gemma3", config_root=config)
 
+    assert gen.api_key is not None
     assert gen.verify_ssl is False
     assert gen.client._client.headers["My-Header"] == "Test-1.0"
-    assert gen.client._client.headers["Authorization"] == f"Bearer sk-1234567abc"
+    assert gen.client._client.headers["Authorization"] == f"Bearer {gen.api_key}"
+
+
+@pytest.mark.usefixtures("set_fake_env")
+def test_ollama_no_api_key():
+    """When no env variable key is provided the generator can be instantiated"""
+    del os.environ[OllamaGenerator.ENV_VAR]
+
+    gen = OllamaGenerator("gemma3")
+    assert gen.api_key is None

--- a/tests/generators/test_ollama.py
+++ b/tests/generators/test_ollama.py
@@ -1,4 +1,6 @@
 import importlib
+import os
+
 import pytest
 import respx
 import httpx
@@ -214,3 +216,43 @@ def test_error_on_nonexistant_model_chat_mocked(respx_mock):
     with pytest.raises(ollama.ResponseError):
         conv = Conversation([Turn("user", Message("This shouldnt work"))])
         gen.generate(conv)
+
+
+@pytest.fixture
+def set_fake_env(request) -> None:
+    stored_env = os.getenv(OllamaGenerator.ENV_VAR, None)
+
+    def restore_env():
+        if stored_env is not None:
+            os.environ[OllamaGenerator.ENV_VAR] = stored_env
+        else:
+            del os.environ[OllamaGenerator.ENV_VAR]
+
+    os.environ[OllamaGenerator.ENV_VAR] = "sk-1234567abc"
+    request.addfinalizer(restore_env)
+
+
+@pytest.mark.usefixtures("set_fake_env")
+def test_ollama_extra_params():
+    """When a user provides extra_params as well as an API Key
+    via the environment (here mocked with set_fake_env),
+    both should combine into one headers dict without overriding each other.
+    Additionally, if the user config requires to disable ssl verification,
+    this should be passed to the ollama client constructor.
+    """
+
+    config = {
+        "generators": {
+            "ollama": {
+                "OllamaGenerator": {
+                    "verify_ssl": False,
+                    "extra_params": {"headers": {"My-Header": "Test-1.0"}},
+                }
+            }
+        }
+    }
+    gen = OllamaGenerator("gemma3", config_root=config)
+
+    assert gen.verify_ssl is False
+    assert gen.client._client.headers["My-Header"] == "Test-1.0"
+    assert gen.client._client.headers["Authorization"] == f"Bearer sk-1234567abc"


### PR DESCRIPTION
This PR adds the possibility to pass kwargs to the Ollama client. This enables support for an enhanced ollama configuration, for example for instances that require an authorization header or that are self hosted (which is likely with ollama), thus also likely having a self-signed certificate that httpx will reject (and which can be circumvented by passing `verify=False`).

Personally, I'd benefit hugely from this rather small changes, finally being able to correctly configure the client for my instance without the need of some hacky circumventions. :) 

## Verification
This is an example for connecting to a fictional (!) ollama server that is self-hosted with self-signed certificates and requires authentication.
- [x] Supporting configuration such as generator configuration file
``` json
{
    "ollama": {
        "OllamaGeneratorChat": {
            "host": "https://my-self-hosted-server.com/ollama",
            "client_kwargs": {
                "verify": false,
                "headers": {
                    "Authorization": "Bearer sk-123456789abc"
                }
            }
        }
    }
}
```
- [x] `garak -t ollama -n gemma3:latest --probes test.Blank`
- [x] Run the tests and ensure they pass `python -m pytest tests/` (5673 passed, 105 skipped, 2 warnings)
- [x] **Verify** the thing does what it should
- [x] **Verify** the thing does not do what it should not
- [x] **Document** the thing and how it works ([Example](https://github.com/NVIDIA/garak/blob/61ce5c4ae3caac08e0abd1d069d223d8a66104bd/garak/generators/rest.py#L24-L100))
