### PR TITLE
housekeeping - reinforce new issues getting `needs-triage`

### DIFF
--- a/.github/workflows/needs_triage.yml
+++ b/.github/workflows/needs_triage.yml
@@ -1,0 +1,65 @@
+name: Needs triage
+
+# Add needs-triage to issues opened by non-members when the label is missing.
+
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  id-token: none
+  # can update issues
+  issues: write
+  discussions: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+on:
+  issues:
+    types: [opened, reopened]
+
+jobs:
+  ensure-needs-triage:
+    if: github.repository_owner == 'NVIDIA'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Inlined instead of a third-party action for security and performance,
+            // consistent with labels.yml.
+            const MEMBER_ASSOCIATIONS = new Set([ // apply to everyone's issues
+              // 'OWNER', 'MEMBER', 'COLLABORATOR',
+            ]);
+            const TRIAGE_LABEL = 'needs-triage';
+
+            const issue = context.payload.issue;
+            const association = issue.author_association;
+
+            if (MEMBER_ASSOCIATIONS.has(association)) {
+              core.info(
+                `Skipping: opener association is ${association} (project member).`
+              );
+              return;
+            }
+
+            const labels = (issue.labels || []).map((label) =>
+              typeof label === 'string' ? label : label.name
+            );
+            if (labels.includes(TRIAGE_LABEL)) {
+              core.info(`Skipping: issue already has ${TRIAGE_LABEL}.`);
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: [TRIAGE_LABEL],
+            });
+            core.info(`Added ${TRIAGE_LABEL} (opener association: ${association}).`);

--- a/.github/workflows/needs_triage.yml
+++ b/.github/workflows/needs_triage.yml
@@ -33,8 +33,8 @@ jobs:
           script: |
             // Inlined instead of a third-party action for security and performance,
             // consistent with labels.yml.
-            const MEMBER_ASSOCIATIONS = new Set([ // apply to everyone's issues
-              // 'OWNER', 'MEMBER', 'COLLABORATOR',
+            const MEMBER_ASSOCIATIONS = new Set([
+              'OWNER', 'MEMBER', 'COLLABORATOR',
             ]);
             const TRIAGE_LABEL = 'needs-triage';
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,10 @@ It's open source software, used in production environments, with an active and s
 As such, the code needs to be robust, precise, and responsible.
 Due to the nature of the project, there is a lot of potentially harmful or dangerous data associated with the repository.   
 
+## Issue policy
+
+Always add the `needs-triage` label to new issues, or use the git issue templates.
+
 ## Contribution policy
 
 ### Duplicate-work checks


### PR DESCRIPTION
* Add action that tiggers on issue -> opened that ensures any issue not opened by a project member gets the tag added automatically if missing.
* Updates `AGENTS.md` to request `needs-triage` label be present on new issues