### PR TITLE
fix(buffs): deep copy mutable attempt fields in _derive_new_attempt

### DIFF
--- a/garak/buffs/base.py
+++ b/garak/buffs/base.py
@@ -4,6 +4,7 @@
 """Base classes for buffs."""
 
 from collections.abc import Iterable
+import copy
 import logging
 from typing import List
 
@@ -51,10 +52,10 @@ class Buff(Configurable):
             status=source_attempt.status,
             prompt=source_attempt.prompt,
             probe_classname=source_attempt.probe_classname,
-            probe_params=source_attempt.probe_params,
-            targets=source_attempt.targets,
-            notes=source_attempt.notes,
-            detector_results=source_attempt.detector_results,
+            probe_params=copy.deepcopy(source_attempt.probe_params),
+            targets=copy.deepcopy(source_attempt.targets),
+            notes=copy.deepcopy(source_attempt.notes) if source_attempt.notes is not None else None,
+            detector_results=copy.deepcopy(source_attempt.detector_results) if source_attempt.detector_results is not None else None,
             goal=source_attempt.goal,
             seq=seq,
         )

--- a/tests/buffs/test_buffs.py
+++ b/tests/buffs/test_buffs.py
@@ -65,3 +65,45 @@ def test_buff_load_and_transform(klassname, mocker):
                 "transform should yield the original attempt plus each unique "
                 "paraphrase, with duplicates removed"
             )
+
+
+def test_derive_new_attempt_deep_copies_mutable_fields():
+    """_derive_new_attempt must not share mutable containers with the source attempt.
+
+    Mutating notes, detector_results, targets, or probe_params on the derived
+    attempt must not affect the source attempt (regression for GitHub #2155).
+    """
+    buff_instance = garak.buffs.base.Buff.__new__(garak.buffs.base.Buff)
+    buff_instance.post_buff_hook = False
+    buff_instance.fullname = "base.Buff"
+
+    source = attempt.Attempt(
+        probe_params={"key": "value", "nested": {"a": 1}},
+        targets=["target1", "target2"],
+        notes={"origin": "test", "nested_note": {"x": 42}},
+        detector_results={"det.A": [0.1, 0.9]},
+    )
+
+    derived = buff_instance._derive_new_attempt(source)
+
+    # Mutate every mutable field on the derived attempt
+    derived.notes["injected"] = "should_not_appear_in_source"
+    derived.notes["nested_note"]["x"] = 999
+    derived.detector_results["det.A"].append(0.5)
+    derived.detector_results["det.B"] = [0.0]
+    derived.targets.append("target3")
+    derived.probe_params["new_key"] = "new_val"
+    derived.probe_params["nested"]["a"] = 99
+
+    # Source must be unchanged
+    assert "injected" not in source.notes, "source notes were mutated via derived attempt"
+    assert source.notes["nested_note"]["x"] == 42, "source nested notes were mutated"
+    assert len(source.detector_results["det.A"]) == 2, "source detector_results were mutated"
+    assert "det.B" not in source.detector_results, "source detector_results gained a new key"
+    assert len(source.targets) == 2, "source targets were mutated"
+    assert "new_key" not in source.probe_params, "source probe_params were mutated"
+    assert source.probe_params["nested"]["a"] == 1, "source nested probe_params were mutated"
+
+    # The buff bookkeeping notes must only appear in derived, not source
+    assert "buff_creator" in derived.notes
+    assert "buff_creator" not in source.notes


### PR DESCRIPTION
## Summary

`Buff._derive_new_attempt` passed `probe_params`, `targets`, `notes`, and `detector_results` directly from the source attempt to the derived attempt without copying. Because `Attempt.__init__` stores these containers by reference, all derived attempts shared the same underlying dict/list objects as the source. Mutations to the derived attempt (including the buff bookkeeping writes to `notes` that happen immediately after derivation) silently mutated the source attempt.

Fixes #2155.

## Root Cause

In `garak/buffs/base.py`, `_derive_new_attempt` constructed the new `Attempt` by passing the source's mutable containers directly:

```python
notes=source_attempt.notes,          # same dict object
detector_results=source_attempt.detector_results,  # same dict object
targets=source_attempt.targets,      # same list object
probe_params=source_attempt.probe_params,  # same dict object
```

The three subsequent lines that write `buff_creator`, `buff_source_attempt_uuid`, and `buff_source_seq` into `new_attempt.notes` then silently wrote into `source_attempt.notes` too. Likewise, any detector scores appended to the derived attempt's `detector_results` would appear in the source.

## Design Decisions

- **`copy.deepcopy` over shallow copy**: jmartin-tech noted that `source_attempt.notes` can contain nested dicts; a shallow copy would still share nested objects. `deepcopy` is the safe default.
- **None guards**: the `if ... is not None else None` guards preserve the existing semantic for callers that explicitly pass `None`—`Attempt.__init__` already converts `None` to an empty container.
- **All four fields**: per jmartin-tech's review, `targets` and `probe_params` receive the same treatment even though the current callers may not mutate them today; it future-proofs the class against subtle aliasing bugs.

## Changes

| File | What changed |
|------|-------------|
| `garak/buffs/base.py` | Add `import copy`; wrap four mutable fields in `copy.deepcopy()` in `_derive_new_attempt` |
| `tests/buffs/test_buffs.py` | Add `test_derive_new_attempt_deep_copies_mutable_fields` — verifies notes, detector_results, targets, and probe_params (including nested dicts) are fully independent |

## Testing

- [ ] Existing tests pass (`pytest tests/buffs/`)
- [ ] New test: `test_derive_new_attempt_deep_copies_mutable_fields` — mutates all four mutable fields on the derived attempt and asserts the source is unchanged, including nested dict values
- [ ] Manually verified: `_derive_new_attempt` no longer writes `buff_creator` into the source attempt's notes

## Impact

Any buff that calls `_derive_new_attempt` (the entire buff subsystem) is affected. Without this fix, buff bookkeeping notes (`buff_creator`, `buff_source_attempt_uuid`, `buff_source_seq`) leak into the source attempt on every invocation, and detector results from buffed attempts can corrupt the source attempt's result set — inflating or deflating hit counts in the safety evaluation report.