### PR TITLE
fix: degrade gracefully on malformed agent_breaker analysis shapes

### DIFF
--- a/garak/probes/agent_breaker.py
+++ b/garak/probes/agent_breaker.py
@@ -327,10 +327,32 @@ class AgentBreaker(garak.probes.IterativeProbe):
         tool_analyses = self.agent_analysis.get("tool_analyses", {})
         priority_targets = self.agent_analysis.get("priority_targets", [])
 
+        if not isinstance(tool_analyses, dict):
+            logging.warning(
+                "%s # ignoring malformed tool_analyses (%s); expected a dict",
+                self.__class__.__name__,
+                type(tool_analyses).__name__,
+            )
+            tool_analyses = {}
+        if not isinstance(priority_targets, list):
+            logging.warning(
+                "%s # ignoring malformed priority_targets (%s); expected a list",
+                self.__class__.__name__,
+                type(priority_targets).__name__,
+            )
+            priority_targets = []
+
         configs: List[Tuple[str, dict]] = []
         seen: set = set()
 
         for entry in priority_targets:
+            if not isinstance(entry, str):
+                logging.warning(
+                    "%s # skipping non-string priority target: %r",
+                    self.__class__.__name__,
+                    entry,
+                )
+                continue
             target_name = entry.split(" - ")[0].strip()
             for tool_name, analysis in tool_analyses.items():
                 if (
@@ -424,8 +446,24 @@ class AgentBreaker(garak.probes.IterativeProbe):
 
     def _format_tools_for_analysis(self) -> str:
         """Format the tools from YAML config for analysis by red team model"""
+        tools = self.agent_config.get("tools", [])
+        if not isinstance(tools, list):
+            logging.warning(
+                "%s # ignoring malformed tools config (%s); expected a list",
+                self.__class__.__name__,
+                type(tools).__name__,
+            )
+            return ""
+
         tools_str = ""
-        for tool in self.agent_config.get("tools", []):
+        for tool in tools:
+            if not isinstance(tool, dict):
+                logging.warning(
+                    "%s # skipping non-dict tool entry: %r",
+                    self.__class__.__name__,
+                    tool,
+                )
+                continue
             tools_str += f"\n### Tool: {tool.get('name', 'unnamed')}\n"
             tools_str += f"Description: {tool.get('description', 'No description')}\n"
 

--- a/tests/probes/test_agent_breaker.py
+++ b/tests/probes/test_agent_breaker.py
@@ -375,6 +375,37 @@ class TestBuildToolConfigs:
         assert set(names) == {"tool_a", "tool_b"}
         assert len(names) == 2
 
+    def test_malformed_tool_analyses_list_ignored(self):
+        probe = _make_probe()
+        probe.agent_analysis = {
+            "tool_analyses": [{"name": "x"}],
+            "priority_targets": [],
+        }
+        assert probe._build_tool_configs() == []
+
+    def test_non_string_priority_targets_skipped(self):
+        probe = _make_probe()
+        probe.agent_analysis = {
+            "tool_analyses": {"tool_a": {"attack_prompts": ["a"]}},
+            "priority_targets": [None, "tool_a - vuln"],
+        }
+        configs = probe._build_tool_configs()
+        assert [name for name, _ in configs] == ["tool_a"]
+
+    def test_malformed_tools_config_ignored(self):
+        probe = _make_probe()
+        probe.agent_config = {"tools": ["rm -rf /"]}
+        assert probe._format_tools_for_analysis() == ""
+
+    def test_non_dict_tool_entry_skipped(self):
+        probe = _make_probe()
+        probe.agent_config = {
+            "tools": ["bad", {"name": "good", "description": "d"}],
+        }
+        out = probe._format_tools_for_analysis()
+        assert "### Tool: good" in out
+        assert "### Tool: bad" not in out
+
 
 # ===========================================================================
 # _attack_single_tool


### PR DESCRIPTION
## Problem

Same untrusted-output class as #2043: the object-level JSON parse is now hardened, but values inside the analysis object are still trusted by shape. Two probe consumers crash the whole run with AttributeError on malformed red-team output:

- `_build_tool_configs`: `tool_analyses` returned as a list, or `priority_targets` containing non-string entries.
- `_format_tools_for_analysis`: `tools` not a list, or containing non-dict entries.

Fixes #2045.

## Fix

Malformed shapes now degrade gracefully with a warning: non-dict `tool_analyses` and non-list `priority_targets` yield no configs, non-string priority entries are skipped, a non-list `tools` config is ignored for analysis, and non-dict tool entries are skipped. Valid entries resolve exactly as before.

## Tests

Added to `tests/probes/test_agent_breaker.py`:

- malformed `tool_analyses` list produces no configs
- non-string `priority_targets` entries are skipped while valid ones match
- non-list `tools` config yields an empty analysis string
- non-dict tool entries are skipped while valid ones render

```
HOME=/tmp/garak-home .venv-dev/bin/python -m pytest tests/probes/test_agent_breaker.py tests/detectors/test_detectors_agent_breaker.py -q
84 passed
```

black 25.1.0 clean on both changed files. AI assistance was used in creating this PR; every changed line has been reviewed by the submitter.
