### PR TITLE
generators: make the ollama empty-response retry actually retry

### DIFF
--- a/garak/generators/ollama.py
+++ b/garak/generators/ollama.py
@@ -117,7 +117,9 @@ class OllamaGenerator(Generator):
         giveup=_give_up,
     )
     @backoff.on_predicate(
-        backoff.fibo, lambda ans: ans == [None] or len(ans) == 0, max_tries=3
+        backoff.fibo,
+        lambda ans: not ans or ans[0] is None or not ans[0].text,
+        max_tries=3,
     )  # Ollama sometimes returns empty responses. Only 3 retries to not delay generations expecting empty responses too much
     def _call_model(
         self, prompt: Conversation, generations_this_call: int = 1
@@ -161,7 +163,9 @@ class OllamaGeneratorChat(OllamaGenerator):
         giveup=_give_up,
     )
     @backoff.on_predicate(
-        backoff.fibo, lambda ans: ans == [None] or len(ans) == 0, max_tries=3
+        backoff.fibo,
+        lambda ans: not ans or ans[0] is None or not ans[0].text,
+        max_tries=3,
     )  # Ollama sometimes returns empty responses. Only 3 retries to not delay generations expecting empty responses too much
     def _call_model(
         self, prompt: Conversation, generations_this_call: int = 1

--- a/tests/generators/test_ollama.py
+++ b/tests/generators/test_ollama.py
@@ -193,6 +193,72 @@ def test_ollama_generation_chat_mocked(respx_mock):
 
 
 @pytest.mark.respx(base_url="http://" + OllamaGenerator.DEFAULT_PARAMS["host"])
+def test_empty_generation_is_retried(respx_mock):
+    """An empty generation is retried and a recovered response is returned."""
+    route = respx_mock.post("/api/generate").mock(
+        side_effect=[
+            httpx.Response(200, json={"model": "mistral", "response": None}),
+            httpx.Response(200, json={"model": "mistral", "response": "Recovered"}),
+        ]
+    )
+    gen = OllamaGenerator("mistral")
+    conv = Conversation([Turn("user", Message("Bla bla"))])
+    generation = gen.generate(conv)
+    assert generation == [
+        Message("Recovered")
+    ], "an empty generation must be retried and the recovered text surfaced"
+    assert (
+        route.call_count == 2
+    ), "the empty first response should have triggered exactly one retry"
+
+
+@pytest.mark.respx(base_url="http://" + OllamaGenerator.DEFAULT_PARAMS["host"])
+def test_empty_chat_generation_is_retried(respx_mock):
+    """An empty chat generation is retried and a recovered response is returned."""
+    route = respx_mock.post("/api/chat").mock(
+        side_effect=[
+            httpx.Response(
+                200,
+                json={"model": "mistral", "message": {"role": "assistant"}},
+            ),
+            httpx.Response(
+                200,
+                json={
+                    "model": "mistral",
+                    "message": {"role": "assistant", "content": "Recovered"},
+                },
+            ),
+        ]
+    )
+    gen = OllamaGeneratorChat("mistral")
+    conv = Conversation([Turn("user", Message("Bla bla"))])
+    generation = gen.generate(conv)
+    assert generation == [
+        Message("Recovered")
+    ], "an empty chat generation must be retried and the recovered text surfaced"
+    assert (
+        route.call_count == 2
+    ), "the empty first chat response should have triggered exactly one retry"
+
+
+@pytest.mark.respx(base_url="http://" + OllamaGenerator.DEFAULT_PARAMS["host"])
+def test_content_generation_is_not_retried(respx_mock):
+    """A response with content goes through on the first attempt."""
+    route = respx_mock.post("/api/generate").mock(
+        return_value=httpx.Response(200, json={"model": "mistral", "response": "Hi"})
+    )
+    gen = OllamaGenerator("mistral")
+    conv = Conversation([Turn("user", Message("Bla bla"))])
+    generation = gen.generate(conv)
+    assert generation == [
+        Message("Hi")
+    ], "the content-bearing response is returned as is"
+    assert (
+        route.call_count == 1
+    ), "a generation carrying content must not trigger retries"
+
+
+@pytest.mark.respx(base_url="http://" + OllamaGenerator.DEFAULT_PARAMS["host"])
 def test_error_on_nonexistant_model_mocked(respx_mock):
     mock_response = {"error": "No such model"}
     respx_mock.post("/api/generate").mock(


### PR DESCRIPTION

## What this change does

The `backoff.on_predicate` guard on both ollama `_call_model` variants tested `ans == [None] or len(ans) == 0`, but the wrapped functions only ever return a one-element list holding a `Message`, so neither condition could ever be true. The retry was dead code: an Ollama generation with no content (`{"response": null}`, or a chat response missing `content`) surfaced as `Message(text=None)` on the first attempt, every time.

The predicate now retries when the list is empty, its first element is None, or the message carries no text, which is what the decorator and its comment always intended. Bounds are unchanged:

- content-bearing generations still take exactly one attempt (pinned by test);
- responses that keep coming back empty still surface unchanged after `max_tries=3`, so downstream consumers see exactly what they saw before;
- worst case added latency for a persistently empty generation is about one second of backoff sleep plus two extra HTTP calls, per call.

Both generator classes (`OllamaGenerator`, `OllamaGeneratorChat`) get the same predicate.

## Why this is not a duplicate

Searches for open or recent PRs touching this returned nothing overlapping:

- `gh pr list --repo NVIDIA/garak --state all --search "ollama"` shows only unrelated feature work (image scaling probes, auth, options forwarding) and nothing about the empty-response retry
- the retry predicate dates back to the original ollama generator and was last touched by refactors that moved it verbatim

## Verification

Environment: garak 0.16.1.pre1 main, Python 3.12.6, Windows 11 Pro.

New tests fail before the fix, pass after (watched both). Before the fix both retry tests fail because only one HTTP request happens; after the fix the second request returns the recovered text:

```
python -m pytest tests/generators/test_ollama.py -q
  -> 13 passed, 4 skipped in 9.57s   (skips need a live Ollama server)

python -m pytest tests/generators/test_generators.py -q
  -> 117 passed in 29.27s

python -m black --config pyproject.toml --check garak/generators/ollama.py tests/generators/test_ollama.py
  -> 2 files would be left unchanged
```

Direct behavioral proof with a fake client whose `generate()` always returns an empty payload:

```
EMPTY CASE:
calls: 3            <- max_tries honoured
returned text: None (Message, unchanged after exhaustion)
CONTENT CASE:
calls: 1            <- no retry when there is content
```

Checklist notes:

- [x] Supporting configuration such as generator configuration file: none needed, no params changed
- [x] `garak -t <target_type> -n <model_name>`: not run end to end; needs a live Ollama server which is not available here. Coverage comes from the mocked respx suite plus the direct behavioral proof above.
- [x] Run the tests: commands and literal results above
- [x] Verify the thing does what it should: empty generation retried up to max_tries, recovered response surfaced
- [x] Verify the thing does not do what it should not: content-bearing generation takes exactly one attempt; exhausted retries return the same value as before
- [x] Documentation: no new plugin class or module; behavior now matches the existing decorator comment

## Statement on AI assistance

AI assistance was used for this contribution: an AI coding agent drafted the change and tests under my direction; I reviewed every changed line, ran all quoted commands myself, and submit this PR as its author. It fixes a self-found defect, verified against a live repro before this PR, and is not a duplicate per the section above.
