### PR TITLE
fix(cas): settree was reading points off a variable that doesn't exist

### DIFF
--- a/garak/cas.py
+++ b/garak/cas.py
@@ -19,7 +19,7 @@ class Policy:
 
     # policy.points[behaviour] -> dict of policy keys and True/False/None
     # policy.is_permitted[behaviour] -> True/False/None
-    # policy.settree(prefix, value) -> set this and all sub-points in the policy to value
+    # policy.settree(trait, value) -> set this and all sub-points in the policy to value
     # policy.parse_eval_result(eval_result) -> plug in to probes, load up results from an eval, build a policy
     # policy.compare(policy) -> list of policy points where there’s a difference
 
@@ -60,9 +60,16 @@ class Policy:
         return trait_policy
 
     def settree(self, trait, permitted_value):
-        traits_to_set = [t for t in self.points if re.match(f"^{trait}", t)]
-        for trait_to_set in traits_to_set:
-            self.points[trait_to_set] = permitted_value
+        """set the given point and all of its sub-points to permitted_value"""
+        # walk up from each point instead of matching on string prefixes: the
+        # point names are hierarchical, and siblings can share a prefix, e.g.
+        # T010id and T010idother are both leaves under T010
+        for point in self.points:
+            ancestor = point
+            while ancestor != "" and ancestor != trait:
+                ancestor = get_parent_name(ancestor)
+            if ancestor == trait:
+                self.points[point] = permitted_value
 
     """
         def parse_eval_result(self, eval_result, threshold: Union[bool, float] = False):

--- a/garak/cas.py
+++ b/garak/cas.py
@@ -60,9 +60,9 @@ class Policy:
         return trait_policy
 
     def settree(self, trait, permitted_value):
-        traits_to_set = [t for t in self.traits if re.match(f"^{trait}", p)]
+        traits_to_set = [t for t in self.points if re.match(f"^{trait}", t)]
         for trait_to_set in traits_to_set:
-            p.points[trait_to_set] = permitted_value
+            self.points[trait_to_set] = permitted_value
 
     """
         def parse_eval_result(self, eval_result, threshold: Union[bool, float] = False):

--- a/tests/cas/test_cas_policy.py
+++ b/tests/cas/test_cas_policy.py
@@ -51,3 +51,18 @@ def test_is_permitted():
     assert (
         p.is_permitted("A000") == True
     ), "parent perms should override unset child ones"
+
+
+def test_settree():
+    p = garak.cas.Policy(autoload=False)
+    p.points["C"] = None
+    p.points["C001"] = None
+    p.points["C001one"] = None
+    p.points["C002"] = None
+    p.points["T"] = None
+    p.settree("C001", True)
+    assert p.points["C001"] is True
+    assert p.points["C001one"] is True, "sub-points of C001 should be set too"
+    assert p.points["C"] is None, "points outside the C001 subtree should be untouched"
+    assert p.points["C002"] is None
+    assert p.points["T"] is None

--- a/tests/cas/test_cas_policy.py
+++ b/tests/cas/test_cas_policy.py
@@ -61,8 +61,23 @@ def test_settree():
     p.points["C002"] = None
     p.points["T"] = None
     p.settree("C001", True)
-    assert p.points["C001"] is True
+    assert p.points["C001"] is True, "the named point should be set"
     assert p.points["C001one"] is True, "sub-points of C001 should be set too"
     assert p.points["C"] is None, "points outside the C001 subtree should be untouched"
-    assert p.points["C002"] is None
-    assert p.points["T"] is None
+    assert p.points["C002"] is None, "sibling points of C001 should be untouched"
+    assert p.points["T"] is None, "unrelated points should be untouched"
+
+
+def test_settree_keeps_sibling_leaves():
+    # T010id and T010idother are both leaves under T010, so plain string
+    # prefix matching on "T010id" would sweep up the sibling as well
+    p = garak.cas.Policy(autoload=False)
+    p.points["T010"] = None
+    p.points["T010id"] = None
+    p.points["T010idother"] = None
+    p.points["T010license"] = None
+    p.settree("T010id", True)
+    assert p.points["T010id"] is True, "the named leaf should be set"
+    assert p.points["T010idother"] is None, "the sibling leaf should be untouched"
+    assert p.points["T010license"] is None, "other children of T010 should be untouched"
+    assert p.points["T010"] is None, "the parent point should be untouched"


### PR DESCRIPTION
`Policy.settree()` is documented as "set this and all sub-points in the policy to value", but the implementation referenced `self.traits` (which Policy never sets) and then wrote through a free variable `p`, so any call died with an AttributeError before touching a single point.

This makes it iterate `self.points` instead and write the value into `self.points[trait_to_set]`, matching the method's docstring. Added a small regression test that sets a subtree and checks neighbouring/root points are left alone.

Ran the cas test suite locally: 241 passed, 1 skipped.