### PR TITLE
feat(generators): add OrcaRouter generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ currently supports:
 * [openai api](https://platform.openai.com/docs/introduction) chat & continuation models
 * [aws bedrock](https://aws.amazon.com/bedrock/) foundation models
 * [litellm](https://www.litellm.ai/)
+* [OrcaRouter](https://www.orcarouter.ai) OpenAI-compatible gateway models
 * pretty much anything accessible via REST
 * gguf models like [llama.cpp](https://github.com/ggerganov/llama.cpp) version >= 1046
 * .. and many more LLMs!
@@ -181,6 +182,12 @@ Private Replicate endpoints:
 * `--target_type groq`
 * `--target_name` - The name of the model to access via the Groq API
 * set the `GROQ_API_KEY` environment variable to your Groq API key, see https://console.groq.com/docs/quickstart for details on creating an API key
+
+### OrcaRouter
+
+* `--target_type orcarouter`
+* `--target_name` - The name of the model to access via the OrcaRouter gateway, e.g. `orcarouter/auto`
+* set the `ORCAROUTER_API_KEY` environment variable to your OrcaRouter API key, see https://www.orcarouter.ai for details on creating an API key
 
 ### ggml
 

--- a/docs/source/generators/orcarouter.rst
+++ b/docs/source/generators/orcarouter.rst
@@ -1,0 +1,7 @@
+garak.generators.orcarouter
+==========================
+
+.. automodule:: garak.generators.orcarouter
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/index_generators.rst
+++ b/docs/source/index_generators.rst
@@ -27,6 +27,7 @@ For a detailed oversight into how a generator operates, see :doc:`generators/bas
    generators/openai
    generators/nim
    generators/nvcf
+   generators/orcarouter
    generators/replicate
    generators/rest
    generators/rasa

--- a/garak/generators/orcarouter.py
+++ b/garak/generators/orcarouter.py
@@ -1,0 +1,76 @@
+"""OrcaRouter API support
+
+OrcaRouter is an OpenAI-compatible gateway that routes requests to a large
+catalogue of models. Put your OrcaRouter API key in the ORCAROUTER_API_KEY
+environment variable and select the model you want with the --target_name
+command line parameter.
+
+Sources:
+
+* https://www.orcarouter.ai
+* https://api.orcarouter.ai/v1
+"""
+
+from typing import List, Union
+
+import openai
+
+from garak.attempt import Message
+from garak.generators.openai import OpenAICompatible
+
+
+class OrcaRouter(OpenAICompatible):
+    """Wrapper for the OrcaRouter gateway.
+
+    Expects ORCAROUTER_API_KEY environment variable.
+    Uses the OpenAI-compatible API at https://api.orcarouter.ai/v1
+    """
+
+    ENV_VAR = "ORCAROUTER_API_KEY"
+    DEFAULT_PARAMS = OpenAICompatible.DEFAULT_PARAMS | {
+        "temperature": 0.7,
+        "top_p": 1.0,
+        "uri": "https://api.orcarouter.ai/v1",
+        "vary_seed_each_call": True,  # encourage variation when generations>1
+        "vary_temp_each_call": True,  # encourage variation when generations>1
+        "suppressed_params": {
+            "n",
+            "frequency_penalty",
+            "presence_penalty",
+            "logprobs",
+            "logit_bias",
+            "top_logprobs",
+        },
+    }
+    active = True
+    supports_multiple_generations = False
+    generator_family_name = "OrcaRouter"
+
+    def _load_unsafe(self):
+        self.client = openai.OpenAI(base_url=self.uri, api_key=self.api_key)
+        if self.name in ("", None):
+            raise ValueError(
+                "OrcaRouter API requires model name to be set, e.g. --target_name orcarouter/auto \nCurrent models:\n"
+                + "\n - ".join(
+                    sorted([entry.id for entry in self.client.models.list().data])
+                )
+            )
+        self.generator = self.client.chat.completions
+
+    def _call_model(
+        self, prompt: Message | List[dict], generations_this_call: int = 1
+    ) -> List[Union[Message, None]]:
+        assert (
+            generations_this_call == 1
+        ), "generations_per_call / n > 1 is not supported"
+
+        if self.vary_seed_each_call:
+            self.seed = self._rng.randint(0, 65535)
+
+        if self.vary_temp_each_call:
+            self.temperature = self._rng.random()
+
+        return super()._call_model(prompt, generations_this_call)
+
+
+DEFAULT_CLASS = "OrcaRouter"

--- a/tests/generators/test_generators.py
+++ b/tests/generators/test_generators.py
@@ -137,6 +137,7 @@ NON_CONVERSATION_GENERATORS = [
     if not (
         "openai" in classname
         or "groq" in classname
+        or "orcarouter" in classname
         or "azure" in classname
         or "NeMoGuardrailsServer" in classname
     )

--- a/tests/generators/test_openai_compatible.py
+++ b/tests/generators/test_openai_compatible.py
@@ -27,6 +27,7 @@ GENERATORS = [
     "generators.openai.OpenAIGenerator",
     "generators.nim.NVOpenAIChat",
     "generators.groq.GroqChat",
+    "generators.orcarouter.OrcaRouter",
 ]
 
 MODEL_NAME = "gpt-3.5-turbo-instruct"

--- a/tests/generators/test_orcarouter.py
+++ b/tests/generators/test_orcarouter.py
@@ -1,0 +1,43 @@
+import os
+import pytest
+
+from garak.attempt import Message, Turn, Conversation
+from garak.generators.orcarouter import OrcaRouter
+
+
+def test_orcarouter_invalid_multiple_completions():
+    if os.getenv(OrcaRouter.ENV_VAR, None) is None:
+        os.environ[OrcaRouter.ENV_VAR] = "fake_api_key"
+    with pytest.raises(AssertionError) as e_info:
+        generator = OrcaRouter(name="orcarouter/auto")
+        generator._call_model(
+            prompt=Message("this is expected to fail"), generations_this_call=2
+        )
+    assert "n > 1 is not supported" in str(e_info.value)
+
+
+@pytest.mark.skipif(
+    os.getenv(OrcaRouter.ENV_VAR, None) is None,
+    reason=f"OrcaRouter API key is not set in {OrcaRouter.ENV_VAR}",
+)
+def test_orcarouter_instantiate():
+    g = OrcaRouter(name="orcarouter/auto")
+
+
+@pytest.mark.skipif(
+    os.getenv(OrcaRouter.ENV_VAR, None) is None,
+    reason=f"OrcaRouter API key is not set in {OrcaRouter.ENV_VAR}",
+)
+def test_orcarouter_generate_1():
+    g = OrcaRouter(name="orcarouter/auto")
+    convo = Conversation([Turn("user", Message("this is a test"))])
+    result = g._call_model(convo, generations_this_call=1)
+    assert isinstance(result, list), "OrcaRouter _call_model should return a list"
+    assert len(result) == 1, "OrcaRouter _call_model result list should have one item"
+    assert isinstance(result[0], Message), "OrcaRouter generate() should contain a str"
+    result = g.generate(convo, generations_this_call=1)
+    assert isinstance(result, list), "OrcaRouter generate() should return a list"
+    assert (
+        len(result) == 1
+    ), "OrcaRouter generate() result list should have one item when generations_this_call=1"
+    assert isinstance(result[0], Message), "OrcaRouter generate() should contain a str"


### PR DESCRIPTION
## Summary

Adds **OrcaRouter** as a named, first-class generator (`--target_type orcarouter`), mirroring the existing `GroqChat` OpenAI-compatible provider pattern.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible gateway that routes to a large catalogue of models. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The new `garak.generators.orcarouter.OrcaRouter` generator:
- Points at `https://api.orcarouter.ai/v1` (OpenAI-compatible chat/completions)
- Reads the API key from the `ORCAROUTER_API_KEY` environment variable
- Defaults to `--target_name orcarouter/auto` for model auto-routing
- Suppresses the same unsupported params as `GroqChat` (single-generation chat only)

## Changes

- `garak/generators/orcarouter.py` — new generator (mirrors `groq.py`)
- `docs/source/generators/orcarouter.rst` + `docs/source/index_generators.rst` — Sphinx docs entry
- `README.md` — add OrcaRouter to the supported-providers list and the "Intro to generators" section
- `tests/generators/test_orcarouter.py` — dedicated tests (mirror `test_groq.py`)
- `tests/generators/test_openai_compatible.py` — add `OrcaRouter` to the shared OpenAI-compatible coverage
- `tests/generators/test_generators.py` — exclude `orcarouter` from the non-conversation-signature test (same as `groq`)

## Why this isn't duplicating an existing PR

Searching `NVIDIA/garak` for `orcarouter` in PRs/issues/code returns no existing work; this is the first OrcaRouter integration for garak.

## Verification

- `python -m pytest tests/generators/test_orcarouter.py tests/generators/test_openai_compatible.py tests/generators/test_generators.py tests/test_docs.py` → **821 passed, 6 skipped**
- `black --check` on new files → clean
- Live end-to-end with a real `ORCAROUTER_API_KEY`:
  - `OrcaRouter(name="orcarouter/auto")._call_model(conversation, 1)` → HTTP 200, response `ORCA-FULL-OK`
  - `.generate(conversation, 1)` → HTTP 200, response `ORCA-FULL-OK`
  - The same endpoint via `httpx` → HTTP 200
- `python -m garak --list_generators` shows `orcarouter` / `orcarouter.OrcaRouter`

Disclosure: I'm an engineer on the OrcaRouter team.

This PR was written primarily with Claude Code (AI assistance).
