### PR TITLE
fix(generators): raise clear error on HF InferenceAPI 404 response

### DIFF
--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -43,6 +43,10 @@ class HFInternalServerError(GarakException):
     pass
 
 
+class ModelNotFoundError(GarakException):
+    pass
+
+
 class Pipeline(Generator, HFCompatible):
     """Get text generations from a locally-run Hugging Face pipeline"""
 
@@ -255,6 +259,13 @@ class InferenceAPI(Generator):
         if req_response.status_code == 503:
             self.wait_for_model = True
             raise HFLoadingException
+
+        if req_response.status_code == 404:
+            raise ModelNotFoundError(
+                f"🤗 Inference API returned 404 for model '{self.name}'. The model may not "
+                "be available via the legacy Inference API and may require selecting an "
+                "Inference Provider instead; see https://huggingface.co/docs/inference-providers"
+            )
 
         # if we get this far, reset the model load wait. let's hope 503 is only for model loading :|
         if self.wait_for_model:

--- a/garak/generators/huggingface.py
+++ b/garak/generators/huggingface.py
@@ -24,7 +24,11 @@ import torch
 
 from garak import _config
 from garak.attempt import Message, Conversation
-from garak.exception import TargetNameMissingError, GarakException
+from garak.exception import (
+    TargetNameMissingError,
+    GarakException,
+    BadGeneratorException,
+)
 from garak.generators.base import Generator
 from garak.resources.api.huggingface import HFCompatible
 
@@ -40,10 +44,6 @@ class HFLoadingException(GarakException):
 
 
 class HFInternalServerError(GarakException):
-    pass
-
-
-class ModelNotFoundError(GarakException):
     pass
 
 
@@ -261,7 +261,7 @@ class InferenceAPI(Generator):
             raise HFLoadingException
 
         if req_response.status_code == 404:
-            raise ModelNotFoundError(
+            raise BadGeneratorException(
                 f"🤗 Inference API returned 404 for model '{self.name}'. The model may not "
                 "be available via the legacy Inference API and may require selecting an "
                 "Inference Provider instead; see https://huggingface.co/docs/inference-providers"

--- a/tests/generators/test_huggingface.py
+++ b/tests/generators/test_huggingface.py
@@ -99,6 +99,21 @@ def test_inference(mocker, hf_mock_response, hf_generator_config):
         assert isinstance(item, Message)
 
 
+def test_inference_model_not_found(mocker, hf_generator_config):
+    target_name = "Qwen/Qwen2.5-7B-Instruct"
+    mock_resp = requests.Response()
+    mock_resp.status_code = 404
+    mock_resp._content = b"Not Found"
+    mocker.patch.object(requests, "request", return_value=mock_resp)
+
+    g = garak.generators.huggingface.InferenceAPI(
+        target_name, config_root=hf_generator_config
+    )
+    conv = Conversation([Turn("user", Message(""))])
+    with pytest.raises(garak.generators.huggingface.ModelNotFoundError):
+        g.generate(conv)
+
+
 def test_endpoint(mocker, hf_mock_response, hf_generator_config):
     target_name = "https://localhost:8000/gpt2"
     mock_request = mocker.patch.object(requests, "post", return_value=hf_mock_response)

--- a/tests/generators/test_huggingface.py
+++ b/tests/generators/test_huggingface.py
@@ -4,6 +4,7 @@ import transformers
 
 from garak.attempt import Message, Turn, Conversation
 from garak._config import GarakSubConfig
+from garak.exception import BadGeneratorException
 import garak.generators.huggingface
 
 
@@ -110,7 +111,7 @@ def test_inference_model_not_found(mocker, hf_generator_config):
         target_name, config_root=hf_generator_config
     )
     conv = Conversation([Turn("user", Message(""))])
-    with pytest.raises(garak.generators.huggingface.ModelNotFoundError):
+    with pytest.raises(BadGeneratorException, match=target_name):
         g.generate(conv)
 
 


### PR DESCRIPTION
Tell us what this change does. If you're fixing a bug, please mention
the github issue number.

This improves the error message raised by `huggingface.InferenceAPI` when the
Hugging Face Inference API returns an HTTP 404 for a model. Previously this
surfaced as a generic `TypeError: Unsure how to parse 🤗 API response type:
b'Not Found', please open an issue...`, which told users to file a bug report
for what is actually an HTTP-level "model not found" response. This is
exactly what happened in issue #1297: a maintainer identified that the model
in question is not exposed via the legacy default Inference API provider (HF
introduced a separate "Inference Providers" architecture in Jan 2025), but
the generator gave no indication of that — it just told the user to file a
bug.

Fully supporting HF's new Inference Providers routing (provider selection,
new endpoints/auth) would be a larger redesign of this generator and is out
of scope here. This change instead makes the immediate failure mode clear and
actionable: a dedicated `ModelNotFoundError` is now raised on HTTP 404,
naming the model and pointing at HF's Inference Providers docs, instead of
the misleading generic parse-error message.

Please ensure you are submitting **from a unique branch** in your repository to `main` upstream.

## Verification

List the steps needed to make sure this thing works

- [x] Supporting configuration such as generator configuration file — not needed; change is exercised via mocked HTTP responses in unit tests, no live generator config required.
- [ ] `garak -t <target_type> -n <model_name>` — not run against a live Hugging Face endpoint (would require a real `HF_INFERENCE_TOKEN` and a model that 404s under the legacy API); the new code path is covered by a targeted unit test instead (see below).
- [x] Run the tests and ensure they pass `python -m pytest tests/`: ran `python -m pytest tests/generators/test_huggingface.py -v` (all 8 tests pass, including the new `test_inference_model_not_found`). Confirmed the new test fails without the fix (`AttributeError: module 'garak.generators.huggingface' has no attribute 'ModelNotFoundError'`) and passes with it, i.e. it reproduces the reported failure mode and proves the fix. Also ran `black --check` and a targeted `pylint` (undefined-variable/unused-variable/unused-import) pass on the two changed files — both clean.
- [x] **Verify** the thing does what it should — new test `test_inference_model_not_found` mocks a 404 response with body `b"Not Found"` (matching the exact response shape from the issue's traceback) and asserts `ModelNotFoundError` is raised with a message identifying the model.
- [x] **Verify** the thing does not do what it should not — confirmed `ModelNotFoundError` is not in the `@backoff.on_exception` retry list, so a 404 is not needlessly retried (a missing/unavailable model is not a transient condition, unlike the existing 503/rate-limit handling it sits alongside).
- [x] **Document** the thing and how it works — the raised error message itself documents the likely cause and links to https://huggingface.co/docs/inference-providers for further reading; no separate doc page seemed warranted for a single, self-explanatory error message.

If you are opening a PR for a new plugin that targets a **specific** piece of hardware or requires a **complex or hard-to-find** testing environment, we recommend that you send us as much detail as possible.

Specific Hardware Examples:
* GPU related
  * Specific support required `cuda` / `mps` ( Please not `cuda` via `ROCm` if related )
  * Minium GPU Memory

Complex Software Examples:
* Expensive proprietary software
* Software with an extensive installation process
* Software without an English language UI

Report: https://github.com/NVIDIA/garak/issues/1297

---
AI assistance: this change was drafted with Claude Code.

Fixes #1297