### PR TITLE
test: reset intentservice state between tests

### DIFF
--- a/tests/cas/test_intentservice.py
+++ b/tests/cas/test_intentservice.py
@@ -37,6 +37,9 @@ INVALID_INTENTS = ["X", "c", "C1", "C0001", "CC001", "C001HELLO"]
 def test_invalid_intents_rejected(invalid_intent):
     import garak.services.intentservice
 
+    garak._config.load_config()
+    garak.services.intentservice.load()
+
     with pytest.raises(ValueError) as excinfo:
         s = garak.services.intentservice.get_intent_stubs(invalid_intent)
     assert str(excinfo.value).startswith("Not a valid")

--- a/tests/cas/test_intentservice_state_reset.py
+++ b/tests/cas/test_intentservice_state_reset.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import garak._config
+
+
+def test_intentservice_load_populates_state():
+    import garak.services.intentservice
+
+    garak.services.intentservice.is_loaded = False
+    garak.services.intentservice.intent_typology = {}
+    garak.services.intentservice.intent_detectors = {}
+    garak.services.intentservice.intents_active = set()
+
+    garak._config.load_config()
+    garak.services.intentservice.load()
+
+    assert garak.services.intentservice.is_loaded, "load() must set is_loaded"
+    assert garak.services.intentservice.intent_typology, "load() must load the typology"
+    assert garak.services.intentservice.intents_active, "load() must activate intents"
+
+
+def test_intentservice_state_reset_between_tests():
+    import garak.services.intentservice
+
+    assert not garak.services.intentservice.is_loaded, (
+        "intentservice must not stay loaded across tests"
+    )
+    assert garak.services.intentservice.intent_typology == {}, (
+        "intent typology must be reset between tests"
+    )
+    assert garak.services.intentservice.intent_detectors == {}, (
+        "intent detector mapping must be reset between tests"
+    )
+    assert garak.services.intentservice.intents_active == set(), (
+        "active intents must be reset between tests"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,21 @@ def config_cleanup(request):
     reload()
 
 
+@pytest.fixture(autouse=True)
+def clear_intentservice_state(request):
+    """Reset intentservice for each test"""
+
+    def clear_intentservice_state():
+        from garak.services import intentservice
+
+        intentservice.is_loaded = False
+        intentservice.intent_typology = {}
+        intentservice.intent_detectors = {}
+        intentservice.intents_active = set()
+
+    request.addfinalizer(clear_intentservice_state)
+
+
 def pytest_configure(config):
     config.addinivalue_line(
         "markers",


### PR DESCRIPTION
### What

`intentservice` keeps its state in module globals (`is_loaded`, `intent_typology`, `intent_detectors`, `intents_active`) and nothing resets them between tests. The suite runs in a single process, so whichever test last called `load()` decides what every later test sees. This is the same problem `langservice` had, already fixed by `clear_langprovider_state` in `tests/langservice/conftest.py`; `intentservice` still needs the equivalent.

Concrete symptom: `test_invalid_intents_rejected` never loads the service itself, so it only passes because an earlier test leaves the service loaded — run alone it raises `GarakException: get_intent_stubs called on non-loaded intentservice` instead of the expected `ValueError`. Intent-probe translation tests in `tests/langservice/probes/test_probes_base.py` also flip their skip reason depending on whether an earlier test loaded the service. (The issue's example uses `probes.tap.TAPIntent`, which no longer exists on `main`; the same flip reproduces with the remaining `IntentProbe`, `probes.grandma.GrandmaIntent`.)

### Fix

- autouse `clear_intentservice_state` fixture in `tests/conftest.py`, mirroring `clear_langprovider_state`: resets the four module globals after every test
- `test_invalid_intents_rejected` now loads the service itself instead of relying on leaked state
- new regression pair in `tests/cas/test_intentservice_state_reset.py`: the first test loads the service and asserts it is populated, the second asserts the state was reset in between — the second test fails on `main` without the fixture

I searched the open PRs and none address intentservice test state; the only intentservice-flavoured open PR (#2030) is about harness intent handling.

### Verification

```
python -m pytest tests/cas tests/test_payloads.py tests/harnesses/test_harness_intent_plugin_cache.py -q
337 passed, 1 skipped

python -m pytest tests/cas/test_intentservice_state_reset.py -v
2 passed   (without the fixture the second test fails on main:
            AssertionError: intentservice must not stay loaded across tests)

# order independence, previously inconsistent:
python -m pytest -p no:cacheprovider "tests/cas/test_intentservice.py::test_load_intentservice" "tests/langservice/probes/test_probes_base.py::test_probe_prompt_translation[probes.grandma.GrandmaIntent]" -rs
python -m pytest -p no:cacheprovider "tests/langservice/probes/test_probes_base.py::test_probe_prompt_translation[probes.grandma.GrandmaIntent]" "tests/cas/test_intentservice.py::test_load_intentservice" -rs
both orders now skip with the same reason; before the change the skip reason flipped
```

- [ ] **Verify** the thing does what it should
- [ ] **Verify** the thing does not do what it should not

Closes #2124