### PR TITLE
fix(probes): retag AgentBreaker to owasp:llm06 (Excessive Agency)

### DIFF
--- a/garak/probes/agent_breaker.py
+++ b/garak/probes/agent_breaker.py
@@ -136,8 +136,7 @@ class AgentBreaker(garak.probes.IterativeProbe):
     primary_detector = "agent_breaker.AgentBreakerResult"
     tags = [
         "owasp:llm01",  # Prompt Injection
-        "owasp:llm07",  # Insecure Plugin Design
-        "owasp:llm08",  # Excessive Agency
+        "owasp:llm06",  # Excessive Agency (matches doc_uri; OWASP LLM Top 10 2025)
         "quality:Security:AgentSecurity",
         "payload:agentic:exploitation",
     ]

--- a/tests/probes/test_agent_breaker.py
+++ b/tests/probes/test_agent_breaker.py
@@ -1014,3 +1014,16 @@ class TestAttackStateRoundTrip:
         notes = state.to_notes()
         assert notes["verified_results"] == [(True, 0.9), (False, 0.1)]
         assert notes["current_attack_prompt"] == "updated prompt"
+
+
+def test_agent_breaker_owasp_tagging_matches_doc_uri():
+    """AgentBreaker is an excessive-agency probe; tags must cite LLM06 like its doc_uri."""
+    assert (
+        "owasp:llm06" in AgentBreaker.tags
+    ), "AgentBreaker must carry the owasp:llm06 tag"
+    assert (
+        "owasp:llm07" not in AgentBreaker.tags
+    ), "llm07 is System Prompt Leakage under OWASP 2025 and does not describe AgentBreaker"
+    assert (
+        "owasp:llm08" not in AgentBreaker.tags
+    ), "llm08 is Vector & Embedding Weaknesses under OWASP 2025 and does not describe AgentBreaker"


### PR DESCRIPTION
## Summary

`AgentBreaker` is an excessive-agency / agent-tool-manipulation probe whose own `doc_uri` cites OWASP LLM06 (Excessive Agency, 2025), but its tags carried the leftover 2023-revision numbering `owasp:llm07` / `owasp:llm08` — which under the OWASP LLM Top 10 2025 revision used by the rest of the catalog mean System Prompt Leakage and Vector & Embedding Weaknesses respectively.

This mis-buckets the single most agent-relevant probe in any tool that joins garak results to the OWASP taxonomy (dashboards, guardrail crosswalks, coverage reports): AgentBreaker never appears under an `owasp:llm06` filter and appears under two wrong categories. It is also the only probe in the catalog tagged llm07/llm08, while 36 other probes already use `owasp:llm06`.

**Fix:** retag to `owasp:llm06  # Excessive Agency` (retaining `owasp:llm01` and the payload tag), aligning the probe with its `doc_uri` and the rest of the catalog.

## Why this is not duplicating an existing PR

Checked before opening: no open PR references this issue in its body and no open PR touches AgentBreaker tags (searched `owasp:llm06`, `AgentBreaker`, `1919`).

## Test

- New regression test `test_agent_breaker_owasp_tagging_matches_doc_uri` in `tests/probes/test_agent_breaker.py`: asserts `owasp:llm06` present and `owasp:llm07`/`owasp:llm08` absent.
- Pre-fix: the test fails against the previous tags; post-fix: passes.
- `pytest tests/probes/test_agent_breaker.py` — 50 passed.
- `pytest 'tests/probes/test_probes.py::test_tag_format[probes.agent_breaker.AgentBreaker]' 'tests/probes/test_probes.py::test_probe_metadata[probes.agent_breaker.AgentBreaker]'` — 2 passed (tag-format and metadata checks still green).
- The bundled `garak/resources/plugin_cache.json` is regenerated by the maintain-cache workflow after merge; no manual cache edit included.

## AI Disclosure

AI assistance was used (DeepSeek) to draft this change; the submitting human reviewed every line and ran the tests above.
