### PR TITLE
fix: stop FileDetector format mismatch from aborting the run

### DIFF
--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -305,7 +305,11 @@ class TriggerListDetector(Detector):
 
 
 class FileDetector(Detector):
-    """Detector subclass for processing attempts whose outputs are filenames for checking"""
+    """Detector subclass for processing attempts whose outputs are filenames for checking
+
+    Attempts whose ``notes["format"]`` does not match ``valid_format`` cannot be
+    scored; one ``None`` per output is returned so the run continues.
+    """
 
     valid_format = "local filename"
 
@@ -317,9 +321,13 @@ class FileDetector(Detector):
             "format" not in attempt.notes
             or attempt.notes["format"] != self.valid_format
         ):
-            raise ValueError(
-                f"detectors.fileformats.{self.__class__.__name__} only processes outputs that are '{self.valid_format}'"
+            logging.warning(
+                "detectors.fileformats.%s only processes outputs that are '%s'; attempt not scored",
+                self.__class__.__name__,
+                self.valid_format,
             )
+            yield from [None] * len(attempt.outputs)
+            return
 
         for local_filename in attempt.outputs:
             if not local_filename or not local_filename.text:

--- a/tests/detectors/test_detectors_fileformats.py
+++ b/tests/detectors/test_detectors_fileformats.py
@@ -39,10 +39,10 @@ def test_fileispickled_invalid_format():
     d = garak.detectors.fileformats.FileIsPickled()
     plain_attempt = Attempt(prompt=Message(text=""))
     plain_attempt.outputs = [Message(s) for s in ["a", "b", "c"]]
-    with pytest.raises(
-        ValueError
-    ) as exc_info:  # should not process attempts without correct "format" note
-        l = list(d.detect(plain_attempt))
+    l = list(d.detect(plain_attempt))
+    assert l == [None] * len(
+        plain_attempt.outputs
+    ), "attempts without the correct 'format' note are not scored, one None per output"
 
 
 def test_fileispickled_valid_format():

--- a/tests/harnesses/test_harnesses.py
+++ b/tests/harnesses/test_harnesses.py
@@ -105,3 +105,35 @@ def test_harness_detector_progress_shows_probe_name(mocker, monkeypatch):
         "test.Blank" in desc and "always.Pass" in desc
         for desc in captured_descriptions
     ), "detector progress description should include probe and detector names"
+
+
+def test_harness_unscorable_outputs_do_not_halt_probe_queue(mocker, monkeypatch):
+    """A detector that cannot score one probe's outputs must not strand the rest of the queue."""
+    mocker.patch("garak.harnesses.base._initialize_runtime_services")
+    monkeypatch.setattr(
+        _config.buffmanager,
+        "buffs",
+        [garak.buffs.base.Buff()],
+    )
+
+    harness = garak.harnesses.base.Harness()
+    model = _plugins.load_plugin("generators.test.Blank")
+    probes = [
+        _plugins.load_plugin("probes.test.Blank"),
+        _plugins.load_plugin("probes.test.Test"),
+    ]
+    # only scores local filenames, so neither probe's text outputs are scorable
+    detector = _plugins.load_plugin("detectors.fileformats.FileIsPickled")
+    evaluator = mocker.Mock()
+
+    harness.run(model, probes, [detector], evaluator)
+
+    evaluated_probes = {
+        attempt.probe_classname
+        for call in evaluator.evaluate.call_args_list
+        for attempt in call.args[0]
+    }
+    assert evaluated_probes == {
+        "test.Blank",
+        "test.Test",
+    }, "every queued probe should reach the evaluator when a detector cannot score its outputs"


### PR DESCRIPTION
## Summary

Found while reviewing **#1952**, which adds an `S008exec` → `fileformats.FileIsExecutable` intent mapping. With it applied, `--spec probes.grandma.GrandmaIntent,intent:S008exec` yields 256 attempts and zero evaluations.

`FileDetector.detect()` raises `ValueError` when `attempt.notes["format"]` does not match `valid_format`, and the harness calls detectors with no `try`/`except`, so the run aborts: queued probes never execute, no `eval` or `completion` records are written, and `cli.main` exits **0**. The mapping only exposes this.

The raise becomes a warning and one `None` per output, not `0.0`, since the outputs are not filenames at all. The evaluator already counts `None` as `nones`, and `StringDetector` and `HFDetector.graceful_fail` use the same idiom.

## Reproduction

```bash
python -m garak --target_type test.Repeat --spec probes.test.Blank,probes.test.Test \
  -d fileformats.FileIsPickled --generations 1 --report_prefix filedetector-guard-before
```

**Before**: `probes.test.Test` never runs; the report holds 1 attempt, 0 `eval`, 0 `completion`.
**After**: both probes run, 9 attempts, 2 `eval`, 1 `completion`.

Both exit **0** — the exit code never signalled the abort.
