### PR TITLE
fix(analyze): rebuild confidence intervals from attack hits

### DIFF
--- a/garak/analyze/ci_calculator.py
+++ b/garak/analyze/ci_calculator.py
@@ -60,8 +60,8 @@ def _extract_reporting_config_from_setup(report_path: str) -> dict:
 
 
 def _reconstruct_binary_from_aggregates(passed: int, failed: int) -> List[int]:
-    # Reconstruct binary pass/fail data from aggregates; order irrelevant for bootstrap resampling
-    return [1] * passed + [0] * failed
+    # Match evaluator scoring: a failure is a successful attack (hit)
+    return [1] * failed + [0] * passed
 
 
 def calculate_ci_from_report(

--- a/tests/analyze/test_ci_calculator.py
+++ b/tests/analyze/test_ci_calculator.py
@@ -39,15 +39,15 @@ def temp_report(request):
 
 
 def test_reconstruct_binary_from_aggregates():
-    """Verify binary reconstruction from passed/failed counts"""
+    """Verify binary reconstruction scores failures as attack hits"""
     binary_results = garak.analyze.ci_calculator._reconstruct_binary_from_aggregates(
         passed=3, failed=2
     )
 
     assert len(binary_results) == 5
-    assert binary_results.count(1) == 3
-    assert binary_results.count(0) == 2
-    assert binary_results == [1, 1, 1, 0, 0]
+    assert binary_results.count(1) == 2
+    assert binary_results.count(0) == 3
+    assert binary_results == [1, 1, 0, 0, 0]
 
 
 def test_reconstruct_binary_from_aggregates_all_passed():
@@ -57,7 +57,7 @@ def test_reconstruct_binary_from_aggregates_all_passed():
     )
 
     assert len(binary_results) == 5
-    assert all(r == 1 for r in binary_results)
+    assert all(r == 0 for r in binary_results)
 
 
 def test_reconstruct_binary_from_aggregates_all_failed():
@@ -67,7 +67,7 @@ def test_reconstruct_binary_from_aggregates_all_failed():
     )
 
     assert len(binary_results) == 5
-    assert all(r == 0 for r in binary_results)
+    assert all(r == 1 for r in binary_results)
 
 
 def test_calculate_ci_from_report_file_not_found():


### PR DESCRIPTION
Fixes #2047.

`rebuild_cis` reconstructed a digest's pass count as attack hits, while the run-time evaluator correctly treats detector failures as hits. This swaps the reconstructed binary outcomes so rebuilt intervals use the same attack-success orientation as intervals generated during a run, and updates the focused regression tests for mixed, all-pass, and all-fail aggregates.

This does not duplicate an existing pull request: I checked the issue timeline, open pull requests mentioning #2047, and pull requests matching `rebuild_cis` / pass-rate keywords before claiming the issue; none addressed it.

AI assistance was used to help inspect the code, implement the focused change, and run verification. I reviewed every changed line.

## Verification

- [x] Supporting configuration — N/A; no configuration changed
- [x] `garak -t <target_type> -n <model_name>` — N/A; the change is isolated to offline report analysis
- [x] Run the relevant tests: `.venv/bin/python -m pytest tests/analyze/ -q` — 158 passed
- [x] Check formatting for changed ranges: `.venv/bin/black --check --line-ranges 62-65 garak/analyze/ci_calculator.py` and `.venv/bin/black --check --line-ranges 40-70 tests/analyze/test_ci_calculator.py` — passed
- [x] **Verify** rebuilt inputs count failures as attack hits — covered by mixed and all-failed regression cases
- [x] **Verify** passes are not counted as attack hits — covered by the all-passed regression case
- [x] **Document** the thing and how it works — the reconstruction comment now states the evaluator-compatible scoring direction; no user-facing documentation is needed

No specific hardware or complex external software is required.
