### PR TITLE
Fix: indefinite hang on OpenAICompatible unreachable targets

### DIFF
--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -17,6 +17,7 @@ import logging
 import re
 from typing import List, Union
 
+import httpx
 import openai
 import backoff
 
@@ -156,6 +157,7 @@ class OpenAICompatible(Generator):
     }
 
     _unsafe_attributes = ["client", "generator"]
+    URI_CONNECT_TIMEOUT = 5
 
     def close(self):
         client = getattr(self, "client", None)
@@ -183,6 +185,20 @@ class OpenAICompatible(Generator):
             )
         self.generator = self.client.chat.completions
 
+    def _validate_uri_connectivity(self):
+        if not hasattr(self, "uri"):
+            return
+
+        try:
+            if not isinstance(self.uri, str):
+                raise ValueError("URI must be a string")
+            httpx.get(self.uri, timeout=self.URI_CONNECT_TIMEOUT)
+        except (httpx.HTTPError, httpx.InvalidURL, ValueError) as e:
+            msg = (
+                f"{self.generator_family_name} target URI is not reachable: {self.uri}"
+            )
+            raise garak.exception.BadGeneratorException(msg) from e
+
     def _validate_config(self):
         pass
 
@@ -191,6 +207,7 @@ class OpenAICompatible(Generator):
         self._load_config(config_root)
         self.fullname = f"{self.generator_family_name} {self.name}"
         self.key_env_var = self.ENV_VAR
+        self._validate_uri_connectivity()
 
         self._load_unsafe()
 
@@ -348,15 +365,6 @@ class OpenAICompatible(Generator):
                 f"OpenAI API authentication failed (HTTP {e.status_code}); "
                 f"verify {self.key_env_var} is valid. Original error: {e}"
             )
-            logging.error(msg)
-            raise garak.exception.GarakException(msg) from None
-        except openai.APITimeoutError as e:
-            # Keep client-side timeouts on the existing backoff path.
-            raise garak.exception.GeneratorBackoffTrigger from e
-        except openai.APIConnectionError as e:
-            # A failed connection to the configured target cannot produce a response.
-            # See https://github.com/NVIDIA/garak/issues/2141.
-            msg = f"Connection error contacting: {e.request.url}"
             logging.error(msg)
             raise garak.exception.GarakException(msg) from None
         except openai.BadRequestError as e:

--- a/garak/generators/openai.py
+++ b/garak/generators/openai.py
@@ -350,6 +350,15 @@ class OpenAICompatible(Generator):
             )
             logging.error(msg)
             raise garak.exception.GarakException(msg) from None
+        except openai.APITimeoutError as e:
+            # Keep client-side timeouts on the existing backoff path.
+            raise garak.exception.GeneratorBackoffTrigger from e
+        except openai.APIConnectionError as e:
+            # A failed connection to the configured target cannot produce a response.
+            # See https://github.com/NVIDIA/garak/issues/2141.
+            msg = f"Connection error contacting: {e.request.url}"
+            logging.error(msg)
+            raise garak.exception.GarakException(msg) from None
         except openai.BadRequestError as e:
             msg = "Bad request: " + str(repr(prompt))
             logging.exception(e)

--- a/tests/generators/conftest.py
+++ b/tests/generators/conftest.py
@@ -5,6 +5,23 @@ import json
 import pytest
 import pathlib
 
+from garak.generators.openai import OpenAICompatible
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "uri_connectivity: run the OpenAI-compatible URI connectivity check",
+    )
+
+
+@pytest.fixture(autouse=True)
+def disable_uri_connectivity_for_generator_tests(request, monkeypatch):
+    if request.node.get_closest_marker("uri_connectivity") is None:
+        monkeypatch.setattr(
+            OpenAICompatible, "_validate_uri_connectivity", lambda self: None
+        )
+
 
 @pytest.fixture
 def openai_compat_mocks():

--- a/tests/generators/test_openai_compatible.py
+++ b/tests/generators/test_openai_compatible.py
@@ -287,6 +287,35 @@ def openai_compatible_generator(monkeypatch):
     return g
 
 
+@pytest.mark.respx(base_url="https://api.openai.com/v1")
+def test_api_connection_error_raises_garak_exception(respx_mock):
+    """A failed target connection must stop without an indefinite backoff loop."""
+    route = respx_mock.post("completions")
+    route.side_effect = httpx.ConnectError("[Errno 61] Connection refused")
+    generator = build_test_instance(OpenAIGenerator)
+    generator.client.max_retries = 0
+    prompt = _make_prompt()
+
+    with pytest.raises(garak.exception.GarakException) as exc_info:
+        generator._call_model(prompt)
+
+    assert "https://api.openai.com/v1/completions" in str(exc_info.value)
+    assert route.called
+
+
+def test_api_timeout_error_raises_backoff_trigger(openai_compatible_generator):
+    """A client timeout must trigger the existing backoff decorator."""
+    prompt = _make_prompt()
+    openai_compatible_generator.generator = MagicMock()
+    openai_compatible_generator.generator.create.side_effect = openai.APITimeoutError(
+        request=httpx.Request("POST", "http://localhost/v1/chat/completions")
+    )
+
+    unwrapped = OpenAICompatible._call_model.__wrapped__
+    with pytest.raises(garak.exception.GeneratorBackoffTrigger):
+        unwrapped(openai_compatible_generator, prompt)
+
+
 def test_transient_retry_codes_override(openai_compatible_generator):
     """transient_retry_codes override suppresses retry for removed code."""
     codes = OpenAICompatible.DEFAULT_PARAMS["transient_retry_codes"]

