### PR TITLE
fix(probes): handle empty prompt sets in Probe.probe

### DIFF
--- a/garak/probes/base.py
+++ b/garak/probes/base.py
@@ -393,6 +393,9 @@ class Probe(Configurable):
         prompts = copy.deepcopy(
             self.prompts
         )  # make a copy to avoid mutating source list
+        if not prompts:
+            logging.warning("probe %s has an empty prompt set", self.probename)
+            return []
         preparation_bar = tqdm.tqdm(
             total=len(prompts),
             leave=False,

--- a/tests/probes/test_probes.py
+++ b/tests/probes/test_probes.py
@@ -362,3 +362,8 @@ def test_encoding_probe_attempt_carries_payload_intent(loaded_intent_service):
     ), "attempt intent must reflect the payload-specific intent set in _attempt_prestore_hook"
 
 
+def test_probe_empty_prompt_set_returns_no_attempts():
+    """A probe with an empty (or translation-emptied) prompt set must not IndexError."""
+    p = _plugins.load_plugin("probes.encoding.InjectROT13")
+    p.prompts = []
+    assert p.probe(generator=None) == [], "empty prompt set must yield zero attempts"


### PR DESCRIPTION
## Summary

`Probe.probe()` indexes `prompts[0]` without checking the list is non-empty, so a probe whose prompt set is empty — or emptied by translation (e.g. the translated prompt set coming back empty under a local langprovider) — raises `IndexError` deep in the execution path instead of yielding zero attempts. `IntentProbe.probe()` already guards this case for intent-filtered probes; the base class does not.

**Fix:** return no attempts with a warning when the copied prompt set is empty:

```python
if not prompts:
    logging.warning("probe %s has an empty prompt set", self.probename)
    return []
```

## Why this is not duplicating an existing PR

Checked before opening: no open PR references this issue in its body, and no open PR addresses empty prompt-set handling in the base probe (searched `empty prompt set`, `prompts[0]`, `IndexError`).

## Test

- New regression test `test_probe_empty_prompt_set_returns_no_attempts` in `tests/probes/test_probes.py`: a loaded probe with `prompts = []` returns `[]` from `probe()` instead of raising.
- Pre-fix: the test fails with the previous implementation (IndexError at the `prompts[0]` subscript); post-fix: passes.
- Targeted run: `pytest tests/probes/test_probes.py -k empty_prompt_set` — 1 passed.
- Full `tests/probes/test_probes.py`: 1351 passed / 6 failed. The 6 failures are `test_probe_metadata[...]` cases that time out fetching network metadata; they fail identically on clean `main` (verified in a separate worktree), so they are environment-side and unrelated to this change.
- Changed lines are black/ruff clean; pre-existing lint findings in these files are left untouched.

## AI Disclosure

AI assistance was used (DeepSeek) to draft this change; the submitting human reviewed every line and ran the tests above.
