### PR TITLE
fix(harnesses): skip probe when its detectors fail to load instead of aborting the scan

### DIFF
--- a/garak/harnesses/probewise.py
+++ b/garak/harnesses/probewise.py
@@ -107,5 +107,15 @@ class ProbewiseHarness(Harness):
                     if d:
                         detectors.append(d)
 
+            if not detectors:
+                # Every detector this probe asked for failed to load. Harness.run
+                # rejects an empty detector list with ValueError, which would
+                # abort the whole scan and silently drop every probe still
+                # queued behind this one; skip just this probe instead.
+                msg = f"no detectors loaded for probe {probename}, skipping >>"
+                print(f" {msg}")
+                logging.error(msg)
+                continue
+
             super().run(model, [probe], detectors, evaluator, announce_probe=False)
             # del probe, h, detectors

--- a/tests/harnesses/test_probewise.py
+++ b/tests/harnesses/test_probewise.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import patch
+
+import pytest
+
+from garak import _config
+from garak.harnesses.probewise import ProbewiseHarness
+
+
+@pytest.fixture(autouse=True)
+def _config_loaded():
+    _config.load_base_config()
+    yield
+
+
+class _FakeProbe:
+    """Minimal probe stand-in exposing only what ProbewiseHarness.run() reads."""
+
+    def __init__(self, name, primary_detector):
+        self.name = name
+        self.primary_detector = primary_detector
+        self.extended_detectors = []
+
+
+class _FakeDetector:
+    pass
+
+
+BAD_PROBE = "probes.a_module.BadProbe"
+GOOD_PROBE = "probes.b_module.GoodProbe"
+UNLOADABLE_DETECTOR = "unloadable.Detector"
+
+
+def _loader(probes_by_name, unloadable_detectors):
+    """Build a load_plugin stand-in: named detectors fail, everything else loads."""
+
+    def _load_plugin(name, break_on_fail=True):
+        if name.startswith("detectors."):
+            detector_name = name[len("detectors.") :]
+            if detector_name in unloadable_detectors:
+                return False
+            return _FakeDetector()
+        return probes_by_name[name]
+
+    return _load_plugin
+
+
+def _run_harness(probes_by_name, unloadable_detectors, probenames):
+    """Run the harness, recording which probes reached Harness.run()."""
+    probes_run = []
+
+    def _fake_super_run(self, model, probes, detectors, evaluator, announce_probe=True):
+        # Mirror the base harness contract: an empty detector list is an error.
+        if not detectors:
+            raise ValueError("No detectors, nothing to do")
+        probes_run.append(probes[0].name)
+
+    harness = ProbewiseHarness()
+    with (
+        patch(
+            "garak._plugins.load_plugin",
+            side_effect=_loader(probes_by_name, unloadable_detectors),
+        ),
+        patch("garak.harnesses.base.Harness.run", _fake_super_run),
+    ):
+        harness.run(None, probenames, None)
+
+    return probes_run
+
+
+def test_probe_with_unloadable_detector_does_not_abort_scan():
+    """A probe whose only detector fails to load is skipped, not fatal.
+
+    Regression test for #1513: ``Harness.run()`` rejects an empty detector
+    list with ``ValueError``. Letting that propagate ended the whole scan, so
+    every probe queued behind the failure was silently dropped.
+    """
+    probes_by_name = {
+        BAD_PROBE: _FakeProbe("BadProbe", UNLOADABLE_DETECTOR),
+        GOOD_PROBE: _FakeProbe("GoodProbe", "loadable.Detector"),
+    }
+
+    # BAD_PROBE sorts first, so the healthy probe is queued behind the failure.
+    probes_run = _run_harness(
+        probes_by_name, {UNLOADABLE_DETECTOR}, [BAD_PROBE, GOOD_PROBE]
+    )
+
+    assert probes_run == ["GoodProbe"]
+
+
+def test_probe_runs_when_only_extended_detector_fails():
+    """Losing an extended detector must not discard a working primary one."""
+    probes_by_name = {GOOD_PROBE: _FakeProbe("GoodProbe", "loadable.Detector")}
+    probes_by_name[GOOD_PROBE].extended_detectors = [UNLOADABLE_DETECTOR]
+    _config.plugins.extended_detectors = True
+
+    probes_run = _run_harness(probes_by_name, {UNLOADABLE_DETECTOR}, [GOOD_PROBE])
+
+    assert probes_run == ["GoodProbe"]
+
+
+def test_all_probes_run_when_detectors_load():
+    """Baseline: nothing is skipped when every detector loads."""
+    probes_by_name = {
+        BAD_PROBE: _FakeProbe("BadProbe", "loadable.Detector"),
+        GOOD_PROBE: _FakeProbe("GoodProbe", "loadable.Detector"),
+    }
+
+    probes_run = _run_harness(probes_by_name, set(), [BAD_PROBE, GOOD_PROBE])
+
+    assert probes_run == ["BadProbe", "GoodProbe"]


### PR DESCRIPTION
Fixes #1513.

`Harness.run()` rejects an empty detector list with `ValueError("No detectors, nothing to do")`. In `ProbewiseHarness.run()` that call is unguarded, so when every detector a probe asks for fails to load, the exception propagates out of the harness, through `command.probewise_run()`, and terminates the process — **every probe still queued behind the failure is silently dropped**. That matches the report in #1513: one `detector load failed: perspective.Toxicity` and the rest of the scan is gone.

The `TypeError: '>' not supported between instances of 'NoneType' and 'float'` also quoted in that issue is already fixed on `main` (the tree-search scorer now handles `None` results explicitly); this PR addresses the remaining half — the failure that ends the run.

The fix skips just the affected probe, logging which probe was dropped and why, so one unloadable detector costs one probe instead of the remainder of the run. `Harness.run()`'s own guard is intentionally left alone: it's still an error to call it directly with no detectors.

## Verification

Reproduced before the change with a stand-in loader where `perspective.Toxicity` fails and a second probe is queued behind it: the scan aborts with `ValueError` and the healthy probe never runs. After the change the bad probe is skipped and the healthy probe runs.

- [x] `python -m pytest tests/harnesses/` → **10 passed**
- [x] `python -m pytest tests/test_config.py tests/plugins` → **1133 passed**, 1 pre-existing unrelated failure (`probes.audio.AudioAchillesHeel` needs optional `soundfile`/`librosa`, fails identically on a clean checkout)
- [x] New regression tests in `tests/harnesses/test_probewise.py` (there was no probewise coverage before):
  - `test_probe_with_unloadable_detector_does_not_abort_scan` — the #1513 case; **fails without the fix** (`ValueError`), passes with it
  - `test_probe_runs_when_only_extended_detector_fails` — losing an extended detector must not discard a working primary one
  - `test_all_probes_run_when_detectors_load` — baseline, nothing skipped when loads succeed
- [x] **Verify** the thing does what it should: a probe with no loadable detectors is skipped and the scan continues
- [x] **Verify** the thing does not do what it should not: probes with a working primary detector still run even when an extended detector fails; no behavior change when all detectors load
- [x] `black` clean

No new configuration or dependencies, and no hardware requirements — the change is in harness control flow and the tests use stand-ins rather than real plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeFDve4mxZ19YxrzggGeJR
