### PR TITLE
always import nltk wrapper for cache location consistency

### DIFF
--- a/garak/resources/autodan/genetic.py
+++ b/garak/resources/autodan/genetic.py
@@ -7,7 +7,6 @@ import torch
 import random
 import openai
 import re
-from nltk.corpus import stopwords, wordnet
 from collections import defaultdict, OrderedDict
 import sys
 import time
@@ -16,6 +15,7 @@ from typing import Tuple, Optional, List, Union
 
 import garak.generators
 from garak.resources.api import nltk
+from nltk.corpus import stopwords, wordnet  # imported after local nltk wrapper
 from garak.resources.autodan.model_utils import AutoDanPrefixManager, forward
 from garak.generators.huggingface import Model, Pipeline
 from garak.attempt import Conversation, Turn, Message

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ dependencies = [
   "replicate>=0.8.3",
   "google-api-python-client>=2.0",
   "backoff>=2.1.1",
-  "nltk==3.10.0",
+  "nltk>=3.10.3",
   "accelerate>=0.23.0",
   "avidtools==0.1.2",
   "stdlibs>=2022.10.9",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ openai>=2.0,<3.0
 replicate>=0.8.3
 google-api-python-client>=2.0
 backoff>=2.1.1
-nltk==3.10.0
+nltk>=3.10.3
 accelerate>=0.23.0
 avidtools==0.1.2
 stdlibs>=2022.10.9

--- a/tests/cas/test_intentservice.py
+++ b/tests/cas/test_intentservice.py
@@ -3,12 +3,11 @@
 
 import importlib
 import inspect
-import nltk
 import pytest
 
 import garak._config
 
-from garak.exception import GarakException
+import garak.resources.api.nltk as nltk
 
 nltk.download("punkt_tab")
 cas_data_path = garak._config.transient.package_dir / "data" / "cas"


### PR DESCRIPTION
Updates imports to ensure the `garak.resource.api.nltk` package sets consistent cache location for the `nltk_data` storage.

Recent test that happen to execute without import of the custom wrapper leave artifacts on disk during test runs that should  not be left behind in various developer systems or in CI/CD environments.

## Verification

List the steps needed to make sure this thing works

- [ ] `garak -t <target_type> -n <model_name>`
- [ ] Run the tests and ensure they pass `python -m pytest tests/`
- [ ] **Verify** the `nltk_data` path on a linux or macOS run test run does not create `~/nltk_data` when it did not exist prior to test run.
