### PR TITLE
Task: drop support for python 3.10, add support for python 3.13

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/remote_package_install.yml
+++ b/.github/workflows/remote_package_install.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10","3.12","3.13"]
+        python-version: ["3.11","3.12","3.13"]
     steps:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
-        python-version: ["3.10","3.12","3.13"]
+        python-version: ["3.11","3.12","3.13"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.10","3.12","3.13"]
+        python-version: ["3.11","3.12","3.13"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.10","3.12"]
+        python-version: ["3.11","3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ python -m pip install -U git+https://github.com/NVIDIA/garak.git@main
 `garak` has its own dependencies. You can to install `garak` in its own Conda environment:
 
 ```
-conda create --name garak "python>=3.10,<=3.12"
+conda create --name garak "python>=3.11,<=3.13"
 conda activate garak
 gh repo clone NVIDIA/garak
 cd garak

--- a/docs/source/extending.generator.rst
+++ b/docs/source/extending.generator.rst
@@ -305,7 +305,7 @@ Done!
 
 Congratulations - you've written a garak plugin!
 
-If it's all tested and working, then it's time to send the code. You should first run ``black --config pyproject.toml <your updated files>`` to format your code in the standard that the garak repository expects (Python 3.10 style, 88 columns). Then, push your work to your github fork, and finally, send us a pull request - and we'll take it from there!
+If it's all tested and working, then it's time to send the code. You should first run ``black --config pyproject.toml <your updated files>`` to format your code in the standard that the garak repository expects (Python 3.11 style, 88 columns). Then, push your work to your github fork, and finally, send us a pull request - and we'll take it from there!
 
 
 Advanced: Modalities

--- a/pylintrc
+++ b/pylintrc
@@ -88,7 +88,7 @@ persistent=yes
 
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.10
+py-version=3.11
 
 # Discover python modules and packages in the file system subtree.
 recursive=no

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,12 +125,12 @@ description = "LLM vulnerability scanner"
 readme = "README.md"
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
   "mikeshardmind-base2048>=1.0.2",
   "transformers>=5.14.1,<6.0",

--- a/tests/test_reqs.py
+++ b/tests/test_reqs.py
@@ -3,17 +3,10 @@
 
 import pytest
 
-try:
-    import tomllib
-except:
-    tomllib = None
-
+import tomllib
 import garak._plugins
 
 
-@pytest.mark.skipif(
-    tomllib is None, reason="No tomllib found (available from Python 3.11)"
-)
 def test_requirements_txt_pyproject_toml():
     with open("requirements.txt", "r", encoding="utf-8") as req_file:
         reqtxt_reqs = req_file.readlines()


### PR DESCRIPTION
Drop official support for python 3.10
Add official support for python 3.13

Fixes #2083 
Fixes #1062

Updates:
* requirements
* docs
* code paths that specifically limit to python 3.10 restrictions.

## Verification

List the steps needed to make sure this thing works

- [x] Run the tests and ensure they pass `python -m pytest tests/`
