### PR TITLE
Verify _call_model output on every generate() path

### DIFF
--- a/garak/generators/base.py
+++ b/garak/generators/base.py
@@ -87,14 +87,19 @@ class Generator(Configurable):
         pass
 
     @staticmethod
-    def _verify_target_result(result: List[Union[Message, None]]):
+    def _verify_target_result(
+        result: List[Union[Message, None]], expected_length: int = 1
+    ):
         assert isinstance(result, list), "_call_model must return a list"
-        assert (
-            len(result) == 1
-        ), f"_call_model must return a list of one item when invoked as _call_model(prompt, 1), got {result}"
-        assert (
-            isinstance(result[0], Message) or result[0] is None
-        ), f"_call_model's item must be a Message or None, got {result[0].__class__.__name__}: {repr(result[0])}"
+        assert len(result) == expected_length, (
+            f"_call_model must return {expected_length} item(s) when invoked with "
+            f"generations_this_call={expected_length}, got {len(result)}: {result}"
+        )
+        for item in result:
+            assert isinstance(item, Message) or item is None, (
+                "_call_model's items must each be a Message or None, got "
+                f"{item.__class__.__name__}: {repr(item)}"
+            )
 
     def clear_history(self):
         pass
@@ -168,9 +173,11 @@ class Generator(Configurable):
 
         if generations_this_call == 1:
             outputs = self._call_model(prompt, 1)
+            self._verify_target_result(outputs, 1)
 
         elif self.supports_multiple_generations:
             outputs = self._call_model(prompt, generations_this_call)
