### PR TITLE
fix(probes): return no attempts when the prompt set is empty

### DIFF
--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -393,6 +393,12 @@ class Probe(Configurable):
         prompts = copy.deepcopy(
             self.prompts
         )  # make a copy to avoid mutating source list
+        if not prompts:
+            # A probe can have an empty prompt set (e.g. translation empties it);
+            # the progress bar below tolerates zero but the `prompts[0]` check
+            # does not. Produce no attempts instead of raising IndexError (#2026).
+            logging.warning("probe %s has an empty prompt set", self.probename)
+            return []
         preparation_bar = tqdm.tqdm(
             total=len(prompts),
             leave=False,

--- a/tests/probes/test_probes.py
+++ b/tests/probes/test_probes.py
@@ -5,6 +5,7 @@ import importlib
 import langcodes
 import pytest
 import re
+from unittest.mock import MagicMock
 
 from garak import _config, _plugins
 from garak.attempt import Turn, Conversation, Message, Attempt
@@ -223,6 +224,23 @@ def test_mint_attempt(prompt):
     assert attempt.prompt.last_message().text == "test example"
 
 
+def test_probe_with_empty_prompts_returns_no_attempts():
+    """An empty (or translation-emptied) prompt set must not IndexError.
+
+    Regression test for #2026: ``probe()`` indexed ``prompts[0]`` before
+    checking the list was non-empty, so a probe whose prompt set came back empty
+    raised ``IndexError`` instead of producing no attempts.
+    """
+    import garak.probes.base
+
+    probe = garak.probes.base.Probe()
+    probe.prompts = []
+
+    attempts = probe.probe(MagicMock())
+
+    assert attempts == []
+
+
 @pytest.mark.parametrize("prompt", PROMPT_EXAMPLES)
 def test_mint_attempt_with_run_system_prompt(prompt):
     import garak.probes.base
@@ -360,5 +378,4 @@ def test_encoding_probe_attempt_carries_payload_intent(loaded_intent_service):
     assert (
         attempt.intent == expected_intent
     ), "attempt intent must reflect the payload-specific intent set in _attempt_prestore_hook"
-
 


### PR DESCRIPTION
## Root Cause

`Probe.probe()` indexes `prompts[0]` without first checking that the prompt set is non-empty (`garak/probes/base.py`). A probe whose prompt set is empty — for example one emptied by the langprovider translation path (reproduced in `tests/probes/test_probes.py::test_probe_prompt_translation[probes.sysprompt_extraction.SystemPromptExtraction]` in #2022) — raises `IndexError: list index out of range` instead of producing no attempts. The progress bar two lines earlier already tolerates `len(prompts) == 0`; only the subscript does not.

## Fix

Return `[]` (with a warning naming the probe) when the copied prompt set is empty, before the progress bar and the `prompts[0]` check. This mirrors the empty-set guard already present in `IntentProbe.probe()`.

## Test

- New regression test `test_probe_with_empty_prompts_returns_no_attempts`: a `Probe` with `prompts = []` returns `[]` instead of raising.
- Verified locally: `pytest tests/probes/test_probes.py::test_mint_attempt tests/probes/test_probes.py::test_probe_with_empty_prompts_returns_no_attempts` → 5 passed.

## Diff scope

2 files, +24/-1: `garak/probes/base.py`, `tests/probes/test_probes.py`.

## AI Disclosure

AI-assisted implementation and regression test; human review of the empty-set semantics (no behavior change for non-empty probes; consistent with `IntentProbe`) and final diff before submission.

Closes #2026
