### PR TITLE
fix(detectors): stop FileDetector scoring an unexamined file as a pass

### DIFF
--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -308,7 +308,8 @@ class FileDetector(Detector):
     """Detector subclass for processing attempts whose outputs are filenames for checking
 
     Attempts whose ``notes["format"]`` does not match ``valid_format`` cannot be
-    scored; one ``None`` per output is returned so the run continues.
+    scored; one ``None`` per output is returned so the run continues. A
+    ``_test_file`` that returns ``None`` is passed through for the same reason.
     """
 
     valid_format = "local filename"
@@ -339,5 +340,6 @@ class FileDetector(Detector):
                 continue
 
             else:
-                test_result = self._test_file(local_filename.text)
-                yield test_result if test_result is not None else 0.0
+                # None means the file could not be examined, which is not the
+                # same as "no hit"; leave it for the evaluator to count unscored
+                yield self._test_file(local_filename.text)

--- a/tests/detectors/test_detectors_fileformats.py
+++ b/tests/detectors/test_detectors_fileformats.py
@@ -14,6 +14,11 @@ from garak.attempt import Attempt, Message
 import garak.detectors.base
 import garak.detectors.fileformats
 
+try:
+    import magic
+except ImportError:
+    magic = None
+
 
 def test_possiblepickle_init():
     d = garak.detectors.fileformats.PossiblePickleName()
@@ -107,7 +112,10 @@ def test_fileisexectuable_nonexec():
         test_file.close()
         exec_attempt.outputs = [Message(test_file.name)]
         results = d.detect(exec_attempt)
-        assert list(results) == [0.0]
+        expected = [0.0] if magic is not None else [None]
+        assert (
+            list(results) == expected
+        ), "a text file is no hit; without libmagic it cannot be examined at all"
 
 
 path_prefix = Path("tests/_assets/fileformats/exec_files/")
@@ -128,12 +136,6 @@ def decoded_filename(request, encoded_exec_filename):
     request.addfinalizer(remove_decoded)
 
 
-try:
-    import magic
-except ImportError as e:
-    magic = None
-
-
 @pytest.mark.skipif(magic is None, reason="libmagic not available")
 @pytest.mark.parametrize(
     "encoded_exec_filename", glob.glob(str(path_prefix / "*.base64"))
@@ -146,3 +148,27 @@ def test_fileisexectuable_exec(decoded_filename):
     exec_attempt.outputs = [Message(decoded_filename)]
     results = d.detect(exec_attempt)
     assert list(results) == [1.0]
+
+
+def test_fileisexecutable_unavailable_magic_is_unscored(monkeypatch):
+    """An unexaminable file is unscored, not scored as a pass.
+
+    FileIsExecutable._test_file returns None when libmagic is unavailable. That
+    is "could not examine", not "not an executable", so it must reach the
+    evaluator as None (counted in `nones`) rather than as 0.0 (counted as a
+    pass). Runs whether or not libmagic is installed.
+    """
+    d = garak.detectors.fileformats.FileIsExecutable()
+    monkeypatch.setattr(d, "magic", None)
+    attempt = Attempt(prompt=Message(text=""))
+    attempt.notes["format"] = "local filename"
+    with tempfile.NamedTemporaryFile(mode="w+", delete=False) as test_file:
+        test_file.write("not examined")
+        test_file.close()
+        attempt.outputs = [Message(test_file.name)]
+        assert (
+            d._test_file(test_file.name) is None
+        ), "a file cannot be examined without libmagic"
+        assert list(d.detect(attempt)) == [
+            None
+        ], "an unexaminable file is unscored, not a pass"


### PR DESCRIPTION
## Summary

`FileDetector.detect()` ends with

```python
test_result = self._test_file(local_filename.text)
yield test_result if test_result is not None else 0.0
```

while `_test_file` is declared `-> Union[None, float]` (`detectors/base.py:316`)
and `0.0` is the no-hit end of the scale. A `None` meaning "I could not examine
this file" is reported as "this file is not a hit".

`FileIsExecutable._test_file` returns that `None` when `self.magic is None`,
which happens whenever `python-magic` imports but the system `libmagic` is
missing: `_load_deps` catches the `ImportError` and logs it. On such a machine
the detector never reads a byte and every file it is handed comes back as not an
executable.

Yielding the `None` instead lets the evaluator count it in `nones` and print
`SKIP` rather than `PASS`. That is the call #2029 already made for the other
branch of this same function, and it matches `StringDetector`'s
`[None] * len(all_outputs)` and `HFDetector`'s `graceful_fail`. The edit is in
`detectors/base.py` because the coercion is there; a subclass cannot undo it.
`FileDetector`'s docstring already documented the format-mismatch `None`, so it
gains one sentence for this one.

Two things to flag rather than leave to review. `analyze/analyze_log.py:60` and
`analyze/qual_review.py:82` compare scores with `>=` / `>` and raise `TypeError`
on a `None`; that is pre-existing, since 20 detector modules already emit `None`
and this makes `fileformats` the 21st, so it wants its own fix. And `_test_file`
could raise instead, but the base signature already permits `None` and the whole
detector layer uses that channel.

## Reproduction

On a machine without `libmagic`, the condition your suite already guards for with
`skipif(magic is None)`:

```
$ python -m pytest tests/detectors/test_detectors_fileformats.py -q
before: 17 passed, 6 skipped
after:  18 passed, 6 skipped
```

`test_fileisexectuable_nonexec` was one of the cases that passed **without the
detector running**: it asserts `[0.0]` on a text file, `_test_file` returned
`None`, and `else 0.0` supplied the expected answer. Rather than guard it with
`skipif` and lose the case, it now expects `[0.0]` where libmagic is present and
`[None]` where it is not, so it runs everywhere and asserts something true in
both. Nothing that ran before is skipped now.

The new test monkeypatches `magic = None`, so it too runs either way. Reverting
the one-line fix and keeping both tests gives `2 failed`.

## Why this is not a duplicate

- **#1883** is in this function but on the other branch: it turns the `continue`
  skips into `yield None` for output/result alignment. The final `else 0.0`
  appears in its diff only as unchanged context, and its test double's
  `_test_file` never returns `None`.
- **#1954** is at the evaluator layer, about `None` scores shrinking the ASR
  denominator. This one is upstream of it: the `None` never arrives.
- **#2000** is also in `detectors/base.py` and applies the same idiom, one `None`
  per output instead of a score, to `TriggerListDetector`. Different class,
  different region.
- **#1634 / #1671** were libmagic *present* returning an unrecognised mimetype,
  fixed in `fileformats.py`. Different input, different line.

## Verification

- [x] `python -m pytest tests/detectors/ -q`: **744 passed, 34 skipped** against
      **743 passed, 34 skipped** on an unpatched tree. Same 13 errors either way,
      all in `test_detectors_judge.py` and unrelated to this change
- [x] `python -m pytest tests/detectors/test_detectors_fileformats.py -q`:
      18 passed, 6 skipped, up from 17 passed, 6 skipped
- [x] Fix reverted with both tests kept: 2 failed, so they pin the behaviour
- [x] `black` 25.1.0 clean on the lines touched
- [ ] `python -m pytest tests/` in full, on the submitter's machine

## AI assistance

AI assistance was used in preparing this change, per `AGENTS.md`. The submitter
has reviewed every changed line, run the tests above, and can defend the change.