--- a/tests/generators/test_openai_compatible.py
+++ b/tests/generators/test_openai_compatible.py
@@ -98,7 +98,8 @@ def compatible() -> Iterable[OpenAICompatible]:
 def build_test_instance(module_klass):
     stored_env = os.getenv(module_klass.ENV_VAR, None)
     os.environ[module_klass.ENV_VAR] = ENV_VAR
-    class_instance = module_klass(name=MODEL_NAME)
+    with patch.object(OpenAICompatible, "_validate_uri_connectivity"):
+        class_instance = module_klass(name=MODEL_NAME)
     if stored_env is not None:
         os.environ[module_klass.ENV_VAR] = stored_env
     else:
@@ -113,6 +114,36 @@ def build_unloaded_compatible():
     generator.api_key = ENV_VAR
     generator.generator_family_name = "OpenAICompatible"
     return generator
+
+
+@pytest.mark.uri_connectivity
+def test_openai_compatible_uri_connectivity_check(mocker):
+    generator = build_unloaded_compatible()
+    get = mocker.patch(
+        "garak.generators.openai.httpx.get",
+        return_value=httpx.Response(404),
+    )
+
+    generator._validate_uri_connectivity()
+
+    get.assert_called_once_with(
+        generator.uri, timeout=OpenAICompatible.URI_CONNECT_TIMEOUT
+    )
+
+
+@pytest.mark.uri_connectivity
+def test_openai_compatible_unreachable_uri_fails_during_init(monkeypatch, mocker):
+    monkeypatch.setenv(OpenAICompatible.ENV_VAR, "test-fake-key")
+    mocker.patch(
+        "garak.generators.openai.httpx.get",
+        side_effect=httpx.ConnectError("connection refused"),
+    )
+
+    with pytest.raises(
+        garak.exception.BadGeneratorException,
+        match="target URI is not reachable",
+    ):
+        OpenAICompatible(name=MODEL_NAME)
 
 
 # helper method to pass mock config
@@ -285,35 +316,6 @@ def openai_compatible_generator(monkeypatch):
     with patch("openai.OpenAI", return_value=mock_client):
         g = OpenAIGenerator(name="gpt-3.5-turbo")
     return g
-
-
-@pytest.mark.respx(base_url="https://api.openai.com/v1")
-def test_api_connection_error_raises_garak_exception(respx_mock):
-    """A failed target connection must stop without an indefinite backoff loop."""
-    route = respx_mock.post("completions")
-    route.side_effect = httpx.ConnectError("[Errno 61] Connection refused")
-    generator = build_test_instance(OpenAIGenerator)
-    generator.client.max_retries = 0
-    prompt = _make_prompt()
-
-    with pytest.raises(garak.exception.GarakException) as exc_info:
-        generator._call_model(prompt)
-
-    assert "https://api.openai.com/v1/completions" in str(exc_info.value)
-    assert route.called
-
-
-def test_api_timeout_error_raises_backoff_trigger(openai_compatible_generator):
-    """A client timeout must trigger the existing backoff decorator."""
-    prompt = _make_prompt()
-    openai_compatible_generator.generator = MagicMock()
-    openai_compatible_generator.generator.create.side_effect = openai.APITimeoutError(
-        request=httpx.Request("POST", "http://localhost/v1/chat/completions")
-    )
-
-    unwrapped = OpenAICompatible._call_model.__wrapped__
-    with pytest.raises(garak.exception.GeneratorBackoffTrigger):
-        unwrapped(openai_compatible_generator, prompt)
 
 
 def test_transient_retry_codes_override(openai_compatible_generator):


### PR DESCRIPTION
Implements https://github.com/NVIDIA/garak/issues/2141 for OpenAICompatible generators.

## Verification

Added a couple unit tests specific for this behaviour and tested out that 
```bash
python -m garak \
  --target_type openai.OpenAICompatible \
  --target_name fake-model \
  --probes test.Blank \
  --detectors always.Pass \
  --generator_options '{"openai":{"OpenAICompatible":{"uri":"http://127.0.0.1:9/v1","api_key":"dummy"}}}'
```
now fails fast and doesn't hang
```
✋ DEPRECATION: --probes on CLI is deprecated since version 0.15.1.pre1
📜 logging to /Users/abeltram/.local/share/garak/garak.log
🦜 loading generator: OpenAICompatible: fake-model
⚠️  This run can be sped up 🥳 Generator 'OpenAICompatible fake-model' supports parallelism! Consider using `--parallel_attempts 16` (or more) to greatly accelerate your run. 🐌
📜 reporting to /Users/abeltram/.local/share/garak/garak_runs/garak.04e6d88e-49c8-4762-98c7-44cce97af679.report.jsonl
🎯 loading intent service
🎯 intents active: S003productkeys, S004, S004describe, S004erotica, S004flirt, S004graphic, S004lewd, S004pua, S004seduction, S005, S005bully, S005hate, S005profanity, S006threat, S008code, S008exec, S008inject, S008mal, S008phish, S008risky, S008spam, S008terminal, S009cred, S009exfil
🕵️  queue of probes: test.Blank
🔎 queue of detectors: always.Pass
probes.test.Blank:   0%|          | 0/1 [00:00<?, ?it/s]
  0%|          | 0/5 [00:00<?, ?it/s]
OpenAICompatible fake-model:   0%|          | 0/5 [00:00<?, ?it/s]
Connection error contacting: http://localhost:8000/v1/chat/completions
```