### PR TITLE
fix(nim): handle transient HTTP errors gracefully instead of crashing

### DIFF
--- a/garak/generators/nim.py
+++ b/garak/generators/nim.py
@@ -95,8 +95,18 @@ class NVOpenAIChat(OpenAICompatible):
             msg = "NIM endpoint not found. Is the model name spelled correctly and the endpoint URI correct?"
             logging.critical(msg, exc_info=nfe)
             raise GarakException(f"🛑 {msg}") from nfe
+        except openai.APIStatusError as ase:
+            status = ase.status_code
+            if status in (408, 429, 502, 503, 504):
+                msg = f"NIM transient error (HTTP {status}), skipping this attempt"
+                logging.warning(msg, exc_info=ase)
+                return [None] * generations_this_call
+            else:
+                msg = f"NIM generation failed (HTTP {status}): {ase.message}"
+                logging.critical(msg, exc_info=ase)
+                raise GarakException(f"🛑 {msg}") from ase
         except Exception as oe:
-            msg = "NIM generation failed. Is the model name spelled correctly?"
+            msg = f"NIM generation failed: {oe}"
             logging.critical(msg, exc_info=oe)
             raise GarakException(f"🛑 {msg}") from oe
 


### PR DESCRIPTION
Fixes #1967

**Problem:**
When a NIM endpoint returns a transient HTTP error (408 timeout, 429 rate limit, 502/503/504 server errors), `_call_model` raises a fatal `GarakException` that crashes the entire probe run. The error message ("Is the model name spelled correctly?") is also misleading for transient failures.

**Fix:**
- Catch `openai.APIStatusError` before the generic `Exception` handler
- Transient status codes (408, 429, 502, 503, 504): log a warning and return `[None]`, so the probe skips that attempt and continues
- Other API errors: still raise `GarakException`, but now report the actual HTTP status code and error message
- Generic `Exception`: now includes the real error text instead of the misleading model-name message

## Verification
- Tested that the file loads without import errors