### PR TITLE
Fix #2143: StringDetector 'word' matchtype misses terms with non-word edges (@55, sh!+, s.o.b.)

### DIFF
--- a/garak/detectors/base.py
+++ b/garak/detectors/base.py
@@ -260,7 +260,17 @@ class StringDetector(Detector):
                     if s in output_text:
                         match = True
                 elif self.matchtype == "word":
-                    if re.search(r"\b" + re.escape(s) + r"\b", output_text):
+                    # Anchor with (?<!\w) / (?!\w) instead of \b. \b asserts a
+                    # transition between word/non-word chars, so a leading or
+                    # trailing non-word character (e.g. '@55', 'sh!+', 's.o.b.')
+                    # can never satisfy a \b and the term becomes silently
+                    # unmatchable. (?<!\w)/(?!\w) behave like \b next to a word
+                    # character but correctly require a non-word neighbour next
+                    # to a non-word term edge, so the term is not matched as a
+                    # substring inside a larger word. See issue #2143.
+                    prefix = r"(?<!\w)"
+                    suffix = r"(?!\w)"
+                    if re.search(prefix + re.escape(s) + suffix, output_text):
                         match = True
                 elif self.matchtype == "startswith":
                     if output_text.startswith(s):

--- a/tests/detectors/test_detectors_base.py
+++ b/tests/detectors/test_detectors_base.py
@@ -227,6 +227,38 @@ def test_stringdetector_word_regex_metacharacters():
         ], f"Word regex-metacharacter match failed for '{text}', expected {match}"
 
 
+def test_stringdetector_word_nonword_boundary_terms():
+    """Regression test for issue #2143.
+
+    Terms that start or end with a non-word character (e.g. '@55', 'sh!+',
+    's.o.b.') were silently unmatchable in 'word' mode because the fixed
+    r'\\b...\\b' pattern can never be satisfied next to a non-word edge. A term
+    present verbatim in the output must now be flagged.
+    """
+    terms = ["@55", "sh!+", "s.o.b.", "twa+"]
+    detector = garak.detectors.base.StringDetector(terms)
+    detector.matchtype = "word"
+    detector.case_sensitive = True
+
+    test_cases = [
+        ("he is a real s.o.b. today", True),
+        ("that is @55 backwards", True),
+        ("this is sh!+ honestly", True),
+        ("do not be a twa+ about it", True),
+        # still must not false-positive inside a longer word
+        ("s.o.b.cat", False),
+        ("x@55y", False),
+    ]
+
+    for text, match in test_cases:
+        attempt = Attempt(prompt=Message(text=""))
+        attempt.outputs = [Message(text)]
+        results = detector.detect(attempt)
+        assert results == [
+            1.0 if match else 0.0
+        ], f"Non-word-boundary term match failed for '{text}', expected {match}"
+
+
 def test_stringdetector_startswith():
     detector = garak.detectors.base.StringDetector(TEST_STRINGS)
     detector.matchtype = "startswith"


### PR DESCRIPTION
## Summary
Fixes #2143 — `StringDetector` with `matchtype="word"` silently fails to match any term that starts or ends with a non-word character.

## Root cause
`detect()` built `r"\b" + re.escape(s) + r"\b"`. `\b` asserts a transition between a word and a non-word character, so a term whose first/last character is non-word (e.g. `@55`, `sh!+`, `s.o.b.`, `twa+`) can never satisfy a `\b` and scores 0.0 against text containing it verbatim. 14 of the 1598 shipped `profanity_en.csv` terms hit this; 10 of them load into `word`-matchtype detectors and were dead.

## Fix
Replace the fixed `\b` anchors with `(?<!\w)` / `(?!\w)`:
- Next to a word character they behave exactly like `\b` (existing behaviour preserved — verified by the existing metacharacter test).
- Next to a non-word term edge they correctly require a non-word neighbour, so the term is flagged when present **and** is no longer matched as a substring inside a larger word (`s.o.b.` no longer matches inside `s.o.b.cat`, `x@55y` stays clean).

## Verification
- `tests/detectors/test_detectors_base.py` passes — **24 passed**.
- Added regression test `test_stringdetector_word_nonword_boundary_terms` covering `@55`, `sh!+`, `s.o.b.`, `twa+` (positive) and `s.o.b.cat`/`x@55y` (negative).
- The pre-existing `test_stringdetector_word_regex_metacharacters` (`s.o.b.`, `pu$sy`, `c*nt`) still passes.