### PR TITLE
fix: correct the lite-config hint guard and its masked AttributeError

### DIFF
--- a/garak/command.py
+++ b/garak/command.py
@@ -49,7 +49,7 @@ def start_run():
 
     logging.info("run started at %s", _config.transient.starttime_iso)
     # print("ASSIGN UUID", args)
-    if _config.system.lite and "probes" not in _config.transient.cli_args and _config.transient.cli_args.list_probes is None and not _config.transient.cli_args.list_detectors and not _config.transient.cli_args.list_generators and not _config.transient.cli_args.list_buffs and not _config.transient.cli_args.list_config and not _config.transient.cli_args.plugin_info and not _config.run.interactive:  # type: ignore
+    if _config.system.lite and "probes" not in _config.transient.cli_args and not _config.transient.cli_args.list_probes and not _config.transient.cli_args.list_detectors and not _config.transient.cli_args.list_generators and not _config.transient.cli_args.list_buffs and not _config.transient.cli_args.list_config and not _config.transient.cli_args.plugin_info and not getattr(_config.run, "interactive", False):  # type: ignore
         hint(
             "The current/default config is optimised for speed rather than thoroughness. Try e.g. --config full for a stronger test, or specify some probes.",
             logging=logging,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -243,3 +243,65 @@ def test_spec_whitespace_rejected(capsys):
     with pytest.raises(SystemExit):
         cli.main(["--spec", "probes.test.Blank, probes.test.Test", "--list_config"])
     assert "invalid --spec" in capsys.readouterr().out, "spaced --spec must be rejected"
+
+
+def _configure_lite_start_run(tmp_path, monkeypatch, *, list_probes):
+    _config.load_base_config()
+    monkeypatch.setattr(_config.system, "lite", True)
+    monkeypatch.setattr(_config.run, "interactive", False, raising=False)
+    monkeypatch.setattr(_config.reporting, "report_dir", str(tmp_path))
+    monkeypatch.setattr(_config.reporting, "report_prefix", None)
+    monkeypatch.setattr(_config.transient, "data_dir", tmp_path)
+    monkeypatch.setattr(
+        _config.transient,
+        "starttime_iso",
+        "2026-08-04T00:00:00",
+    )
+    monkeypatch.setattr(
+        _config.transient,
+        "cli_args",
+        argparse.Namespace(
+            list_probes=list_probes,
+            list_detectors=False,
+            list_generators=False,
+            list_buffs=False,
+            list_config=False,
+            plugin_info=False,
+        ),
+        raising=False,
+    )
+
+
+def _close_reportfile():
+    reportfile = getattr(_config.transient, "reportfile", None)
+    if reportfile is not None and not reportfile.closed:
+        reportfile.close()
+
+
+def test_start_run_hints_for_default_lite_config(tmp_path, monkeypatch, mocker):
+    from garak import command
+
+    _configure_lite_start_run(tmp_path, monkeypatch, list_probes=False)
+    hint = mocker.patch("garak.command.hint")
+
+    try:
+        command.start_run()
+    finally:
+        _close_reportfile()
+
+    hint.assert_called_once()
+    assert "optimised for speed" in hint.call_args.args[0]
+
+
+def test_start_run_does_not_hint_when_listing_probes(tmp_path, monkeypatch, mocker):
+    from garak import command
+
+    _configure_lite_start_run(tmp_path, monkeypatch, list_probes=True)
+    hint = mocker.patch("garak.command.hint")
+
+    try:
+        command.start_run()
+    finally:
+        _close_reportfile()
+
+    hint.assert_not_called()


### PR DESCRIPTION
### Summary
The "current/default config is optimised for speed" hint in `start_run()` can never fire,
and the guard that prevents it was also masking an `AttributeError`.

**1. The clause is always false.** `--list_probes` is declared `action="store_true"`
(`cli.py`), and `cli.py` forces command vars into `cli_args` "even if false", so
`cli_args.list_probes` is always a bool and never `None`:

```
no flag : False   -> is None? False
w/ flag : True
```

`... .list_probes is None` is therefore always false, which makes the whole `and` chain
false. Every sibling flag in the same condition is tested with `not ...`; this one is the
odd one out.

**2. Fixing that alone surfaces a second defect.** The chain then reaches its final term,
`not _config.run.interactive` - and that attribute does not exist on a normal run.
`interactive` is declared in `_config.run_params`, but `garak.core.yaml` gives it no
default (unlike `deprefix`, `generations`, ...), and `cli.py` only copies it into
`_config.run` when `--interactive` is passed:

```
start_run() with lite config and no probes
  -> AttributeError: 'GarakSubConfig' object has no attribute 'interactive'
```

That is exactly the path the hint exists for, so the short-circuit was hiding it.

### What this changes
Makes the `list_probes` clause consistent with its siblings, and reads `interactive`
defensively so the restored code path does not raise.

Worth noting for maintainers: the underlying gap is that `run.interactive` has no default
in `garak.core.yaml`. Adding one there would be an alternative fix; this change stays
local to the guard.

### Testing
Adds positive and negative cases around `garak.command.start_run()`. The positive case
fails on `main` and passes with this change.
