### PR TITLE
generators: add OpenRouter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,12 @@ Private Replicate endpoints:
 * `--target_name` - The name of the model to access via the Groq API
 * set the `GROQ_API_KEY` environment variable to your Groq API key, see https://console.groq.com/docs/quickstart for details on creating an API key
 
+### OpenRouter
+
+* `--target_type openrouter`
+* `--target_name` - the model to access via OpenRouter, using its `<provider>/<model>` naming, e.g. `anthropic/claude-sonnet-4`; browse available models at https://openrouter.ai/models
+* set the `OPENROUTER_API_KEY` environment variable to your OpenRouter API key, see https://openrouter.ai/keys for details on creating one
+
 ### ggml
 
 * `--target_type ggml`

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -84,6 +84,7 @@ redirects = {
     "garak.generators.test": "generators/test.html",
     "garak.generators.nim": "generators/nim.html",
     "garak.generators.openai": "generators/openai.html",
+    "garak.generators.openrouter": "generators/openrouter.html",
     "garak.generators.replicate": "generators/replicate.html",
     "garak.generators.huggingface": "generators/huggingface.html",
     "garak.generators.watsonx": "generators/watsonx.html",

--- a/docs/source/generators/openrouter.rst
+++ b/docs/source/generators/openrouter.rst
@@ -1,0 +1,7 @@
+garak.generators.openrouter
+===========================
+
+.. automodule:: garak.generators.openrouter
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/index_generators.rst
+++ b/docs/source/index_generators.rst
@@ -25,6 +25,7 @@ For a detailed oversight into how a generator operates, see :doc:`generators/bas
    generators/mistral
    generators/ollama
    generators/openai
+   generators/openrouter
    generators/nim
    generators/nvcf
    generators/replicate

--- a/garak/generators/openrouter.py
+++ b/garak/generators/openrouter.py
@@ -1,0 +1,97 @@
+"""OpenRouter LLM interface
+
+Connects to OpenRouter's unified, OpenAI-compatible endpoint, giving access
+to hundreds of models hosted by many different providers behind a single
+API key.
+"""
+
+import functools
+import logging
+from typing import List, Union
+
+import openai
+
+from garak.attempt import Message, Conversation
+from garak.exception import BadGeneratorException
+from garak.generators.openai import OpenAICompatible
+
+
+class OpenRouterGenerator(OpenAICompatible):
+    """Wrapper for OpenRouter (https://openrouter.ai), a unified API giving
+    access to hundreds of models from many different providers.
+
+    Expects the ``OPENROUTER_API_KEY`` environment variable to be set to an
+    OpenRouter API key; see https://openrouter.ai/keys for details on
+    creating one.
+
+    Model names follow OpenRouter's ``<provider>/<model>`` convention, e.g.
+    ``anthropic/claude-sonnet-4``. Browse available models at
+    https://openrouter.ai/models.
+    """
+
+    ENV_VAR = "OPENROUTER_API_KEY"
+    DEFAULT_PARAMS = OpenAICompatible.DEFAULT_PARAMS | {
+        "uri": "https://openrouter.ai/api/v1",
+        # per https://openrouter.ai/docs/api-reference/parameters and
+        # github.com/OpenRouterTeam/openrouter-runner issue 99, `n > 1` is not
+        # supported: OpenRouter fans a request out to a single upstream
+        # provider per call, so multiple completions require multiple requests.
+        "suppressed_params": {"n"},
+    }
+    active = True
+    supports_multiple_generations = False
+    generator_family_name = "OpenRouter"
+
+    @staticmethod
+    def _reject_insufficient_credit(create_fn):
+        """Wrap an OpenAI-SDK ``create`` callable so that OpenRouter's HTTP 402
+        (out of credit) is treated as terminal instead of being logged and
+        skipped like other non-transient errors. Retrying a 402 never helps,
+        and silently returning ``None`` for every prompt would let a long scan
+        run to completion producing nothing but empty results.
+
+        ``functools.wraps`` preserves ``create_fn``'s signature via
+        ``__wrapped__`` so that ``OpenAICompatible._call_model``, which
+        inspects ``generator.create``'s parameters to build the request, keeps
+        seeing the real argument names (``model``, ``messages``, ``n``, ...)
+        instead of this wrapper's generic ``*args, **kwargs``.
+        """
+
+        @functools.wraps(create_fn)
+        def wrapper(*args, **kwargs):
+            try:
+                return create_fn(*args, **kwargs)
+            except openai.APIStatusError as e:
+                if e.status_code == 402:
+                    msg = (
+                        "OpenRouter account has insufficient credit (HTTP 402); "
+                        "top up at https://openrouter.ai/credits before retrying."
+                    )
+                    logging.error(msg)
+                    # raised from None: openai.APIStatusError carries a non-picklable
+                    # httpx.Response, which crashes multiprocessing.Pool's result
+                    # handling if attached as __cause__ (see NVIDIA/garak#1357).
+                    raise BadGeneratorException(msg) from None
+                raise
+
+        return wrapper
+
+    def _load_unsafe(self):
+        if self.name in ("", None):
+            raise ValueError(
+                "OpenRouter requires model name to be set, e.g. "
+                "--target_name anthropic/claude-sonnet-4\n"
+                "Browse available models at https://openrouter.ai/models"
+            )
+        super()._load_unsafe()
+        self.generator.create = self._reject_insufficient_credit(self.generator.create)
+
+    def _call_model(
+        self, prompt: Conversation, generations_this_call: int = 1
+    ) -> List[Union[Message, None]]:
+        if generations_this_call != 1:
+            raise AssertionError("generations_per_call / n > 1 is not supported")
+        return super()._call_model(prompt, generations_this_call)
+
+
+DEFAULT_CLASS = "OpenRouterGenerator"

--- a/tests/generators/test_openai_compatible.py
+++ b/tests/generators/test_openai_compatible.py
@@ -30,6 +30,7 @@ GENERATORS = [
     "generators.openai.OpenAIGenerator",
     "generators.nim.NVOpenAIChat",
     "generators.groq.GroqChat",
+    "generators.openrouter.OpenRouterGenerator",
 ]
 
 MODEL_NAME = "gpt-3.5-turbo-instruct"

--- a/tests/generators/test_openrouter.py
+++ b/tests/generators/test_openrouter.py
@@ -1,0 +1,204 @@
+import inspect
+import json
+import multiprocessing
+import os
+
+import httpx
+import openai
+import pytest
+import respx
+
+import garak.exception
+from garak.attempt import Message, Turn, Conversation
+from garak.generators.openrouter import OpenRouterGenerator
+from .test_openai_compatible import _make_api_status_error
+
+# ---------------------------------------------------------------------------
+# unit tests for the HTTP 402 (out of credit) wrapper, independent of any
+# live client or network mocking
+# ---------------------------------------------------------------------------
+
+
+def test_reject_insufficient_credit_raises_bad_generator_exception():
+    def failing_create(**kwargs):
+        raise _make_api_status_error(402)
+
+    wrapped = OpenRouterGenerator._reject_insufficient_credit(failing_create)
+    with pytest.raises(
+        garak.exception.BadGeneratorException, match="insufficient credit"
+    ):
+        wrapped(model="openai/gpt-4o-mini", messages=[])
+
+
+def test_reject_insufficient_credit_passes_through_other_errors():
+    def failing_create(**kwargs):
+        raise _make_api_status_error(429)
+
+    wrapped = OpenRouterGenerator._reject_insufficient_credit(failing_create)
+    with pytest.raises(openai.APIStatusError):
+        wrapped(model="openai/gpt-4o-mini", messages=[])
+
+
+def test_reject_insufficient_credit_preserves_signature():
+    def create(model, messages, n=1, temperature=None):
+        return "ok"
+
+    wrapped = OpenRouterGenerator._reject_insufficient_credit(create)
+    assert set(inspect.signature(wrapped).parameters) == {
+        "model",
+        "messages",
+        "n",
+        "temperature",
+    }
+
+
+# ---------------------------------------------------------------------------
+# full-stack tests against a mocked HTTP endpoint (respx); no credentials
+# required, no real network access
+# ---------------------------------------------------------------------------
+
+
+def test_openrouter_invalid_multiple_completions(monkeypatch):
+    monkeypatch.setenv(OpenRouterGenerator.ENV_VAR, "test-fake-key-for-unit-tests")
+    generator = OpenRouterGenerator(name="openai/gpt-4o-mini")
+    with pytest.raises(AssertionError) as e_info:
+        generator._call_model(
+            prompt=Conversation([Turn("user", Message("this is expected to fail"))]),
+            generations_this_call=2,
+        )
+    assert "n > 1 is not supported" in str(e_info.value)
+
+
+def test_openrouter_missing_model_name(monkeypatch):
+    monkeypatch.setenv(OpenRouterGenerator.ENV_VAR, "test-fake-key-for-unit-tests")
+    with pytest.raises(ValueError, match="openrouter.ai/models"):
+        OpenRouterGenerator(name="")
+
+
+@pytest.mark.respx(base_url="https://openrouter.ai/api/v1")
+def test_openrouter_call_model_suppresses_n(
+    monkeypatch, openai_compat_mocks, respx_mock
+):
+    monkeypatch.setenv(OpenRouterGenerator.ENV_VAR, "test-fake-key-for-unit-tests")
+    generator = OpenRouterGenerator(name="openai/gpt-4o-mini")
+
+    mock_response = openai_compat_mocks["chat"]
+    route = respx_mock.post("chat/completions").mock(
+        return_value=httpx.Response(mock_response["code"], json=mock_response["json"])
+    )
+    result = generator._call_model(Conversation([Turn("user", Message("hello"))]))
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert isinstance(result[0], Message)
+
+    sent_body = json.loads(route.calls[0].request.content)
+    assert "n" not in sent_body, "n must be suppressed; OpenRouter does not support it"
+    assert sent_body["model"] == "openai/gpt-4o-mini"
+
+
+@pytest.mark.respx(base_url="https://openrouter.ai/api/v1")
+def test_openrouter_call_model_402_raises_bad_generator_exception(
+    monkeypatch, respx_mock
+):
+    monkeypatch.setenv(OpenRouterGenerator.ENV_VAR, "test-fake-key-for-unit-tests")
+    generator = OpenRouterGenerator(name="openai/gpt-4o-mini")
+
+    respx_mock.post("chat/completions").mock(
+        return_value=httpx.Response(
+            402, json={"error": {"code": 402, "message": "insufficient credit"}}
+        )
+    )
+    with pytest.raises(
+        garak.exception.BadGeneratorException, match="insufficient credit"
+    ):
+        generator._call_model(Conversation([Turn("user", Message("hello"))]))
+
+
+def _generate_402_in_subprocess(args):
+    """Picklable worker: mocks a 402 response and calls _call_model.
+
+    Must be a module-level function (not a closure) so it can be sent to a
+    multiprocessing.Pool worker.
+    """
+    generator, prompt = args
+    with respx.mock(base_url=generator.uri, assert_all_called=False) as respx_mock:
+        respx_mock.post("chat/completions").mock(
+            return_value=httpx.Response(
+                402, json={"error": {"code": 402, "message": "insufficient credit"}}
+            )
+        )
+        return generator._call_model(prompt)
+
+
+def test_openrouter_402_survives_multiprocessing_pool(monkeypatch):
+    """The 402 -> BadGeneratorException path must survive the pickle/unpickle
+    cycle a real --parallel_requests run puts generators through: the wrapped
+    `generator.create` has to be rebuilt by `_load_unsafe()` in the worker
+    process, and the raised exception has to make it back to the parent
+    process without crashing Pool's result-handling thread (see the `from
+    None` rationale in openrouter.py, and NVIDIA/garak#1357).
+    """
+    monkeypatch.setenv(OpenRouterGenerator.ENV_VAR, "test-fake-key-for-unit-tests")
+    generator = OpenRouterGenerator(name="openai/gpt-4o-mini")
+    prompt = Conversation([Turn("user", Message("hello"))])
+
+    pool = multiprocessing.Pool(1)
+    try:
+        with pytest.raises(
+            garak.exception.BadGeneratorException, match="insufficient credit"
+        ):
+            for _ in pool.imap_unordered(
+                _generate_402_in_subprocess, [(generator, prompt)]
+            ):
+                pass
+    finally:
+        pool.close()
+        pool.join()
+
+
+# ---------------------------------------------------------------------------
+# tests requiring a real OPENROUTER_API_KEY; skipped when not present
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    os.getenv(OpenRouterGenerator.ENV_VAR, None) is None,
+    reason=f"OpenRouter API key is not set in {OpenRouterGenerator.ENV_VAR}",
+)
+def test_openrouter_instantiate():
+    OpenRouterGenerator(name="openai/gpt-4o-mini")
+
+
+@pytest.mark.skipif(
+    os.getenv(OpenRouterGenerator.ENV_VAR, None) is None,
+    reason=f"OpenRouter API key is not set in {OpenRouterGenerator.ENV_VAR}",
+)
+def test_openrouter_generate_1():
+    g = OpenRouterGenerator(name="openai/gpt-4o-mini")
+    result = g._call_model(
+        Conversation([Turn("user", Message("this is a test"))]),
+        generations_this_call=1,
+    )
+    assert isinstance(
+        result, list
+    ), "OpenRouterGenerator _call_model should return a list"
+    assert (
+        len(result) == 1
+    ), "OpenRouterGenerator _call_model result list should have one item"
+    assert isinstance(
+        result[0], Message
+    ), "OpenRouterGenerator generate() should contain a Message"
+    result = g.generate(
+        Conversation([Turn("user", Message("this is a test"))]),
+        generations_this_call=1,
+    )
+    assert isinstance(
+        result, list
+    ), "OpenRouterGenerator generate() should return a list"
+    assert (
+        len(result) == 1
+    ), "OpenRouterGenerator generate() result list should have one item when generations_this_call=1"
+    assert isinstance(
+        result[0], Message
+    ), "OpenRouterGenerator generate() should contain a Message"


### PR DESCRIPTION
## Summary

OpenRouter is one of the most widely used LLM aggregators (access to hundreds of models from many providers via a single API key), but garak had no dedicated generator for it — only indirect access via the `litellm` generator using the `openrouter/<model>` prefix, which is not discoverable via `--list_generators` and does not get OpenRouter-specific error handling.

OpenRouter exposes an OpenAI-compatible endpoint, so this follows the same `OpenAICompatible` extension pattern already used by `generators/groq.py` and `generators/nim.py`.

Two OpenRouter-specific quirks are handled explicitly:

- **`n` (multiple completions per request) is not supported upstream** ([confirmed upstream](https://github.com/OpenRouterTeam/openrouter-runner/issues/99)), so it is suppressed via `suppressed_params`, same as Groq/NIM.
- **HTTP 402 (out of credit) is treated as terminal**, raising `BadGeneratorException` instead of being logged and silently skipped like other non-transient errors. Retrying a 402 never helps, and the default `OpenAICompatible` behavior of returning `None` per prompt would let a long scan run to completion producing nothing but empty results. The 402 is intercepted by wrapping the OpenAI SDK's `generator.create` callable (using `functools.wraps` so `OpenAICompatible._call_model`'s parameter introspection, used to build the request payload, still sees the real signature).

## Test plan

- [x] New unit tests in `tests/generators/test_openrouter.py`: 7 run without credentials (mocked via `respx`), 2 are skipped unless `OPENROUTER_API_KEY` is set
- [x] Added `generators.openrouter.OpenRouterGenerator` to the shared `GENERATORS` list in `tests/generators/test_openai_compatible.py` for generic multiprocessing/backoff coverage
- [x] Full `tests/generators/` + `tests/test_docs.py` suite passes with no regressions
- [x] `python -m garak --list_generators` shows `openrouter`
- [x] Manually verified against the live OpenRouter API with a real (initially creditless) key:
  - Creditless key → clean abort with the intended error message, full traceback in the debug log
  - After topping up credit → real generations returned correctly, `test.Test` probe 40/40 pass
  - Ran a real vulnerability probe (`encoding.InjectBase64`, 256 attempts) end-to-end against `openai/gpt-4o-mini` via OpenRouter — generator, detectors and harness scoring all worked correctly

(Note: supersedes #2163, closed due to an unrelated commit-identity cleanup.)