### PR TITLE
Return no attempts when a probe's prompt set is empty

### DIFF
--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -393,6 +393,12 @@ class Probe(Configurable):
         prompts = copy.deepcopy(
             self.prompts
         )  # make a copy to avoid mutating source list
+        if not prompts:
+            # An empty prompt set (including one emptied by translation) would
+            # otherwise raise IndexError at prompts[0] below; there is simply
+            # nothing to attempt, so return no attempts.
+            logging.warning("probe %s has an empty prompt set", self.probename)
+            return []
         preparation_bar = tqdm.tqdm(
             total=len(prompts),
             leave=False,

--- a/tests/probes/test_probes.py
+++ b/tests/probes/test_probes.py
@@ -362,3 +362,13 @@ def test_encoding_probe_attempt_carries_payload_intent(loaded_intent_service):
     ), "attempt intent must reflect the payload-specific intent set in _attempt_prestore_hook"
 
 
+
+
+def test_probe_empty_prompt_set_returns_no_attempts():
+    # A probe whose prompt set is empty (for instance one emptied by
+    # translation) must return no attempts rather than raising IndexError at
+    # prompts[0] in Probe.probe(). See issue #2026.
+    p = _plugins.load_plugin("probes.test.Test")
+    p.prompts = []
+    g = _plugins.load_plugin("generators.test.Blank")
+    assert list(p.probe(g)) == []


### PR DESCRIPTION
Fixes #2026

### Problem

`Probe.probe()` in `garak/probes/base.py` uses `len(prompts)` for the preparation progress bar and then indexes `prompts[0]` to decide whether prompts are plain strings:

```python
preparation_bar = tqdm.tqdm(total=len(prompts), ...)   # fine with 0
if isinstance(prompts[0], str):                          # IndexError when empty
```

An empty prompt set (including one emptied by translation under some langproviders) reaches the subscript and raises `IndexError: list index out of range` deep in the run, rather than simply producing zero attempts. This is observed on `main` via `tests/probes/test_probes.py::test_probe_prompt_translation[...SystemPromptExtraction]`.

### Fix

Return an empty attempt list (with a warning naming the probe) when the prompt set is empty, before the `prompts[0]` check.

### Test

Added `test_probe_empty_prompt_set_returns_no_attempts`, which loads `probes.test.Test`, empties its prompts, and asserts `probe()` returns no attempts. It fails with `IndexError` before this change and passes after.