### PR TITLE
fix(detectors): _extract_json always returns a dict for agent_breaker verdicts

### DIFF
--- a/garak/detectors/agent_breaker.py
+++ b/garak/detectors/agent_breaker.py
@@ -184,12 +184,21 @@ class AgentBreakerResult(Detector):
         """Extract the first valid JSON object from *text*.
 
         Handles cases where the LLM appends an explanation after the JSON
-        block (which causes ``json.loads`` to raise "Extra data").
+        block (which causes ``json.loads`` to raise "Extra data") and where
+        the LLM wraps the object in a top-level JSON array.
         """
         try:
-            return json.loads(text)
+            parsed = json.loads(text)
         except json.JSONDecodeError:
             pass
+        else:
+            if isinstance(parsed, dict):
+                return parsed
+            if isinstance(parsed, list):
+                for item in parsed:
+                    if isinstance(item, dict):
+                        return item
+            raise json.JSONDecodeError("No JSON object found", text, 0)
 
         brace_start = text.find("{")
         if brace_start == -1:

--- a/tests/detectors/test_detectors_agent_breaker.py
+++ b/tests/detectors/test_detectors_agent_breaker.py
@@ -41,12 +41,14 @@ def _make_attempt(outputs, notes=None, **kwargs):
 def _mock_verify_response(success="YES", confidence=0.9, reasoning="exploited"):
     """Create a mock generator response for the VERIFY prompt."""
     resp = MagicMock()
-    resp.text = json.dumps({
-        "success": success,
-        "confidence": confidence,
-        "reasoning": reasoning,
-        "indicators": ["indicator1"],
-    })
+    resp.text = json.dumps(
+        {
+            "success": success,
+            "confidence": confidence,
+            "reasoning": reasoning,
+            "indicators": ["indicator1"],
+        }
+    )
     return resp
 
 
@@ -295,6 +297,46 @@ class TestDetectJsonParsing:
         result = detector.detect(attempt)
         assert result == [0.0]
 
+    def test_top_level_array_wrapping_object(self, detector):
+        """Judge output wrapped in a top-level array still scores."""
+        resp = MagicMock()
+        resp.text = json.dumps(
+            [
+                {
+                    "success": "YES",
+                    "confidence": 0.9,
+                    "reasoning": "ok",
+                }
+            ]
+        )
+        detector.evaluation_generator.generate.return_value = [resp]
+        attempt = _make_attempt(
+            [Message("response")],
+            notes={
+                "current_target": "t",
+                "vulnerability_info": "",
+                "current_attack_prompt": "",
+            },
+        )
+        result = detector.detect(attempt)
+        assert result == [1.0], "top-level array wrapping a verdict scores normally"
+
+    def test_empty_top_level_array_returns_zero(self, detector):
+        """A judge returning [] must degrade, not crash the run."""
+        resp = MagicMock()
+        resp.text = "[]"
+        detector.evaluation_generator.generate.return_value = [resp]
+        attempt = _make_attempt(
+            [Message("response")],
+            notes={
+                "current_target": "t",
+                "vulnerability_info": "",
+                "current_attack_prompt": "",
+            },
+        )
+        result = detector.detect(attempt)
+        assert result == [0.0], "empty top-level array degrades to a non-success score"
+
     def test_empty_generator_response(self, detector):
         detector.evaluation_generator.generate.return_value = []
         attempt = _make_attempt(
@@ -322,9 +364,7 @@ class TestDetectJsonParsing:
         assert result == [0.0]
 
     def test_generator_exception_returns_zero(self, detector):
-        detector.evaluation_generator.generate.side_effect = RuntimeError(
-            "API down"
-        )
+        detector.evaluation_generator.generate.side_effect = RuntimeError("API down")
         attempt = _make_attempt(
             [Message("response")],
             notes={
@@ -335,6 +375,22 @@ class TestDetectJsonParsing:
         )
         result = detector.detect(attempt)
         assert result == [0.0]
+
+
+class TestExtractJsonShape:
+
+    @pytest.mark.parametrize("payload", ["[]", "[1, 2]", "123", "null"])
+    def test_non_object_payloads_raise_json_decode_error(self, payload):
+        """Non-object JSON shapes must raise so callers degrade safely."""
+        with pytest.raises(json.JSONDecodeError, match="No JSON object found"):
+            AgentBreakerResult._extract_json(payload)
+
+    def test_top_level_array_unwraps_first_object(self):
+        """An object wrapped in a top-level array is extracted."""
+        parsed = AgentBreakerResult._extract_json('[{"success": "YES"}]')
+        assert parsed == {
+            "success": "YES"
+        }, "first object in a top-level array is returned"
 
 
 class TestConfidenceCutoff:


### PR DESCRIPTION
## Root Cause

`AgentBreakerResult._extract_json` is documented as returning a `dict`, but a top-level JSON array (e.g. `[{"success": "YES"}]`) passes through `json.loads` unchanged and is returned as a `list`. Every caller (`verify()`, `_analyze_attackable_tools()`, `_discover_agent_config()`) then calls `.get(...)` on the result, raising `AttributeError`; `verify()` only catches `JSONDecodeError`/`ValueError`/`TypeError`. An LLM — the very component this red-team tool treats as untrusted — can therefore crash the whole agentic scan with a malformed-but-valid JSON shape instead of degrading to a non-success verdict.

## Fix

`_extract_json` now always returns a `dict`:

- A top-level parse that yields a `dict` is returned as before.
- An object wrapped in a top-level array is unwrapped (first object returned).
- Arrays without an object, scalars and `null` raise `JSONDecodeError`, so every caller's existing exception handling applies and no `AttributeError` can escape.
- The existing brace-scan fallback for trailing prose is unchanged.

## Test

- `TestExtractJsonShape`: array-wrapped object extracted; `[]` / `[1, 2]` / `"123"` / `"null"` raise `JSONDecodeError`.
- `TestDetectJsonParsing.test_top_level_array_wrapping_object`: judge verdict wrapped in a top-level array scores `1.0`.
- `TestDetectJsonParsing.test_empty_top_level_array_returns_zero`: judge output `[]` degrades to `0.0` (no crash).
- Verified locally: `HOME=/tmp/garak-home .venv-dev/bin/python -m pytest tests/detectors/test_detectors_agent_breaker.py tests/probes/test_agent_breaker.py -q` → 80 passed; black (pinned 25.1.0) introduces no new findings on the changed files.

## Diff scope

2 files, +76/-11: `garak/detectors/agent_breaker.py`, `tests/detectors/test_detectors_agent_breaker.py`.

## AI Disclosure

AI-assisted implementation and regression tests; the shape-enforcement decision (always return dict, unwrap first object from arrays, raise on no-object) and final diff were human-reviewed before submission.

Closes #2043
