### PR TITLE
pin litellm for python 3.10 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,7 @@ dependencies = [
   "zalgolib>=0.2.2",
   "ecoji>=0.1.1",
   "deepl==1.17.0",
-  "litellm>=1.84.0",
+  "litellm>=1.84.0,<1.97.0",
   "llm>=0.31",
   "jsonpath-ng>=1.6.1",
   "huggingface_hub>=1.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ numpy>=2.0.0
 zalgolib>=0.2.2
 ecoji>=0.1.1
 deepl==1.17.0
-litellm>=1.84.0
+litellm>=1.84.0,<1.97.0
 llm>=0.31
 jsonpath-ng>=1.6.1
 huggingface_hub>=1.0


### PR DESCRIPTION
Lock LiteLLM version until 3.10 compatibility is sorted out.

## Verification

List the steps needed to make sure this thing works

- [ ] Run the tests and ensure they pass `python -m pytest tests/`
