### PR TITLE
fix(evaluators): record a probe_summary for zero-attempt probes

### DIFF
--- a/garak/evaluators/base.py
+++ b/garak/evaluators/base.py
@@ -221,17 +221,42 @@ class Evaluator:
 
         return eval_record
 
-    def evaluate(self, attempts: Iterable[garak.attempt.Attempt]) -> None:
+    def evaluate(
+        self, attempts: Iterable[garak.attempt.Attempt], probename: str = None
+    ) -> None:
         """evaluate feedback from detectors
 
         expects a list of attempts that correspond to one probe
         outputs results once per detector
+
+        :param probename: dotted probe name, used to record a zero-attempt probe
+            in the report when ``attempts`` is empty
         """
 
         if isinstance(attempts, list) and len(attempts) == 0:
-            logging.error(
-                "evaluators.base.Evaluator.evaluate called with list of 0 attempts, expected len 1+ or iterable"
+            logging.warning(
+                "evaluators.base.Evaluator.evaluate called with 0 attempts for probe %s",
+                probename,
             )
+            if probename is not None:
+                # a probe can legitimately yield no attempts (e.g. a prompt set
+                # emptied by translation); still write a zero-count probe_summary
+                # so the report shows the probe ran rather than leaving "did not
+                # run" indistinguishable from "was never configured"
+                empty_summary = {
+                    "entry_type": "probe_summary",
+                    "probe": probename,
+                    "inference_counts": {"total_evaluated": 0, "nones": 0},
+                    "detection_counts": {
+                        "detectors": [],
+                        "passed": 0,
+                        "fails": 0,
+                        "nones": 0,
+                    },
+                }
+                _config.transient.reportfile.write(
+                    json.dumps(empty_summary, ensure_ascii=False) + "\n"
+                )
             return
 
         attempts = list(

--- a/garak/harnesses/base.py
+++ b/garak/harnesses/base.py
@@ -283,7 +283,10 @@ class Harness(Configurable):
             if len(attempt_results) == 0:
                 logging.warning("zero attempt results: probe %s" % probe.probename)
 
-            evaluator.evaluate(attempt_results)
+            evaluator.evaluate(
+                attempt_results,
+                probename=".".join(probe.probename.split(".")[-2:]),
+            )
 
         self._end_run_hook()
 

--- a/tests/evaluators/test_base.py
+++ b/tests/evaluators/test_base.py
@@ -108,6 +108,43 @@ def _eval_rows(report_path: Path) -> list[dict]:
     return rows
 
 
+def _probe_summaries(report_path: Path) -> list[dict]:
+    rows = []
+    for line in report_path.read_text(encoding="utf-8").splitlines():
+        if not line:
+            continue
+        row = json.loads(line)
+        if row.get("entry_type") == "probe_summary":
+            rows.append(row)
+    return rows
+
+
+def test_zero_attempt_probe_writes_summary(tmp_path):
+    """A probe that produces no attempts must still leave a probe_summary so the
+    report distinguishes "ran but produced nothing" from "never configured"."""
+    reportfile = tmp_path / "report.report.jsonl"
+    with _capture_report(reportfile):
+        evaluator = ThresholdEvaluator()
+        evaluator.evaluate([], probename="test.EmptyProbe")
+
+    summaries = _probe_summaries(reportfile)
+    assert len(summaries) == 1, "a zero-attempt probe should leave one summary row"
+    summary = summaries[0]
+    assert summary["probe"] == "test.EmptyProbe"
+    assert summary["inference_counts"]["total_evaluated"] == 0
+    assert summary["detection_counts"]["detectors"] == []
+
+
+def test_zero_attempt_without_probename_writes_nothing(tmp_path):
+    """Without a probename there is nothing to attribute, so stay silent."""
+    reportfile = tmp_path / "report.report.jsonl"
+    with _capture_report(reportfile):
+        evaluator = ThresholdEvaluator()
+        evaluator.evaluate([])
+
+    assert _probe_summaries(reportfile) == [], "no probename means no summary row"
+
+
 def test_eval_row_includes_intents_breakdown(tmp_path):
     reportfile = tmp_path / "report.report.jsonl"
     with _capture_report(reportfile):


### PR DESCRIPTION
### What

When a probe produces no attempts, `Evaluator.evaluate` returns before writing anything, so nothing about that probe reaches `report.jsonl`: no `probe_summary` row and no attempt rows. A report then reads identically whether a probe ran and produced nothing or was never requested, which hides skipped coverage from anything auditing the run.

### Fix

`evaluate` now accepts an optional `probename` and, when the attempt list is empty, writes a zero-count `probe_summary` for that probe. The harness passes the probe name (in the same short form used elsewhere in the report). The counts are all zero, which the existing report/digest consumers already handle. Callers that pass no `probename` keep the previous silent behaviour.

### Not a duplicate

I searched the open PRs against #2021 and found none addressing it.

### Testing

```
python -m pytest tests/evaluators/test_base.py tests/harnesses/
```

18 passed. Added tests assert a zero-attempt probe with a name leaves exactly one `probe_summary` row, and that omitting the name stays silent.

This issue is labelled `question`, so I am happy to adjust the shape of the emitted record (or move where it is written) if maintainers prefer a different approach.

Fixes #2021

_AI assistance was used on this change; I reviewed every line and ran the tests above myself._