+            self._verify_target_result(outputs, generations_this_call)
 
         else:
             if (
@@ -200,7 +207,7 @@ class Generator(Configurable):
                     for result in pool.imap_unordered(
                         self._call_model, [prompt] * generations_this_call
                     ):
-                        self._verify_target_result(result)
+                        self._verify_target_result(result, 1)
                         outputs.append(result[0])
                         multi_generator_bar.update(1)
                 except OSError as o:
@@ -226,7 +233,7 @@ class Generator(Configurable):
                     output_one = self._call_model(
                         prompt, 1
                     )  # generate once as `generation_iterator` consumes `generations_this_call`
-                    self._verify_target_result(output_one)
+                    self._verify_target_result(output_one, 1)
                     outputs.append(output_one[0])
 
         if len(outputs) != generations_this_call:

--- a/garak/generators/cohere.py
+++ b/garak/generators/cohere.py
@@ -114,19 +114,19 @@ class CohereGenerator(Generator):
                             # Get the first text content item
                             for content_item in response.message.content:
                                 if hasattr(content_item, "text"):
-                                    responses.append(content_item.text)
+                                    responses.append(Message(content_item.text))
                                     break
                             else:
                                 # No text content found
                                 logging.warning(
                                     "No text content found in chat response"
                                 )
-                                responses.append(str(response))
+                                responses.append(Message(str(response)))
                         else:
                             logging.warning(
                                 "Chat response structure doesn't match expected format"
                             )
-                            responses.append(str(response))
+                            responses.append(Message(str(response)))
                     except Exception as e:
 
                         backoff_exception_types = (
@@ -168,17 +168,17 @@ class CohereGenerator(Generator):
                     # Handle response based on structure
                     if hasattr(response, "generations"):
                         # Handle the v5+ API response format
-                        return [gen.text for gen in response.generations]
+                        return [Message(gen.text) for gen in response.generations]
                     else:
                         # Try to handle other possible response formats
                         try:
                             if isinstance(response, list):
-                                return [g.text for g in response]
+                                return [Message(g.text) for g in response]
                             elif hasattr(response, "text"):
-                                return [response.text]
+                                return [Message(response.text)]
                             else:
                                 # Last resort - try to convert response to string
-                                return [str(response)]
+                                return [Message(str(response))]
                         except RuntimeError as e:
                             logging.error(
                                 f"Failed to extract text from Cohere response: {e}"

--- a/tests/generators/test_cohere.py
+++ b/tests/generators/test_cohere.py
@@ -167,7 +167,9 @@ def test_cohere_generate_api_respx(respx_mock, cohere_mock_responses):
 
     # Assert response parsing
     assert result == [
-        cohere_mock_responses["generate_response"]["json"]["generations"][0]["text"]
+        Message(
+            cohere_mock_responses["generate_response"]["json"]["generations"][0]["text"]
+        )
     ]
 
 
@@ -205,7 +207,7 @@ def test_cohere_chat_api_respx(
     if expect_error_str:
         assert result[0] is None, f"Expected None for error but got {result[0]}"
     else:
-        assert isinstance(result[0], str) and result[0]
+        assert isinstance(result[0], Message) and result[0].text
 
 
 # ─── Logging on Error Variants ─────────────────────────────────────────

--- a/tests/generators/test_generators_base.py
+++ b/tests/generators/test_generators_base.py
@@ -1,2 +1,83 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from garak import _plugins
+from garak.attempt import Conversation, Message, Turn
+
+
+CONVERSATION = Conversation([Turn("user", Message("test prompt"))])
+
+
+def _load_test_generator(classname):
+    return _plugins.load_plugin(classname)
+
+
+@pytest.mark.parametrize(
+    "generations_this_call,supports_multiple_generations",
+    [
+        (1, False),  # single-generation path
+        (3, True),  # supports_multiple_generations path
+        (3, False),  # serial multi-generation path
+    ],
+    ids=["single", "multi-gen", "serial-multi"],
+)
+def test_generate_rejects_non_message_call_model_output(
+    generations_this_call, supports_multiple_generations
+):
+    """generate() must reject a _call_model that returns raw strings (or any
+    non-Message, non-None item) on every path, not only the parallel and
+    serial-multi ones. A generator making this mistake otherwise leaks raw
+    strings downstream, where they surface as an opaque AttributeError rather
+    than the clear contract assertion."""
+    g = _load_test_generator("generators.test.Blank")
+    g.supports_multiple_generations = supports_multiple_generations
+    g._call_model = (
+        lambda prompt, generations_this_call=1: ["a raw string, not a Message"]
+        * generations_this_call
+    )
+
+    with pytest.raises(AssertionError, match="must each be a Message or None"):
+        g.generate(CONVERSATION, generations_this_call)
+
+
+@pytest.mark.parametrize(
+    "generations_this_call,supports_multiple_generations",
+    [(1, False), (3, True)],
+    ids=["single", "multi-gen"],
+)
+def test_generate_rejects_wrong_length_call_model_output(
+    generations_this_call, supports_multiple_generations
+):
+    """generate() must reject a _call_model that returns the wrong number of
+    items for the requested generation count."""
+    g = _load_test_generator("generators.test.Blank")
+    g.supports_multiple_generations = supports_multiple_generations
+    g._call_model = lambda prompt, generations_this_call=1: [Message("")] * (
+        generations_this_call + 1
+    )
+
+    with pytest.raises(AssertionError, match="must return"):
+        g.generate(CONVERSATION, generations_this_call)
+
+
+@pytest.mark.parametrize(
+    "generations_this_call,supports_multiple_generations",
+    [(1, False), (3, True), (3, False)],
+    ids=["single", "multi-gen", "serial-multi"],
+)
+def test_generate_accepts_well_formed_call_model_output(
+    generations_this_call, supports_multiple_generations
+):
+    """A _call_model returning the right count of Message/None items passes on
+    every path."""
+    g = _load_test_generator("generators.test.Blank")
+    g.supports_multiple_generations = supports_multiple_generations
+    g._call_model = lambda prompt, generations_this_call=1: (
+        [Message("ok"), None][:1] * generations_this_call
+    )
+
+    result = g.generate(CONVERSATION, generations_this_call)
+    assert len(result) == generations_this_call
+    assert all(isinstance(item, Message) or item is None for item in result)


### PR DESCRIPTION
## What

`Generator.generate()` calls `_verify_target_result()` to enforce that `_call_model` returns a list of `Message`/`None` items — but only on 2 of the 4 paths that populate `outputs`:

| path | condition | verified before |
|---|---|---|
| 1 | `generations_this_call == 1` | ❌ |
| 2 | `supports_multiple_generations == True` | ❌ |
| 3 | parallel (`pool.imap_unordered`) | ✅ |
| 4 | serial multi-generation loop | ✅ |

Path 1 is the common case for a normal scan. A generator whose `_call_model` returns a raw `str` instead of a `Message` sailed straight through, then failed later with an opaque `AttributeError: 'str' object has no attribute 'text'` inside `_prune_skip_sequences` or a detector — instead of the clear assertion `_verify_target_result` exists to raise.

Fixes #2160.

## Changes

- `_verify_target_result` now checks **every** item and takes an explicit `expected_length`, so it works for the batch paths, not just the one-item calls. All four call sites pass the count explicitly.
- `generate()` verifies `outputs` on paths 1 and 2 as well.
- **`CohereGenerator._call_model` was returning raw `str`** on all its non-empty success paths (v1 `[gen.text for ...]`, v2 `responses.append(content_item.text)`) — every other generator (`openai`, `anthropic`, `mistral`, …) wraps in `Message`. Wrapped Cohere's returns in `Message` so it satisfies the now-enforced contract, and updated the two `test_cohere.py` assertions that compared against raw strings.

## Not a duplicate

Open PR #1673 ("modernize Cohere generator") also wraps Cohere's outputs in `Message` as one part of a broader change (drops the default model, adds fine-grained error handling, live-endpoint tests). This PR is a different fix — the base-class guardrail gap — and only touches Cohere because the newly-enforced contract exposes it. If #1673 lands first, the Cohere hunk here becomes a trivial no-op to drop; happy to rebase or split it out if you'd prefer this PR stay purely in `generators/base.py`.

## Testing

- `pytest tests/generators/` → **423 passed, 17 skipped** (Python 3.12, Windows)
- New tests in `tests/generators/test_generators_base.py` (was empty): reject non-`Message` items and wrong-length output on every path, accept well-formed output on every path
- `black --check` clean on all four files

## AI assistance

AI-assisted (Claude Code), under my direction. I reviewed every changed line, ran the tests above, and can discuss the change.
