### PR TITLE
fix(attempt): default reverse_translation_outputs to a list

### DIFF
--- a/garak/attempt.py
+++ b/garak/attempt.py
@@ -196,7 +196,7 @@ class Attempt:
     :param conversations: conversation turn histories
     :type conversations: List(Conversation)
     :param reverse_translation_outputs: The reverse translation of output based on the original language of the probe
-    :type reverse_translation_outputs: List(str)
+    :type reverse_translation_outputs: List[Optional[Message]]
     :param intent: None, or the primary intent type in this attempt
     :type notes: str|None
 
@@ -261,7 +261,7 @@ class Attempt:
         self.goal = goal
         self.seq = seq
         self.reverse_translation_outputs = (
-            {} if reverse_translation_outputs is None else reverse_translation_outputs
+            [] if reverse_translation_outputs is None else reverse_translation_outputs
         )
         self.intent = intent
 

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -639,6 +639,51 @@ def test_outputs_for():
     assert all_output_a.outputs_for("en") == reverse_outputs
 
 
+def test_reverse_translation_outputs_defaults_to_list():
+    """The default for reverse_translation_outputs must be a list, not a dict.
+
+    Regression for the type drift between the docstring (``List[str]``) and the
+    former ``{}`` default: list operations (``append``, indexing, ``len``) fail
+    on a dict, and ``outputs_for`` silently returned no outputs for translated
+    runs when the field was never populated.
+    """
+    attempt = garak.attempt.Attempt()
+    assert attempt.reverse_translation_outputs == []
+    assert isinstance(attempt.reverse_translation_outputs, list)
+
+
+def test_outputs_for_unset_reverse_translation_returns_empty_list():
+    attempt = garak.attempt.Attempt()
+    attempt.prompt = garak.attempt.Message("hello", lang="en")
+    attempt.outputs = [garak.attempt.Message("bonjour", lang="fr")]
+
+    assert attempt.outputs_for("en") == [garak.attempt.Message("bonjour", lang="fr")]
+    assert attempt.outputs_for("de") == []
+    assert isinstance(attempt.outputs_for("de"), list)
+
+
+def test_reverse_translation_outputs_as_dict_round_trip():
+    attempt = garak.attempt.Attempt()
+    attempt.prompt = garak.attempt.Message("hello", lang="en")
+    attempt.outputs = [garak.attempt.Message("bonjour", lang="fr")]
+    attempt.reverse_translation_outputs = [
+        garak.attempt.Message("this is a test", lang="en"),
+        None,
+    ]
+
+    data = attempt.as_dict()
+    entries = data["reverse_translation_outputs"]
+    assert len(entries) == 2
+    assert entries[0]["text"] == "this is a test"
+    assert entries[0]["lang"] == "en"
+    assert entries[1] is None
+
+    # Reconstructing the serialized Message must preserve its fields.
+    restored = garak.attempt.Message(**entries[0])
+    assert restored.text == "this is a test"
+    assert restored.lang == "en"
+
+
 def test_attempt_prompt_no_str():
     with pytest.raises(TypeError):
         attempt = garak.attempt.Attempt(prompt="nine two one eight black")


### PR DESCRIPTION
## Root Cause

`Attempt.__init__` defaulted `reverse_translation_outputs` to `{}` while the docstring describes a list and every production caller assigns a list of `Optional[Message]` (`_postprocess_attempt` in `garak/probes/base.py`, `probes/atkgen.py`). For translated runs that never populate the field, `outputs_for(lang)` therefore returned an empty dict: detectors that iterate the result (e.g. `garak/detectors/base.py`) saw string keys instead of messages and could raise `AttributeError` on `output.text`, and `as_dict()` likewise iterated dict keys when serializing the attempt.

## Fix

Default `reverse_translation_outputs` to `[]`, matching the documented type and all existing callers, and correct the docstring to `List[Optional[Message]]` (the list legitimately contains `None` for missing generator outputs). The empty list preserves the falsy behavior of the old default, so no caller relying on truthiness changes behavior.

## Test

- `test_reverse_translation_outputs_defaults_to_list`: the default is a list, not a dict.
- `test_outputs_for_unset_reverse_translation_returns_empty_list`: `outputs_for()` returns the original outputs for the matching language and `[]` for a translated language when the field was never populated.
- `test_reverse_translation_outputs_as_dict_round_trip`: `Message`/`None` entries serialize via `as_dict()` and can be reconstructed field-for-field.
- Verified locally: `pytest tests/test_attempt.py` → 26 passed; `tests/langservice/probes/test_probes_base.py` postprocess tests → 5 passed. (Full `tests/langservice/detectors` suites require Hugging Face model downloads and were not run to completion locally.)

## Diff scope

2 files, +47/-2: `garak/attempt.py`, `tests/test_attempt.py`.

## AI Disclosure

AI-assisted implementation and regression tests; the type-semantics decision (all callers already assign lists; empty list preserves falsy behavior) was human-reviewed before submission.
