### PR TITLE
fix: correct typos in comments, docstrings, and log messages

### DIFF
--- a/garak/detectors/continuation.py
+++ b/garak/detectors/continuation.py
@@ -12,7 +12,7 @@ from garak.detectors.base import Detector
 
 
 class Continuation(Detector):
-    """Detect if model intiates / continues a trigger word"""
+    """Detect if model initiates / continues a trigger word"""
 
     DEFAULT_PARAMS = Detector.DEFAULT_PARAMS | {"case_sensitive": False}
 

--- a/garak/evaluators/base.py
+++ b/garak/evaluators/base.py
@@ -256,7 +256,7 @@ class Evaluator:
         # build probe_summary during this loop to reference probe specific counts
         # include:
         #  total inference output counts (output_counts: sum(None), sum(not None)),
-        #  total detections preformed (detection_counts: sum(None), sum(hit), sum(pass))
+        #  total detections performed (detection_counts: sum(None), sum(hit), sum(pass))
         for idx, attempt in enumerate(attempts):
             if not self.probename:
                 self.probename = attempt.probe_classname

--- a/garak/harnesses/probewise.py
+++ b/garak/harnesses/probewise.py
@@ -37,7 +37,7 @@ class ProbewiseHarness(Harness):
         * if the probe specifies a ``primary_detector``; ``_config.args`` is
         set; and ``_config.args.extended_detectors`` is true; the union of
         ``primary_detector`` and ``extended_detectors`` are used.
-        * if the probe specifices a ``primary_detector`` and ``_config.args.extended_detectors``
+        * if the probe specifies a ``primary_detector`` and ``_config.args.extended_detectors``
         if false, or ``_config.args`` is not set, then only the detector in
         ``primary_detector`` is used.
         * if the probe does not specify ``primary_detector`` value, or this is

--- a/garak/langproviders/base.py
+++ b/garak/langproviders/base.py
@@ -48,7 +48,7 @@ def is_english(text):
     _initialize_words()
     from nltk.corpus import words
 
-    special_terms = {"ascii85", "encoded", "decoded", "acsii", "plaintext"}
+    special_terms = {"ascii85", "encoded", "decoded", "ascii", "plaintext"}
     english_words = set(words.words()).union(special_terms)
 
     text = text.lower()

--- a/garak/probes/apikey.py
+++ b/garak/probes/apikey.py
@@ -58,7 +58,7 @@ class CompleteKey(garak.probes.Probe):
         "demon:Possible_worlds:World_building:Scenarios",  # frames key completion as a lost-data recovery scenario
         "demon:Stratagems:Meta-prompting:Ask_for_examples",  # directly asks the model to supply a concrete key completion
     ]
-    goal = "generate an API key for the specificed API"
+    goal = "generate an API key for the specified API"
     tier = garak.probes.Tier.COMPETE_WITH_SOTA
     active = True
 

--- a/garak/probes/atkgen.py
+++ b/garak/probes/atkgen.py
@@ -70,7 +70,7 @@ class Tox(garak.probes.Probe):
         "red_team_model_name": "garak-llm/attackgeneration-toxicity_gpt2",
         "red_team_model_config": {
             "hf_args": {"device": "cpu", "torch_dtype": "float32"}
-        },  # defer acceleration devices to model under test unless overriden
+        },  # defer acceleration devices to model under test unless overridden
         "red_team_prompt_template": "<|input|>[query]<|response|>",
         "red_team_postproc_rm_regex": r"\<\|.*",
         "use_only_first_sent": True,  # should we only consider the first sentence of the target's response?

--- a/garak/probes/divergence.py
+++ b/garak/probes/divergence.py
@@ -5,7 +5,7 @@
 
 These attacks try to get target output to deviate from the original topic and leak training data or other unwanted/unexpected material.
 
-This module is for any attack attemtping to get target output to diverge from input request.
+This module is for any attack attempting to get target output to diverge from input request.
 """
 
 from garak import _config

--- a/garak/probes/leakreplay.py
+++ b/garak/probes/leakreplay.py
@@ -174,7 +174,7 @@ class LiteratureCompleteFull(CompleteProbeMixin, garak.probes.Probe):
     """
 
     source_file = "book_cloze.tsv"
-    tier = garak.probes.Tier.COMPETE_WITH_SOTA  # regraded to tier 2
+    tier = garak.probes.Tier.COMPETE_WITH_SOTA  # regarded to tier 2
 
 
 class LiteratureComplete(NonFullMixin, LiteratureCompleteFull):

--- a/garak/probes/phrasing.py
+++ b/garak/probes/phrasing.py
@@ -3,7 +3,7 @@
 These attacks rephrase requests for unsafe content in an attempt to bypass safeguards.
 
 This module is home to probes that rely on specific grammatical alterations and rephrasing
-to implement their techinque.
+to implement their technique.
 
 """
 

--- a/garak/resources/autodan/autodan.py
+++ b/garak/resources/autodan/autodan.py
@@ -64,7 +64,7 @@ autodan_parser.add_argument(
     "--reference",
     type=str,
     default=autodan_resource_data / "prompt_group.pth",
-    help="Path to refernces",
+    help="Path to references",
 )
 autodan_parser.add_argument(
     "--low_memory", action="store_true", help="Use low memory mode"

--- a/garak/services/intentservice.py
+++ b/garak/services/intentservice.py
@@ -309,7 +309,7 @@ def _get_stubs_code(intent_code: str) -> Set[Stub]:
 
 
 def get_intent_parts(intent_specifier: str) -> List[str]:
-    """separate an intent specifier into its consituent parts:
+    """separate an intent specifier into its constituent parts:
 
     X999aaa - X is top-level code, 999 is a three-digit category,
     aaa is a text name for a leaf subcategory"""

--- a/garak/services/langservice.py
+++ b/garak/services/langservice.py
@@ -47,7 +47,7 @@ def _load_langprovider(language_service: dict) -> LangProvider:
     langprovider_config = {
         "langproviders": {language_service["model_type"]: language_service}
     }
-    logging.debug(f"langauge provision service: {language_service['language']}")
+    logging.debug(f"language provision service: {language_service['language']}")
     source_lang, target_lang = language_service["language"].split(",")
     if source_lang == target_lang:
         return Passthru(langprovider_config)


### PR DESCRIPTION
Fixes 12 typos across 12 files (comments, docstrings, a debug log message, and one whitelist entry in `langproviders/base.py` where `"acsii"` should have been `"ascii"`).

No behavior changes other than the `acsii`/`ascii` fix. No test references any of the changed strings.