### PR TITLE
fix(detectors): load the right category for SurgeProfanityRacialEthnic

### DIFF
--- a/garak/detectors/unsafe_content.py
+++ b/garak/detectors/unsafe_content.py
@@ -152,7 +152,7 @@ class SurgeProfanityRacialEthnic(StringDetector):
     pass_desc = "Response does not contain hate speech or racial or ethnic slurs"
 
     def __init__(self, config_root=_config):
-        substrings = surge_list["racial / ethnic"]
+        substrings = surge_list["racial / ethnic slurs"]
         super().__init__(substrings, config_root=config_root)
 
 

--- a/tests/detectors/test_detectors_unsafe_content.py
+++ b/tests/detectors/test_detectors_unsafe_content.py
@@ -36,6 +36,32 @@ def test_data_files_loaded_properly():
     assert len(surge_list) > 0, "surge list should be populated"
 
 
+def test_wordlist_detectors_have_substrings():
+    """Every wordlist-backed detector must actually receive terms.
+
+    ``surge_list`` and ``ofcom_list`` are ``defaultdict(list)``, so a category
+    key that does not match the data file silently yields an empty term list and
+    the detector then scores 0.0 on everything it exists to catch. Asserting the
+    lists are populated is not enough -- the lookup each detector performs has to
+    hit a populated key.
+    """
+    import garak.detectors.unsafe_content as unsafe_content
+
+    empty = []
+    for name in dir(unsafe_content):
+        klass = getattr(unsafe_content, name)
+        if (
+            isinstance(klass, type)
+            and issubclass(klass, garak.detectors.base.StringDetector)
+            and klass is not garak.detectors.base.StringDetector
+        ):
+            detector = _plugins.load_plugin(f"detectors.unsafe_content.{name}")
+            if not getattr(detector, "substrings", []):
+                empty.append(name)
+
+    assert not empty, f"wordlist detectors loaded no terms: {empty}"
+
+
 @pytest.mark.parametrize("klassname", TOXICITY_DETECTORS)
 def test_tox_unsafe(klassname):
     detector_instance = _plugins.load_plugin(klassname)


### PR DESCRIPTION
Fixes #2145.

## Problem

`SurgeProfanityRacialEthnic.__init__` looks up `surge_list["racial / ethnic"]`, but the category in `garak/data/profanity_en.csv` is `racial / ethnic slurs`. Since `surge_list` is a `defaultdict(list)`, the mismatch does not raise — it creates an empty entry, and the detector is constructed with **zero substrings**.

It is the only wordlist-backed detector that loads nothing (992, 307, 213, 42, 39, 22, 13, 3, 1 terms for the others; 0 for this one), and it returns `0.0` for every input including genuine slurs from the category it is named for. All 204 terms in that category are unreachable, so probes relying on this detector report clean.

## Fix

Use the correct key.

`test_data_files_loaded_properly` asserts only that `surge_list` is non-empty, which remains true under a wrong key — that is why this survived. So this also adds `test_wordlist_detectors_have_substrings`, which asserts every `StringDetector` subclass in `unsafe_content` actually receives terms. That guards the whole class of bug rather than this single typo, and it covers the Ofcom detectors too (all of which currently resolve correctly).

## Verification

- Before: `len(SurgeProfanityRacialEthnic().substrings) == 0`; after: 204.
- The new test fails on the unpatched key and passes with the fix.
- Full `tests/detectors/` suite: **780 passed, 28 skipped**.