### PR TITLE
fix: remove unused imports across 6 modules

### DIFF
--- a/garak/_config.py
+++ b/garak/_config.py
@@ -10,7 +10,6 @@
 import platform
 from collections import defaultdict
 from dataclasses import dataclass
-import importlib
 import json
 import logging
 import os

--- a/garak/analyze/detector_metrics.py
+++ b/garak/analyze/detector_metrics.py
@@ -6,7 +6,6 @@ from json import JSONDecodeError
 import logging
 from typing import Optional, Tuple
 
-from garak import _config
 from garak.data import path as data_path
 from garak.exception import GarakException
 

--- a/garak/evaluators/base.py
+++ b/garak/evaluators/base.py
@@ -8,7 +8,7 @@ import json
 import logging
 from pathlib import Path
 
-from typing import Iterable, Optional, Tuple, List
+from typing import Iterable, Optional, List
 
 from colorama import Fore, Style
 

--- a/garak/resources/autodan/genetic.py
+++ b/garak/resources/autodan/genetic.py
@@ -11,7 +11,7 @@ from collections import defaultdict, OrderedDict
 import sys
 import time
 from logging import getLogger
-from typing import Tuple, Optional, List, Union
+from typing import Tuple, Optional, List
 
 import garak.generators
 from garak.resources.api import nltk

--- a/garak/resources/autodan/model_utils.py
+++ b/garak/resources/autodan/model_utils.py
@@ -3,9 +3,8 @@
 
 import gc
 import torch
-from typing import Tuple, Union, Optional
+from typing import Tuple, Optional
 from logging import getLogger
-import garak._config
 from garak.generators.huggingface import Model, Pipeline
 from transformers import PreTrainedModel
 

--- a/garak/resources/gcg/attack_manager.py
+++ b/garak/resources/gcg/attack_manager.py
@@ -33,7 +33,6 @@ from logging import getLogger
 from tqdm import tqdm
 
 from garak.generators.huggingface import Model, Pipeline
-import garak._config
 from garak.resources.common import load_advbench, REJECTION_STRINGS
 
 logger = getLogger(__name__)


### PR DESCRIPTION
## Summary

Remove imports that are never referenced in their respective modules:

- `garak/_config.py`: `importlib`
- `garak/analyze/detector_metrics.py`: `from garak import _config`
- `garak/evaluators/base.py`: `Tuple` from typing
- `garak/resources/autodan/genetic.py`: `Union` from typing
- `garak/resources/autodan/model_utils.py`: `import garak._config`
- `garak/resources/gcg/attack_manager.py`: `import garak._config`

These are residual from code refactoring and upstream code integration.

## Test plan

- [x] `pytest tests/analyze/ tests/evaluators/ tests/cas/` — 461 passed
- [ ] Full CI suite (linux/macos/windows)