### PR TITLE
fix(probes): tolerate malformed agent_breaker analysis shapes

### DIFF
--- a/garak/probes/agent_breaker.py
+++ b/garak/probes/agent_breaker.py
@@ -327,11 +327,29 @@ class AgentBreaker(garak.probes.IterativeProbe):
         """
         tool_analyses = self.agent_analysis.get("tool_analyses", {})
         priority_targets = self.agent_analysis.get("priority_targets", [])
+        if not isinstance(tool_analyses, dict):
+            logging.warning(
+                f"{self.__class__.__name__} # tool_analyses is not a dict; "
+                "ignoring analyses"
+            )
+            tool_analyses = {}
+        if not isinstance(priority_targets, list):
+            logging.warning(
+                f"{self.__class__.__name__} # priority_targets is not a list; "
+                "ignoring priority ordering"
+            )
+            priority_targets = []
 
         configs: List[Tuple[str, dict]] = []
         seen: set = set()
 
         for entry in priority_targets:
+            if not isinstance(entry, str):
+                logging.warning(
+                    f"{self.__class__.__name__} # Skipping malformed priority "
+                    f"target entry: {entry!r}"
+                )
+                continue
             target_name = entry.split(" - ")[0].strip()
             for tool_name, analysis in tool_analyses.items():
                 if (
@@ -426,7 +444,20 @@ class AgentBreaker(garak.probes.IterativeProbe):
     def _format_tools_for_analysis(self) -> str:
         """Format the tools from YAML config for analysis by red team model"""
         tools_str = ""
-        for tool in self.agent_config.get("tools", []):
+        tools = self.agent_config.get("tools", [])
+        if not isinstance(tools, list):
+            logging.warning(
+                f"{self.__class__.__name__} # agent config 'tools' is not a list; "
+                "ignoring for analysis"
+            )
+            return tools_str
+        for tool in tools:
+            if not isinstance(tool, dict):
+                logging.warning(
+                    f"{self.__class__.__name__} # Skipping malformed tool entry "
+                    f"in agent config: {tool!r}"
+                )
+                continue
             tools_str += f"\n### Tool: {tool.get('name', 'unnamed')}\n"
             tools_str += f"Description: {tool.get('description', 'No description')}\n"
 

--- a/tests/probes/test_agent_breaker.py
+++ b/tests/probes/test_agent_breaker.py
@@ -375,6 +375,47 @@ class TestBuildToolConfigs:
         assert set(names) == {"tool_a", "tool_b"}
         assert len(names) == 2
 
+    def test_non_dict_tool_analyses_returns_empty(self):
+        """A list instead of a dict must degrade to no configs, not crash."""
+        probe = _make_probe()
+        probe.agent_analysis = {
+            "tool_analyses": [{"name": "tool_a"}],
+            "priority_targets": [],
+        }
+        assert probe._build_tool_configs() == []
+
+    def test_non_string_priority_targets_skipped(self):
+        """Malformed priority entries are skipped; valid ones still resolve."""
+        probe = _make_probe()
+        probe.agent_analysis = {
+            "tool_analyses": {
+                "tool_a": {"attack_prompts": ["a"]},
+                "tool_b": {"attack_prompts": ["b"]},
+            },
+            "priority_targets": [None, "tool_b - dangerous"],
+        }
+        configs = probe._build_tool_configs()
+        names = [name for name, _ in configs]
+        assert names == ["tool_b", "tool_a"]
+
+
+class TestFormatToolsForAnalysis:
+    """Tool formatting must tolerate malformed agent config entries."""
+
+    def test_non_dict_tool_entries_skipped(self):
+        probe = _make_probe()
+        probe.agent_config = {
+            "tools": ["rm -rf /", {"name": "ok", "description": "fine"}],
+        }
+        rendered = probe._format_tools_for_analysis()
+        assert "### Tool: ok" in rendered
+        assert "rm -rf /" not in rendered
+
+    def test_non_list_tools_returns_empty(self):
+        probe = _make_probe()
+        probe.agent_config = {"tools": "not-a-list"}
+        assert probe._format_tools_for_analysis() == ""
+
 
 # ===========================================================================
 # _attack_single_tool


### PR DESCRIPTION
## Root Cause

The `agent_breaker` probe's red-team model output is untrusted, but two consumers assumed exact internal shapes and crashed the whole probe run with `AttributeError` on valid JSON with unexpected types:

- `_build_tool_configs()`: `tool_analyses` returned as a list → `.items()` raises; a non-string `priority_targets` entry → `.split()` raises. This runs outside the per-tool try/except in `_create_init_attempts()`, so the crash kills the entire probe.
- `_format_tools_for_analysis()`: a non-dict `tools` entry → `.get()` raises; a non-list `tools` value is iterated directly.

## Fix

Validate/coerce shapes at the two consumers:

- `tool_analyses` that is not a dict and `priority_targets` that is not a list degrade to empty with a `logging.warning` (priority ordering is skipped, not fatal).
- Non-string `priority_targets` entries are skipped; valid string entries still resolve normally.
- Non-dict `tools` entries are skipped during formatting, and a non-list `tools` config is ignored for analysis with a warning.

## Test

- `TestBuildToolConfigs.test_non_dict_tool_analyses_returns_empty` — list analyses yield no configs, no crash.
- `TestBuildToolConfigs.test_non_string_priority_targets_skipped` — `None` entry skipped, valid entry still resolved.
- `TestFormatToolsForAnalysis.test_non_dict_tool_entries_skipped` — string tool entries omitted, dict entries rendered.
- `TestFormatToolsForAnalysis.test_non_list_tools_returns_empty` — non-list config returns empty, no crash.
- Verified locally: `pytest tests/probes/test_agent_breaker.py` → 53 passed; black (pinned 25.1.0) clean on changed files.

## Diff scope

2 files, +73/-1: `garak/probes/agent_breaker.py`, `tests/probes/test_agent_breaker.py`.

## AI Disclosure

AI-assisted implementation and regression tests; the shape-validation decision (degrade with warning, never crash, keep valid entries working) and final diff were human-reviewed before submission.

Closes #2045
