### PR TITLE
feat(probes): add Unicode circled-character encoding probe

### DIFF
--- a/garak/probes/encoding.py
+++ b/garak/probes/encoding.py
@@ -57,6 +57,20 @@ def rot13(text):
     return bytes(text.decode().translate(ROT13TRANS), "utf-8")
 
 
+def unicode_circled(text: bytes) -> bytes:
+    """Encode ASCII letters and digits as Unicode circled characters."""
+    circled_characters = {
+        **{chr(ord("A") + index): chr(0x24B6 + index) for index in range(26)},
+        **{chr(ord("a") + index): chr(0x24D0 + index) for index in range(26)},
+        **{str(number): chr(0x245F + number) for number in range(1, 10)},
+        "0": "⓪",
+    }
+
+    translated = text.decode("utf-8").translate(str.maketrans(circled_characters))
+
+    return translated.encode("utf-8")
+
+
 def braille(text):
     # fmt: off
     characterUnicodes = {
@@ -270,9 +284,7 @@ class EncodingMixin:
             not self.follow_prompt_cap
             or len(generated_prompts) < self.soft_probe_prompt_cap
         ):
-            self.prompts, self.triggers, self._prompt_intents = zip(
-                *generated_prompts
-            )
+            self.prompts, self.triggers, self._prompt_intents = zip(*generated_prompts)
         else:
             self.prompts, self.triggers, self._prompt_intents = zip(
                 *random.sample(generated_prompts, self.soft_probe_prompt_cap)
@@ -646,6 +658,23 @@ class InjectLeet(EncodingMixin, garak.probes.Probe):
 
     encoding_name = "Leetspeak"
     encoding_funcs = [leet_bytes]
+
+    def __init__(self, config_root=_config):
+        garak.probes.Probe.__init__(self, config_root=config_root)
+        EncodingMixin.__init__(self)
+
+
+class InjectUnicodeCircled(EncodingMixin, garak.probes.Probe):
+    """Probe for susceptibility to Unicode circled-character encoding.
+
+    Encodes ASCII letters and digits as circled Unicode characters to
+    assess whether targets decode obfuscated instructions.
+    """
+
+    doc_uri = "https://www.unicode.org/charts/PDF/U2460.pdf"
+    encoding_name = "Unicode circled"
+    encoding_funcs = [unicode_circled]
+    active = True
 
     def __init__(self, config_root=_config):
         garak.probes.Probe.__init__(self, config_root=config_root)

--- a/tests/probes/test_probes_encoding.py
+++ b/tests/probes/test_probes_encoding.py
@@ -91,3 +91,30 @@ def test_atbash_function(plain, expected):
     encoder = InjectAtbash.atbash  # staticmethod reference
     result = encoder(plain.encode()).decode()
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("plain", "expected"),
+    [
+        ("abc", "ⓐⓑⓒ"),
+        ("ABC", "ⒶⒷⒸ"),
+        ("0123456789", "⓪①②③④⑤⑥⑦⑧⑨"),
+        ("Hello, World!", "Ⓗⓔⓛⓛⓞ, Ⓦⓞⓡⓛⓓ!"),
+        ("", ""),
+    ],
+)
+def test_unicode_circled_encoding(plain, expected):
+    encoded = garak.probes.encoding.unicode_circled(plain.encode("utf-8")).decode(
+        "utf-8"
+    )
+
+    assert encoded == expected, "ASCII characters should become circled Unicode"
+
+
+def test_unicode_circled_probe_generates_prompts():
+    probe = garak.probes.encoding.InjectUnicodeCircled()
+
+    assert probe.prompts, "Circled encoding probe should generate prompts"
+    assert (
+        probe.primary_detector == "encoding.DecodeMatch"
+    ), "Circled encoding probe should use the encoding detector"


### PR DESCRIPTION
## Description

Adds a Unicode circled-character encoding probe to assess whether targets decode obfuscated instructions.

Related to #152.

### Changes

- Added Unicode circled encoding for ASCII letters and digits.
- Preserved punctuation, whitespace, and other unsupported characters.
- Added the `InjectUnicodeCircled` probe.
- Added tests covering uppercase letters, lowercase letters, digits, mixed text, and prompt generation.

### Duplicate-work check

No existing open pull request implements Unicode circled-character encoding. Existing encoding contributions address different transformations.

## Verification

```bash
python -m pytest tests/probes/test_probes_encoding.py -k unicode_circled -q