### PR TITLE
fix(generators): retry transient HTTP errors and report honest failures

### DIFF
--- a/garak/generators/nim.py
+++ b/garak/generators/nim.py
@@ -96,7 +96,9 @@ class NVOpenAIChat(OpenAICompatible):
             logging.critical(msg, exc_info=nfe)
             raise GarakException(f"🛑 {msg}") from nfe
         except Exception as oe:
-            msg = "NIM generation failed. Is the model name spelled correctly?"
+            # Include the underlying error: the previous wording blamed the
+            # model name even for unrelated failures (e.g. HTTP timeouts).
+            msg = f"NIM generation failed. Underlying error: {oe!r}"
             logging.critical(msg, exc_info=oe)
             raise GarakException(f"🛑 {msg}") from oe
 

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -25,6 +25,11 @@ from garak.attempt import Message, Conversation
 import garak.exception
 from garak.generators.base import Generator
 
+# HTTP status codes the OpenAI SDK does not map to a dedicated exception
+# subclass. They surface as the generic APIStatusError and are treated as
+# transient: a single hiccup should retry, not abort the probe run.
+_TRANSIENT_HTTP_STATUS_CODES = (408, 429, 502, 503, 504)
+
 # lists derived from https://platform.openai.com/docs/models
 chat_models = (
     "gpt-5-nano",
@@ -353,6 +358,27 @@ class OpenAICompatible(Generator):
             msg = "Bad request: " + str(repr(prompt))
             logging.exception(e)
             logging.error(msg)
+            return [None]
+        except openai.APIStatusError as e:
+            # Proxies and load balancers can return statuses the SDK does not
+            # map to a dedicated subclass (e.g. 408). Retry the transient ones
+            # through the backoff decorator; skip this generation on the rest
+            # so a single bad response cannot abort the whole probe run.
+            if e.status_code in _TRANSIENT_HTTP_STATUS_CODES:
+                logging.warning(
+                    "Transient HTTP %s from %s, retrying with backoff",
+                    e.status_code,
+                    self.generator_family_name,
+                )
+                raise garak.exception.GeneratorBackoffTrigger(
+                    f"transient HTTP {e.status_code}"
+                ) from e
+            logging.error(
+                "HTTP %s from %s, skipping generation: %s",
+                e.status_code,
+                self.generator_family_name,
+                e,
+            )
             return [None]
         except json.decoder.JSONDecodeError as e:
             logging.exception(e)

--- a/tests/generators/test_nim.py
+++ b/tests/generators/test_nim.py
@@ -110,3 +110,23 @@ def test_nim_vision_prep():
     )
     delattr(v, "max_input_len")  # remove to avoid follow on test impacts
     delattr(v, "embed_data")
+
+
+def test_nim_unexpected_error_message_includes_cause(monkeypatch):
+    """The generic failure message names the underlying error, not the model."""
+    from garak.exception import GarakException
+
+    g = NVOpenAIChat.__new__(NVOpenAIChat)
+    g.vary_seed_each_call = False
+    g.vary_temp_each_call = False
+    g.name = "org/model"
+
+    def raise_runtime_error(self, prompt, generations_this_call=1):
+        raise RuntimeError("upstream blew up")
+
+    monkeypatch.setattr(
+        "garak.generators.openai.OpenAICompatible._call_model",
+        raise_runtime_error,
+    )
+    with pytest.raises(GarakException, match="upstream blew up"):
+        g._call_model(Conversation([Turn(role="user", content=Message("hi"))]))

--- a/tests/generators/test_openai_compatible.py
+++ b/tests/generators/test_openai_compatible.py
@@ -251,3 +251,66 @@ def test_conversation_to_list_image_turn_uses_chat_completions_format():
     assert header == "data:image/gif;base64"
     assert separator == ","
     assert base64.b64decode(payload) == IMAGE_ASSET.read_bytes()
