### PR TITLE
fix(detectors): retag AgentBreakerResult to owasp:llm06 (Excessive Agency)

### DIFF
--- a/garak/detectors/agent_breaker.py
+++ b/garak/detectors/agent_breaker.py
@@ -49,8 +49,7 @@ class AgentBreakerResult(Detector):
     lang_spec = "*"
     tags = [
         "owasp:llm01",
-        "owasp:llm07",
-        "owasp:llm08",
+        "owasp:llm06",  # Excessive Agency (matches doc_uri; OWASP LLM Top 10 2025)
         "quality:Security:AgentSecurity",
     ]
 

--- a/tests/detectors/test_detectors_agent_breaker.py
+++ b/tests/detectors/test_detectors_agent_breaker.py
@@ -70,6 +70,18 @@ class TestDetectorInit:
     def test_tags_present(self):
         assert len(AgentBreakerResult.tags) > 0
 
+    def test_owasp_tagging_matches_doc_uri(self):
+        """AgentBreakerResult is an excessive-agency detector; tags must cite LLM06 like its doc_uri."""
+        assert (
+            "owasp:llm06" in AgentBreakerResult.tags
+        ), "detector must carry the owasp:llm06 tag"
+        assert (
+            "owasp:llm07" not in AgentBreakerResult.tags
+        ), "llm07 is System Prompt Leakage under OWASP 2025 and does not describe AgentBreaker"
+        assert (
+            "owasp:llm08" not in AgentBreakerResult.tags
+        ), "llm08 is Vector & Embedding Weaknesses under OWASP 2025 and does not describe AgentBreaker"
+
 
 class TestDetectIndependentScoring:
     """Each output should be evaluated independently."""


### PR DESCRIPTION
## Summary

`AgentBreakerResult` — the detector paired with the `AgentBreaker` probe — still carries the leftover 2023-revision tags `owasp:llm07` / `owasp:llm08` that the probe fix retagged to `owasp:llm06` in #2072. Its own `doc_uri` cites LLM06 (Excessive Agency, 2025), and under the OWASP LLM Top 10 2025 revision llm07/llm08 mean System Prompt Leakage and Vector & Embedding Weaknesses respectively. Detector findings are therefore mis-bucketed in any OWASP-taxonomy dashboard/coverage report, exactly like the probe findings were.

**Fix:** retag to `owasp:llm06  # Excessive Agency` (retaining `owasp:llm01` and `quality:Security:AgentSecurity`), aligning the detector with its `doc_uri` and with the paired probe.

## Why this is not duplicating an existing PR

Checked before opening: no open PR touches the detector tags (searched `AgentBreakerResult`, `llm06`, `detector owasp`). #2072 covered the probe half only.

## Test

- New regression test `test_owasp_tagging_matches_doc_uri` in `tests/detectors/test_detectors_agent_breaker.py`: asserts `owasp:llm06` present and `owasp:llm07`/`owasp:llm08` absent.
- Pre-fix: the test fails against the previous tags; post-fix: passes.
- `pytest tests/detectors/test_detectors_agent_breaker.py` — 25 passed. Ruff clean on both touched files.
- The bundled `garak/resources/plugin_cache.json` is regenerated by the maintain-cache workflow after merge; no manual cache edit included.

## AI Disclosure

AI assistance was used (DeepSeek) to draft this change; the submitting human reviewed every line and ran the tests above.
