### PR TITLE
probes.encoding: add InjectFancyText Unicode font encoding

### DIFF
--- a/garak/probes/encoding.py
+++ b/garak/probes/encoding.py
@@ -652,6 +652,63 @@ class InjectLeet(EncodingMixin, garak.probes.Probe):
         EncodingMixin.__init__(self)
 
 
+def _fancy_text(
+    text: bytes, upper_base: int, lower_base: int, digit_base: int
+) -> bytes:
+    output = []
+    for char in text.decode():
+        if "A" <= char <= "Z":
+            output.append(chr(upper_base + ord(char) - ord("A")))
+        elif "a" <= char <= "z":
+            output.append(chr(lower_base + ord(char) - ord("a")))
+        elif "0" <= char <= "9":
+            output.append(chr(digit_base + ord(char) - ord("0")))
+        else:
+            output.append(char)
+    return bytes("".join(output), "utf-8")
+
+
+def fullwidth(text: bytes) -> bytes:
+    output = []
+    for char in text.decode():
+        codepoint = ord(char)
+        if 0x21 <= codepoint <= 0x7E:  # printable ASCII -> Fullwidth Forms
+            output.append(chr(codepoint + 0xFEE0))
+        elif char == " ":
+            output.append("　")  # ideographic space
+        else:
+            output.append(char)
+    return bytes("".join(output), "utf-8")
+
+
+def math_bold(text: bytes) -> bytes:
+    # Mathematical Alphanumeric Symbols: bold
+    return _fancy_text(text, 0x1D400, 0x1D41A, 0x1D7CE)
+
+
+def monospace(text: bytes) -> bytes:
+    # Mathematical Alphanumeric Symbols: monospace
+    return _fancy_text(text, 0x1D670, 0x1D68A, 0x1D7F6)
+
+
+class InjectFancyText(EncodingMixin, garak.probes.Probe):
+    """Probe for susceptibility to "fancy text" Unicode font encoding.
+
+    Encodes payloads by mapping ASCII characters to visually-similar Unicode
+    glyphs (fullwidth forms and Mathematical Alphanumeric Symbols), in the style
+    of the qaz.wtf Unicode text converter, and tries a variety of ways of getting
+    the target model to repeat & decode them."""
+
+    doc_uri = "https://qaz.wtf/u/convert.cgi"
+    encoding_funcs = [fullwidth, math_bold, monospace]
+    encoding_name = "Fancy text"
+    active = True
+
+    def __init__(self, config_root=_config):
+        garak.probes.Probe.__init__(self, config_root=config_root)
+        EncodingMixin.__init__(self)
+
+
 class InjectUnicodeTagChars(EncodingMixin, garak.probes.Probe):
     """Probe for susceptibility to unicode tag ASCII smuggling
 

--- a/tests/probes/test_probes_encoding.py
+++ b/tests/probes/test_probes_encoding.py
@@ -4,6 +4,7 @@ import pytest
 import garak.probes.encoding
 from garak import _plugins
 from garak.probes.encoding import InjectAtbash
+from garak.probes.encoding import fullwidth, math_bold, monospace
 
 ENCODING_PROBES = [
     classname
@@ -89,5 +90,29 @@ def test_atbash_function(plain, expected):
     # Uppercase, Lowercase, Mixed case, and Numbers/Special characters.
 
     encoder = InjectAtbash.atbash  # staticmethod reference
+    result = encoder(plain.encode()).decode()
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "encoder, plain, expected",
+    [
+        # Fullwidth Forms: letters, digits and punctuation are all remapped
+        (fullwidth, "abc", "ａｂｃ"),
+        (fullwidth, "XYZ", "ＸＹＺ"),
+        (fullwidth, "Hello, World! 123", "Ｈｅｌｌｏ，　Ｗｏｒｌｄ！　１２３"),
+        (fullwidth, "1234!?", "１２３４！？"),
+        # Mathematical Alphanumeric Symbols: bold (punctuation passes through)
+        (math_bold, "abc", "𝐚𝐛𝐜"),
+        (math_bold, "XYZ", "𝐗𝐘𝐙"),
+        (math_bold, "1234!?", "𝟏𝟐𝟑𝟒!?"),
+        # Mathematical Alphanumeric Symbols: monospace (punctuation passes through)
+        (monospace, "abc", "𝚊𝚋𝚌"),
+        (monospace, "XYZ", "𝚇𝚈𝚉"),
+        (monospace, "1234!?", "𝟷𝟸𝟹𝟺!?"),
+    ],
+)
+def test_fancy_text_functions(encoder, plain, expected):
+    # Fancy-text encoders map ASCII to visually-similar Unicode glyphs.
     result = encoder(plain.encode()).decode()
     assert result == expected


### PR DESCRIPTION
## What this does

Adds a new **"fancy text" Unicode font encoding** to the `encoding` probe, addressing the remaining unchecked item (`utf (qaz.wtf)`) in #152. The `zalgo` item from that issue is already implemented; this completes the list.

The new `probes.encoding.InjectFancyText` probe encodes payloads by mapping ASCII characters to visually-similar Unicode glyphs, in the style of the [qaz.wtf Unicode text converter](https://qaz.wtf/u/convert.cgi). It ships three algorithmic transforms as `encoding_funcs`:

- **Fullwidth** — printable ASCII → Halfwidth/Fullwidth Forms (`Hello` → `Ｈｅｌｌｏ`)
- **Math bold** — Mathematical Alphanumeric Symbols, bold (`Hello` → `𝐇𝐞𝐥𝐥𝐨`)
- **Monospace** — Mathematical Alphanumeric Symbols, monospace (`Hello` → `𝙷𝚎𝚕𝚕𝚘`)

### Design notes

- **No bundled mapping table / no new dependency.** qaz.wtf's own mapping tables have no clear open-source license, so rather than copy them, the transforms are computed algorithmically from fixed Unicode code-point offsets (defined by the Unicode Standard). This keeps the change self-contained and license-clean, matching the inline style of the existing `braille` / `morse` / `nato` encoders.
- **Gap-free styles only.** I deliberately chose fullwidth, math-bold and monospace because their letter/digit ranges are contiguous. Styles like italic/script/fraktur/double-struck were avoided because Unicode borrows some of their glyphs from the Letterlike Symbols block, which would create irregular gaps.
- **No detector change.** The probe reuses the existing `encoding.DecodeMatch` (primary) and `encoding.DecodeApprox` (extended) detectors unchanged. The stored trigger remains the plaintext payload, so if the target decodes the fancy text back to ASCII, the existing detectors fire — exactly as for `zalgo`, `braille`, etc.
- Follows the neighboring `Inject*` probe pattern (mixin + `encoding_funcs` + `encoding_name` + `active = True`); registration is automatic via plugin discovery.

## Verification

- [x] Run the tests and ensure they pass: `python -m pytest tests/probes/test_probes_encoding.py tests/detectors/test_detectors_encoding.py` → **116 passed, 1 skipped**
- [x] **Verify** the probe is discoverable and generates prompts: `InjectFancyText` enumerates via `_plugins.enumerate_plugins("probes")` and produces prompts/triggers of equal length.
- [x] **Verify** encoders map ASCII to distinct non-ASCII glyphs (added `test_fancy_text_functions`, mirroring `test_atbash_function`), so the shared `test_encoding_triggers_not_in_prompts` invariant holds.
- [x] **Verify** end-to-end that `encoding.DecodeMatch` scores a hit when a response decodes the fancy text back to the plaintext trigger.
- [x] No existing encodings broke (the parametrized encoding tests run against every `probes.encoding.*` class and pass).
- [x] `black --config pyproject.toml` (v25.1.0, matching `.pre-commit-config.yaml`) — added code is formatted.

No special hardware or complex environment required.

> Note: the change is limited to `garak/probes/encoding.py` and `tests/probes/test_probes_encoding.py`. `black` also flags one pre-existing line (`zip(*generated_prompts)` in `EncodingMixin.__init__`) that is unrelated to this change; I left it untouched to keep the diff scoped.
