### PR TITLE
fix(harnesses): skip falsy intents instead of registering them

### DIFF
--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -237,6 +237,7 @@ class Harness(Configurable):
                             "probe %s attempt %s seq %s has no or empty intent"
                             % (probe.probename, a.uuid, a.seq)
                         )
+                        continue
                     intents_observed.add(intent)
 
                 if intents_observed:
@@ -263,7 +264,7 @@ class Harness(Configurable):
                     intent_detectors.append(d)
                     attempt_subset = []
                     for a in attempt_results_list:
-                        mapping = intent_to_detector[a.intent]
+                        mapping = intent_to_detector.get(a.intent, ())
                         if detector_name in mapping:
                             attempt_subset.append(a)
                     self._run_detector(attempt_subset, d)

--- a/tests/harnesses/test_harnesses.py
+++ b/tests/harnesses/test_harnesses.py
@@ -10,6 +10,7 @@ from garak import _plugins, _config
 
 import garak.buffs.base
 import garak.harnesses.base
+import garak.probes.base
 
 HARNESSES = [
     classname for (classname, active) in _plugins.enumerate_plugins("harnesses")
@@ -137,3 +138,87 @@ def test_harness_unscorable_outputs_do_not_halt_probe_queue(mocker, monkeypatch)
         "test.Blank",
         "test.Test",
     }, "every queued probe should reach the evaluator when a detector cannot score its outputs"
+
+
+@pytest.mark.parametrize("intent", [None, ""])
+def test_harness_does_not_resolve_falsy_intent(mocker, intent):
+    """Falsy attempt intents are warned about and never sent to intentservice."""
+    mocker.patch("garak.harnesses.base._initialize_runtime_services")
+    mocker.patch("garak.harnesses.base._emit_plugin_cache_entry")
+    get_detectors = mocker.patch("garak.services.intentservice.get_detectors")
+
+    harness = garak.harnesses.base.Harness()
+    mocker.patch.object(harness, "_start_run_hook")
+    mocker.patch.object(harness, "_end_run_hook")
+
+    model = mocker.Mock()
+    model.modality = {"in": {"text"}}
+
+    probe = mocker.Mock(spec=garak.probes.base.IntentProbe)
+    probe.probename = "garak.probes.test.EmptyIntent"
+    probe.modality = {"in": {"text"}}
+
+    attempt = mocker.Mock()
+    attempt.intent = intent
+    attempt.uuid = "empty-intent-attempt"
+    attempt.seq = 0
+    attempt.as_dict.return_value = {}
+    probe.probe.return_value = [attempt]
+
+    detector = mocker.Mock()
+    detector.detectorname = "garak.detectors.always.Pass"
+
+    harness.run(model, [probe], [detector], mocker.Mock())
+
+    get_detectors.assert_not_called()
+
+
+def test_harness_skips_falsy_intent_when_valid_intent_is_present(mocker):
+    """An invalid attempt must not break detector selection for valid attempts."""
+    mocker.patch("garak.harnesses.base._initialize_runtime_services")
+    mocker.patch("garak.harnesses.base._emit_plugin_cache_entry")
+    get_detectors = mocker.patch(
+        "garak.services.intentservice.get_detectors",
+        return_value=["always.Pass"],
+    )
+
+    harness = garak.harnesses.base.Harness()
+    mocker.patch.object(harness, "_start_run_hook")
+    mocker.patch.object(harness, "_end_run_hook")
+    run_detector = mocker.patch.object(harness, "_run_detector")
+
+    model = mocker.Mock()
+    model.modality = {"in": {"text"}}
+
+    probe = mocker.Mock(spec=garak.probes.base.IntentProbe)
+    probe.probename = "garak.probes.test.MixedIntent"
+    probe.modality = {"in": {"text"}}
+
+    invalid_attempt = mocker.Mock()
+    invalid_attempt.intent = None
+    invalid_attempt.uuid = "empty-intent-attempt"
+    invalid_attempt.seq = 0
+    invalid_attempt.as_dict.return_value = {}
+
+    valid_attempt = mocker.Mock()
+    valid_attempt.intent = "T009ignore"
+    valid_attempt.uuid = "valid-intent-attempt"
+    valid_attempt.seq = 1
+    valid_attempt.as_dict.return_value = {}
+
+    probe.probe.return_value = [invalid_attempt, valid_attempt]
+
+    detector = mocker.Mock()
+    detector.detectorname = "garak.detectors.always.Pass"
+
+    resolved_detector = mocker.Mock()
+    resolved_detector.detectorname = "garak.detectors.always.Pass"
+    mocker.patch(
+        "garak.harnesses.base._plugins.load_plugin",
+        return_value=resolved_detector,
+    )
+
+    harness.run(model, [probe], [detector], mocker.Mock())
+
+    get_detectors.assert_called_once_with("T009ignore")
+    run_detector.assert_called_once_with([valid_attempt], resolved_detector)


### PR DESCRIPTION
### Summary
`Harness.run()` logs a warning when an attempt has no or empty intent, then adds that
value to `intents_observed` anyway. The set is iterated straight into
`intentservice.get_detectors()`, which indexes `intent_specifier[0]`, so the run fails on
the value it just warned about.

### Reproduction
With the intent service loaded:

```
get_detectors(None)         -> TypeError: 'NoneType' object is not subscriptable
get_detectors('')           -> IndexError: string index out of range
get_detectors('T009ignore') -> returns cleanly
```

### What this changes
Skips falsy intents after warning, rather than registering them.

A mixed result set needed a second part: with only the skip, a run containing one valid
intent and one falsy intent still reached the later `intent_to_detector[a.intent]` lookup
and raised `KeyError`. That lookup now tolerates a missing key.

### Testing
Adds regression coverage for `None`, `""`, and a mixed valid/falsy result set. All three
fail on `main` and pass with this change; the existing harness tests continue to pass.