+
+
+def _stubbed_compatible():
+    generator = build_unloaded_compatible()
+    generator.client = None
+    generator.generator = None
+    generator.api_key = "test-key"
+    generator.suppressed_params = set()
+    generator.supports_multiple_generations = False
+    generator.retry_json = True
+    generator.extra_params = {}
+    generator.key_env_var = "OPENAI_API_KEY"
+    return generator
+
+
+def test_transient_apistatuserror_retries_and_succeeds(openai_compat_mocks):
+    """A transient 408 retries through the backoff decorator instead of aborting.
+
+    The OpenAI SDK itself retries idempotent requests (default max_retries=2),
+    so the first three attempts return 408 to exhaust the SDK-level retries and
+    exercise garak's backoff path.
+    """
+    generator = _stubbed_compatible()
+    mock_url = generator.uri
+    calls = []
+
+    def route(request):
+        calls.append(request)
+        if len(calls) <= 3:
+            return httpx.Response(
+                408, json={"error": {"message": "request timeout"}}, request=request
+            )
+        return httpx.Response(200, json=openai_compat_mocks["chat"]["json"], request=request)
+
+    with respx.mock(base_url=mock_url, assert_all_called=False) as respx_mock:
+        respx_mock.post("chat/completions").mock(side_effect=route)
+        result = generator._call_model(
+            Conversation([Turn(role="user", content=Message("this is a test"))])
+        )
+
+    assert len(calls) == 4, "a transient 408 should retry through garak's backoff"
+    assert isinstance(result, list) and len(result) == 1
+    assert isinstance(result[0], Message), "retried call should return a Message"
+
+
+def test_non_transient_apistatuserror_skips_generation(openai_compat_mocks):
+    """A non-transient unmapped status skips the generation without retrying."""
+    generator = _stubbed_compatible()
+    mock_url = generator.uri
+    calls = []
+
+    def route(request):
+        calls.append(request)
+        return httpx.Response(418, json={"error": {"message": "teapot"}}, request=request)
+
+    with respx.mock(base_url=mock_url, assert_all_called=False) as respx_mock:
+        respx_mock.post("chat/completions").mock(side_effect=route)
+        result = generator._call_model(
+            Conversation([Turn(role="user", content=Message("this is a test"))])
+        )
+
+    assert len(calls) == 1, "non-transient status must not retry"
+    assert result == [None], "non-transient status should skip the generation"


### PR DESCRIPTION
## Root Cause

When a target endpoint (or a load-balancing proxy in front of it) returns a transient HTTP status that the OpenAI SDK does not map to a dedicated exception subclass — e.g. **408 REQUEST TIMEOUT** — it surfaces as the generic `openai.APIStatusError`. That type is not in the `@backoff.on_exception` retry tuple of `OpenAICompatible._call_model`, so a single transient response propagated out of the generator, aborted the whole probe run (reported in #1967: probe killed at attempt 48/256, zero `eval` entries), and was wrapped by the NIM generator into the misleading "Is the model name spelled correctly?".

## Fix

1. `OpenAICompatible._call_model` now catches `openai.APIStatusError`:
   - transient codes (`408, 429, 502, 503, 504`) re-raise as `GeneratorBackoffTrigger` so the existing fibonacci backoff retries them — a single hiccup no longer aborts the run;
   - other unmapped statuses log the code and return `[None]`, skipping just that generation so the rest of the probe continues.
2. The NIM generator's catch-all now reports the underlying error (`NIM generation failed. Underlying error: ...`) instead of blaming the model name.

## Test

New regression tests (pre-fix FAIL → post-fix PASS verified):

- `test_transient_apistatuserror_retries_and_succeeds` — three 408 responses (exhausting the SDK's own idempotent-retry budget) then a 200; asserts the call is retried through garak's backoff and returns a `Message`. Fails on main (exception propagates), passes with the fix.
- `test_non_transient_apistatuserror_skips_generation` — a 418 returns `[None]` without retrying. Fails on main.
- `test_nim_unexpected_error_message_includes_cause` — a non-OpenAI error from the base call is wrapped in a `GarakException` that names the real cause. Fails on main.

Commands run (venv: `.venv-dev`, `HOME=/tmp/garak-home` for an isolated config dir):

```
python -m pytest tests/generators/test_openai_compatible.py tests/generators/test_nim.py -k "apistatuserror or unexpected_error"
# 3 passed
```

Full files on this branch: 8 failures, all pre-existing on main (multiprocessing/subprocess tests in this environment — same 8 fail on the unmodified baseline; baseline also shows 11 with the 3 new tests failing). `ruff check` on the four touched files reports only pre-existing findings in untouched lines (F841/F541/E712 at old line numbers).

## Why this does not duplicate #1973

PR #1973 (same issue, by Varshith-Kali) is **closed without merging**. It made the retry-code list configurable via `DEFAULT_PARAMS`; this PR follows maintainer jmartin-tech's direction in the issue thread (catch `openai.APIStatusError`, inspect the code, backoff or return `None`) with a module-level constant and no new config surface, and additionally fixes the misleading NIM error message from the same report.

## AI assistance

This PR was developed with AI assistance (DeepSeek) and reviewed line-by-line by a human submitter.
