### PR TITLE
fix(detectors): default a detector's name to its class name string

### DIFF
--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -60,7 +60,7 @@ class Detector(Configurable):
     def __init__(self, config_root=_config):
         self._load_config(config_root)
         if "name" not in dir(self):
-            self.name = __class__  # short name
+            self.name = self.__class__.__name__  # short name
         self.detectorname = str(self.__class__).split("'")[1]
         self._set_description()
         if hasattr(_config.system, "verbose") and _config.system.verbose > 0:

--- a/tests/detectors/test_detectors.py
+++ b/tests/detectors/test_detectors.py
@@ -79,6 +79,22 @@ def test_detector_structure(classname):
     ), f"_supported_params must contain all DEFAULT_PARAMS; {unsupported_defaults} missing"
 
 
+def test_detector_default_name_is_class_name_string():
+    """A detector that sets no name of its own gets its class name as a string,
+    not the base Detector class object (which reaches user-facing messages)."""
+
+    class _Nameless(Detector):
+        """a detector that does not set its own name"""
+
+    base = Detector()
+    sub = _Nameless()
+
+    assert isinstance(base.name, str), "base detector name must be a string"
+    assert base.name == "Detector", "base detector name should be its class name"
+    assert isinstance(sub.name, str), "subclass detector name must be a string"
+    assert sub.name == "_Nameless", "subclass should take its own class name"
+
+
 @pytest.mark.parametrize("classname", DETECTORS)
 def test_detector_detect(classname, monkeypatch):
     monkeypatch.setattr("datasets.load_dataset", Mock(return_value=_MockDataset()))


### PR DESCRIPTION
### What

`Detector.__init__` sets `self.name = __class__` when a detector defines no name of its own. The implicit `__class__` cell resolves to the base `Detector` class rather than `type(self)`, so every such detector ends up with the `Detector` class object instead of a string.

This reaches user-facing output. `detectors/judge.py` renders `f"{self.name} failed to load generator for {self.detector_model_type}"`, and `ModelAsJudge` sets no name, so a judge-model misconfiguration prints:

```
<class 'garak.detectors.base.Detector'> failed to load generator for ...
```

### Fix

Default the name to `self.__class__.__name__`, i.e. the detector's own short name as a string. Subclasses that already set their own `name` are unaffected.

### Not a duplicate

I searched the open PRs against #2053 and found none addressing it.

### Testing

```
python -m pytest tests/detectors/test_detectors.py::test_detector_default_name_is_class_name_string
```

passes. The added regression test checks that the base `Detector` and a nameless subclass each return their own class name as a string.

Fixes #2053

_AI assistance was used on this change; I reviewed every line and ran the tests above myself._
